### PR TITLE
feat: add opengrep as default scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,14 @@ FROM scanner-installer
 # Copy the crypto-finder binary from builder
 COPY --from=builder /build/crypto-finder /usr/local/bin/crypto-finder
 
+# Add opengrep to PATH
+ENV PATH="$PATH:/root/.opengrep/cli/latest"
+
 # Create workspace directory
 WORKDIR /workspace
+
+# Build arguments for labels
+ARG VERSION=dev
 
 # Add labels for metadata
 LABEL org.opencontainers.image.title="SCANOSS Crypto Finder"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 # ============================================================================
-# GoReleaser Dockerfile - Standard Image with Semgrep
+# GoReleaser Dockerfile - Standard Image with Scanners
 # ============================================================================
 # This Dockerfile is used by GoReleaser and expects a pre-built binary.
 # For manual builds from source, use the regular Dockerfile instead.
@@ -12,8 +12,17 @@ ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 
-# Install Semgrep 1.119.0
-RUN pip install --no-cache-dir semgrep==1.119.0
+# Install system dependencies for OpenGrep installer
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Semgrep 1.145.0
+RUN pip install --no-cache-dir semgrep==1.145.0
+
+# Install OpenGrep (minimum version 1.12.1)
+RUN curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
 
 # Copy the pre-built crypto-finder binary from GoReleaser's build context
 COPY crypto-finder /usr/local/bin/crypto-finder
@@ -33,7 +42,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.version="${VERSION}"
 
 # Verify installations
-RUN crypto-finder version && semgrep --version
+RUN crypto-finder version && semgrep --version && opengrep --version
 
 # Set entrypoint
 ENTRYPOINT ["crypto-finder"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -30,6 +30,9 @@ COPY crypto-finder /usr/local/bin/crypto-finder
 # Make binary executable
 RUN chmod +x /usr/local/bin/crypto-finder
 
+# Add opengrep to PATH
+ENV PATH="$PATH:/root/.opengrep/cli/latest"
+
 # Create workspace directory
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ A powerful CLI tool and execution framework for detecting cryptographic algorith
 
 ## Features
 
-- **Multi-Scanner Support**: Currently supports Semgrep with extensible architecture for additional scanners
+- **Multi-Scanner Support**: Supports OpenGrep (default) and Semgrep with extensible architecture for additional scanners
+- **Advanced Taint Analysis**: OpenGrep scanner includes `--taint-intrafile` by default for enhanced dataflow analysis
 - **Automatic Language Detection**: Uses [go-enry](https://github.com/go-enry/go-enry) to detect project languages for optimized scanning
 - **Flexible Rule Management**: Support for local rule files and directories
 - **Standardized Output**: Interim JSON format compatible with the SCANOSS ecosystem
-- **CycloneDX Support**: Convert results to CycloneDX 1.6 CBOM format
+- **CycloneDX Support**: Convert results to CycloneDX 1.7 CBOM format
 - **CI/CD Ready**: Docker images and integration-friendly design
 - **Performance Optimized**: Language-based rule filtering to minimize scan time
 - **Skip Patterns**: Configurable file/directory exclusion via scanoss.json
@@ -33,7 +34,7 @@ sudo make install
 ### Docker
 
 ```bash
-# Full image with Semgrep included
+# Full image with OpenGrep and Semgrep included
 docker pull ghcr.io/scanoss/crypto-finder:latest
 
 # Slim image (requires external scanner)
@@ -78,7 +79,7 @@ crypto-finder scan [flags] <target>
 |------|-------------|---------|
 | `--rules <file>` | Rule file path (repeatable) | - |
 | `--rules-dir <dir>` | Rule directory path (repeatable) | - |
-| `--scanner <name>` | Scanner to use | `semgrep` |
+| `--scanner <name>` | Scanner to use: `opengrep`, `semgrep` | `opengrep` |
 | `--format <format>` | Output format: `json`, `cyclonedx` | `json` |
 | `--output <file>` | Output file path | stdout |
 | `--languages <langs>` | Override language detection (comma-separated) | auto-detect |
@@ -107,6 +108,9 @@ crypto-finder scan --fail-on-findings --rules-dir ./rules/ /path/to/code
 
 # Pipe output to jq for processing
 crypto-finder scan --rules-dir ./rules /path/to/code | jq '.findings | length'
+
+# Use Semgrep scanner instead of default OpenGrep
+crypto-finder scan --scanner semgrep --rules-dir ./rules /path/to/code
 ```
 
 ### Convert Command
@@ -251,8 +255,8 @@ The default output format containing detailed cryptographic asset information.
 {
   "version": "1.0",
   "tool": {
-    "name": "semgrep",
-    "version": "1.45.0"
+    "name": "opengrep",
+    "version": "1.12.1"
   },
   "findings": [
     {
@@ -260,7 +264,7 @@ The default output format containing detailed cryptographic asset information.
       "language": "java",
       "cryptographic_assets": [
         {
-          "match_type": "semgrep",
+          "match_type": "opengrep",
           "line_number": 29,
           "match": "cipher = Cipher.getInstance(\"AES/CBC/PKCS5Padding\");",
           "rule": {
@@ -283,10 +287,10 @@ The default output format containing detailed cryptographic asset information.
 
 ### CycloneDX CBOM Format
 
-CycloneDX 1.6 compatible Cryptography Bill of Materials format.
+CycloneDX 1.7 compatible Cryptography Bill of Materials format.
 
 **Features:**
-- Validates against CycloneDX 1.6 schema
+- Validates against CycloneDX 1.7 schema
 - Maps cryptographic assets to standardized component types
 - Includes algorithm properties and metadata
 - Supports asset types: `algorithm`, `certificate`, `protocol`, `related-crypto-material`
@@ -299,7 +303,7 @@ CycloneDX 1.6 compatible Cryptography Bill of Materials format.
 - Go 1.23.2 or later
 - Make
 - Docker (optional, for container builds)
-- Semgrep (for running scans)
+- OpenGrep >= 1.12.1 or Semgrep >= 1.119.0 (for running scans)
 
 ### Building
 
@@ -330,6 +334,7 @@ make test
 make coverage
 
 # Run specific test
+go test -v ./internal/scanner/opengrep/...
 go test -v ./internal/scanner/semgrep/...
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/go-enry/go-oniguruma v1.2.1 // indirect
+	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/go-enry/go-oniguruma v1.2.1/go.mod h1:bWDhYP+S6xZQgiRL7wlTScFYBe023B6
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
+github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,7 +19,7 @@ var rootCmd = &cobra.Command{
 	Use:   "scanoss-cf",
 	Short: "SCANOSS Crypto-Finder scans source code for cryptographic algorithm usage",
 	Long: `SCANOSS Crypto-Finder is a CLI tool that scans source code repositories to detect
-	cryptographic operations and extract relevant values. It executes Semgrep
+	cryptographic operations and extract relevant values. It executes OpenGrep
 	as the default scanning engine and outputs results in a standardized interim JSON format.`,
 	SilenceUsage: true,
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -18,19 +18,20 @@ import (
 	"github.com/scanoss/crypto-finder/internal/output"
 	"github.com/scanoss/crypto-finder/internal/rules"
 	"github.com/scanoss/crypto-finder/internal/scanner"
+	"github.com/scanoss/crypto-finder/internal/scanner/opengrep"
 	"github.com/scanoss/crypto-finder/internal/scanner/semgrep"
 	"github.com/scanoss/crypto-finder/internal/skip"
 )
 
 const (
-	defaultScanner = "semgrep"
+	defaultScanner = "opengrep"
 	defaultFormat  = "json"
 	defaultTimeout = "10m"
 )
 
 // AllowedScanners lists the scanners supported by the tool.
-// TODO: We'll support more scanners in the future.
-var AllowedScanners = []string{"semgrep"}
+// TODO: We'll support more scanners in the future (e.g., cbom-toolkit).
+var AllowedScanners = []string{"opengrep", "semgrep"}
 
 // SupportedFormats lists the output formats supported by the tool.
 var SupportedFormats = []string{"json", "cyclonedx"} // Future: csv, html, sarif
@@ -51,7 +52,7 @@ var scanCmd = &cobra.Command{
 	Short: "Scan source code for cryptographic usage",
 	Long: `Scan source code repositories for cryptographic algorithm usage.
 
-	The scan command executes a scanner (default: Semgrep) against the target
+	The scan command executes a scanner (default: OpenGrep) against the target
 	directory or file using specified rules. By default, it outputs findings to
 	stdout in JSON format. Use --output to write to a file instead.
 
@@ -147,7 +148,8 @@ func runScan(_ *cobra.Command, args []string) error {
 	scannerRegistry := scanner.NewRegistry()
 
 	// Register scanners
-	// TODO: Register opengrep, cbom-toolkit
+	// TODO: Register cbom-toolkit
+	scannerRegistry.Register("opengrep", opengrep.NewScanner())
 	scannerRegistry.Register("semgrep", semgrep.NewScanner())
 
 	// Create orchestrator

--- a/internal/scanner/opengrep/scanner_test.go
+++ b/internal/scanner/opengrep/scanner_test.go
@@ -1,0 +1,312 @@
+package opengrep
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/internal/scanner"
+)
+
+func TestNewScanner(t *testing.T) {
+	s := NewScanner()
+
+	if s == nil {
+		t.Fatal("NewScanner returned nil")
+	}
+
+	if s.executablePath != "opengrep" {
+		t.Errorf("Expected default executable path 'opengrep', got '%s'", s.executablePath)
+	}
+
+	if s.timeout != 10*time.Minute {
+		t.Errorf("Expected default timeout 10 minutes, got %v", s.timeout)
+	}
+}
+
+func TestGetInfo(t *testing.T) {
+	s := NewScanner()
+	s.version = "1.12.1"
+
+	info := s.GetInfo()
+
+	if info.Name != ScannerName {
+		t.Errorf("Expected scanner name '%s', got '%s'", ScannerName, info.Name)
+	}
+
+	if info.Version != "1.12.1" {
+		t.Errorf("Expected version '1.12.1', got '%s'", info.Version)
+	}
+
+	if info.Description == "" {
+		t.Error("Expected non-empty description")
+	}
+}
+
+func TestBuildCommand(t *testing.T) {
+	s := NewScanner()
+	s.skipPatterns = []string{"*.test", "vendor/*"}
+	s.extraArgs = []string{"--debug"}
+
+	rulePaths := []string{"/rules/crypto.yaml", "/rules/hash.yaml"}
+	target := "/tmp/target"
+
+	args := s.buildCommand(target, rulePaths)
+
+	// Verify required arguments
+	expectedArgs := map[string]bool{
+		"--json":             false,
+		"--no-git-ignore":    false,
+		"--taint-intrafile":  false,
+		"--config":           false,
+		"/rules/crypto.yaml": false,
+		"/rules/hash.yaml":   false,
+		"--exclude":          false,
+		"*.test":             false,
+		"vendor/*":           false,
+		"--debug":            false,
+		"/tmp/target":        false,
+	}
+
+	for _, arg := range args {
+		if _, ok := expectedArgs[arg]; ok {
+			expectedArgs[arg] = true
+		}
+	}
+
+	// Check that all expected arguments were found
+	for arg, found := range expectedArgs {
+		if !found {
+			t.Errorf("Expected argument '%s' not found in command", arg)
+		}
+	}
+
+	// Verify --taint-intrafile is included (default for OpenGrep)
+	hasTaintIntrafile := false
+	for _, arg := range args {
+		if arg == "--taint-intrafile" {
+			hasTaintIntrafile = true
+			break
+		}
+	}
+	if !hasTaintIntrafile {
+		t.Error("Expected --taint-intrafile argument to be included")
+	}
+
+	// Verify target is the last argument
+	if args[len(args)-1] != target {
+		t.Errorf("Expected target '%s' to be last argument, got '%s'", target, args[len(args)-1])
+	}
+}
+
+func TestInitialize_WithConfig(t *testing.T) {
+	// Mock the exec functions to avoid needing real opengrep
+	originalLookPath := lookPath
+	originalCommandOutput := commandOutput
+	defer func() {
+		lookPath = originalLookPath
+		commandOutput = originalCommandOutput
+	}()
+
+	// Mock exec.LookPath to return success
+	lookPath = func(_ string) (string, error) {
+		return "/usr/local/bin/opengrep", nil
+	}
+
+	// Mock command output to return a valid version
+	commandOutput = func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "--version" {
+			return []byte("1.12.1"), nil
+		}
+		return nil, nil
+	}
+
+	s := NewScanner()
+
+	config := scanner.Config{
+		Timeout:      5 * time.Minute,
+		WorkDir:      "/tmp/work",
+		Env:          map[string]string{"FOO": "bar"},
+		ExtraArgs:    []string{"--verbose"},
+		SkipPatterns: []string{"*.test"},
+	}
+
+	err := s.Initialize(config)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	// Verify configuration was applied
+	if s.timeout != 5*time.Minute {
+		t.Errorf("Expected timeout 5 minutes, got %v", s.timeout)
+	}
+
+	if s.workDir != "/tmp/work" {
+		t.Errorf("Expected workDir '/tmp/work', got '%s'", s.workDir)
+	}
+
+	if s.env["FOO"] != "bar" {
+		t.Errorf("Expected env FOO='bar', got '%s'", s.env["FOO"])
+	}
+
+	if len(s.extraArgs) != 1 || s.extraArgs[0] != "--verbose" {
+		t.Errorf("Expected extraArgs ['--verbose'], got %v", s.extraArgs)
+	}
+
+	if len(s.skipPatterns) != 1 || s.skipPatterns[0] != "*.test" {
+		t.Errorf("Expected skipPatterns ['*.test'], got %v", s.skipPatterns)
+	}
+
+	// Verify version was detected
+	if s.version != "1.12.1" {
+		t.Errorf("Expected version '1.12.1', got '%s'", s.version)
+	}
+
+	// Verify executable path was set
+	if s.executablePath != "/usr/local/bin/opengrep" {
+		t.Errorf("Expected executablePath '/usr/local/bin/opengrep', got '%s'", s.executablePath)
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		shouldError bool
+	}{
+		{
+			name:        "Exact minimum version",
+			version:     "1.12.1",
+			shouldError: false,
+		},
+		{
+			name:        "Higher version",
+			version:     "1.13.0",
+			shouldError: false,
+		},
+		{
+			name:        "Much higher version",
+			version:     "2.0.0",
+			shouldError: false,
+		},
+		{
+			name:        "Below minimum - patch",
+			version:     "1.12.0",
+			shouldError: true,
+		},
+		{
+			name:        "Below minimum - minor",
+			version:     "1.11.5",
+			shouldError: true,
+		},
+		{
+			name:        "Below minimum - major",
+			version:     "0.99.0",
+			shouldError: true,
+		},
+		{
+			name:        "Unknown version",
+			version:     "unknown",
+			shouldError: true, // Should error when version cannot be determined
+		},
+		{
+			name:        "Empty version",
+			version:     "",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner()
+			s.version = tt.version
+
+			err := s.validateVersion()
+
+			if tt.shouldError && err == nil {
+				t.Errorf("Expected error for version %s, got nil", tt.version)
+			}
+
+			if !tt.shouldError && err != nil {
+				t.Errorf("Expected no error for version %s, got: %v", tt.version, err)
+			}
+		})
+	}
+}
+
+func TestMapToEnvSlice(t *testing.T) {
+	envMap := map[string]string{
+		"PATH":   "/usr/bin",
+		"HOME":   "/home/user",
+		"CUSTOM": "value",
+	}
+
+	envSlice := mapToEnvSlice(envMap)
+
+	if len(envSlice) != 3 {
+		t.Errorf("Expected 3 environment variables, got %d", len(envSlice))
+	}
+
+	// Convert slice back to map for easier verification
+	resultMap := make(map[string]string)
+	for _, env := range envSlice {
+		// Split on first '=' only
+		parts := splitOnce(env, "=")
+		if len(parts) == 2 {
+			resultMap[parts[0]] = parts[1]
+		}
+	}
+
+	for key, expectedValue := range envMap {
+		if actualValue, ok := resultMap[key]; !ok {
+			t.Errorf("Expected key '%s' not found in result", key)
+		} else if actualValue != expectedValue {
+			t.Errorf("For key '%s', expected value '%s', got '%s'", key, expectedValue, actualValue)
+		}
+	}
+}
+
+func TestScan_NoRulePaths(t *testing.T) {
+	s := NewScanner()
+	ctx := context.Background()
+
+	_, err := s.Scan(ctx, "/tmp/target", []string{}, mockToolInfo())
+
+	if err == nil {
+		t.Error("Expected error when no rule paths provided")
+	}
+
+	if err.Error() != "no rule paths provided" {
+		t.Errorf("Expected 'no rule paths provided' error, got: %v", err)
+	}
+}
+
+// Helper function to split string on first occurrence of separator.
+func splitOnce(s, sep string) []string {
+	parts := make([]string, 0, 2)
+	if idx := findFirst(s, sep); idx >= 0 {
+		parts = append(parts, s[:idx], s[idx+len(sep):])
+	} else {
+		parts = append(parts, s)
+	}
+	return parts
+}
+
+// Helper function to find first occurrence of substring.
+func findFirst(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+// mockToolInfo creates a mock ToolInfo for testing.
+func mockToolInfo() entities.ToolInfo {
+	return entities.ToolInfo{
+		Name:    "crypto-finder",
+		Version: "test",
+	}
+}

--- a/internal/scanner/semgrep/parser.go
+++ b/internal/scanner/semgrep/parser.go
@@ -9,8 +9,9 @@ import (
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 
-// parseSemgrepOutput parses Semgrep's JSON output into the SemgrepOutput schema.
-func parseSemgrepOutput(data []byte) (*entities.SemgrepOutput, error) {
+// ParseSemgrepCompatibleOutput parses Semgrep's JSON output into the SemgrepOutput schema.
+// This function can be reused by other compatible scanners (e.g., OpenGrep).
+func ParseSemgrepCompatibleOutput(data []byte) (*entities.SemgrepOutput, error) {
 	if len(data) == 0 {
 		// Empty output means no findings, which is valid
 		return &entities.SemgrepOutput{
@@ -53,7 +54,7 @@ func getErrorType(typeField any) string {
 	}
 
 	// If it's an array, extract the first element
-	if typeSlice, ok := typeField.([]interface{}); ok && len(typeSlice) > 0 {
+	if typeSlice, ok := typeField.([]any); ok && len(typeSlice) > 0 {
 		if typeStr, ok := typeSlice[0].(string); ok {
 			return typeStr
 		}

--- a/internal/scanner/semgrep/parser_test.go
+++ b/internal/scanner/semgrep/parser_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 
-func TestParseSemgrepOutput_WithArrayTypeError(t *testing.T) {
+func TestParseSemgrepCompatibleOutput_WithArrayTypeError(t *testing.T) {
 	// Test parsing a Semgrep error with an array-type field (like PartialParsing errors)
 	jsonData := `{
 		"results": [],
@@ -38,7 +38,7 @@ func TestParseSemgrepOutput_WithArrayTypeError(t *testing.T) {
 		]
 	}`
 
-	output, err := parseSemgrepOutput([]byte(jsonData))
+	output, err := ParseSemgrepCompatibleOutput([]byte(jsonData))
 	if err != nil {
 		t.Fatalf("Failed to parse Semgrep output: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestParseSemgrepOutput_WithArrayTypeError(t *testing.T) {
 	}
 }
 
-func TestParseSemgrepOutput_WithStringTypeError(t *testing.T) {
+func TestParseSemgrepCompatibleOutput_WithStringTypeError(t *testing.T) {
 	// Test parsing a Semgrep error with a simple string type
 	jsonData := `{
 		"results": [],
@@ -91,7 +91,7 @@ func TestParseSemgrepOutput_WithStringTypeError(t *testing.T) {
 		]
 	}`
 
-	output, err := parseSemgrepOutput([]byte(jsonData))
+	output, err := ParseSemgrepCompatibleOutput([]byte(jsonData))
 	if err != nil {
 		t.Fatalf("Failed to parse Semgrep output: %v", err)
 	}

--- a/internal/scanner/semgrep/scanner.go
+++ b/internal/scanner/semgrep/scanner.go
@@ -96,13 +96,13 @@ func (s *Scanner) Scan(ctx context.Context, target string, rulePaths []string, t
 	}
 
 	// Parse semgrep JSON output
-	semgrepResults, err := parseSemgrepOutput(output)
+	semgrepResults, err := ParseSemgrepCompatibleOutput(output)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse semgrep output: %w", err)
 	}
 
 	// Transform to interim format
-	report := transformToInterim(semgrepResults, toolInfo, target)
+	report := TransformSemgrepCompatibleOutputToInterimFormat(semgrepResults, toolInfo, target)
 
 	return report, nil
 }

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -14,8 +14,9 @@ import (
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 
-// transformToInterim converts Semgrep results to the interim JSON format.
-func transformToInterim(semgrepOutput *entities.SemgrepOutput, toolInfo entities.ToolInfo, target string) *entities.InterimReport {
+// TransformSemgrepCompatibleOutputToInterimFormat converts Semgrep compatible results to SCANOSS interim JSON format.
+// This function can be reused by other compatible scanners (e.g., OpenGrep).
+func TransformSemgrepCompatibleOutputToInterimFormat(semgrepOutput *entities.SemgrepOutput, toolInfo entities.ToolInfo, target string) *entities.InterimReport {
 	// Group results by file path
 	findingsByFile := groupByFile(semgrepOutput.Results)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenGrep is now the default scanner (Semgrep remains available); CLI shows help by default.

* **Documentation**
  * README updated with OpenGrep-first examples, CLI flag docs, advanced taint analysis notes, and CycloneDX 1.7 CBOM guidance.

* **Chores**
  * Container image rebuilt to include both scanners, installer/verification steps, PATH updates, workspace and metadata labels, and Semgrep upgraded to 1.145.0.

* **Tests**
  * Added unit tests covering the OpenGrep scanner.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->