### PR TITLE
feat: add --scanner-args to scan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ crypto-finder scan [flags] <target>
 | `--languages <langs>` | Override language detection (comma-separated) | auto-detect |
 | `--fail-on-findings` | Exit with error if findings detected | `false` |
 | `--timeout <duration>` | Scan timeout (e.g., 10m, 1h) | `10m` |
+| `--scanner-args <arg>` | Pass additional arguments to scanner (repeatable) | - |
 | `--verbose`, `-v` | Enable verbose logging | `false` |
 | `--quiet`, `-q` | Enable quiet mode | `false` |
 
@@ -111,6 +112,12 @@ crypto-finder scan --rules-dir ./rules /path/to/code | jq '.findings | length'
 
 # Use Semgrep scanner instead of default OpenGrep
 crypto-finder scan --scanner semgrep --rules-dir ./rules /path/to/code
+
+# Pass extra arguments to the scanner (e.g., increase verbosity)
+crypto-finder scan --scanner-args="--verbose" --rules-dir ./rules /path/to/code
+
+# Pass multiple scanner arguments
+crypto-finder scan --scanner-args="--verbose" --scanner-args="--max-memory=4GB" --rules-dir ./rules /path/to/code
 ```
 
 ### Convert Command

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -45,6 +45,7 @@ var (
 	scanLanguages  []string
 	scanFailOnFind bool
 	scanTimeout    string
+	scannerArgs    []string
 )
 
 var scanCmd = &cobra.Command{
@@ -93,6 +94,7 @@ func init() {
 	scanCmd.Flags().StringSliceVar(&scanLanguages, "languages", []string{}, "Override language detection (comma-separated)")
 	scanCmd.Flags().BoolVar(&scanFailOnFind, "fail-on-findings", false, "Exit with error if findings detected")
 	scanCmd.Flags().StringVarP(&scanTimeout, "timeout", "t", defaultTimeout, "Scan timeout (e.g., 10m, 1h)")
+	scanCmd.Flags().StringArrayVar(&scannerArgs, "scanner-args", []string{}, "Pass additional arguments directly to the scanner (repeatable)")
 }
 
 func runScan(_ *cobra.Command, args []string) error {
@@ -163,6 +165,7 @@ func runScan(_ *cobra.Command, args []string) error {
 		ScannerConfig: scanner.Config{
 			Timeout:      timeout,
 			SkipPatterns: skipPatterns,
+			ExtraArgs:    scannerArgs,
 		},
 	}
 

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestScanCommandFlags(t *testing.T) {
+	// Reset scannerArgs to empty before each test
+	scannerArgs = []string{}
+
+	// Test that the --scanner-args flag is properly registered
+	flag := scanCmd.Flags().Lookup("scanner-args")
+	if flag == nil {
+		t.Fatal("--scanner-args flag is not registered")
+	}
+
+	// Verify flag properties
+	if flag.Usage != "Pass additional arguments directly to the scanner (repeatable)" {
+		t.Errorf("Unexpected flag usage: %s", flag.Usage)
+	}
+
+	// Test single scanner arg
+	err := scanCmd.Flags().Set("scanner-args", "--verbose")
+	if err != nil {
+		t.Fatalf("Failed to set scanner-args flag: %v", err)
+	}
+
+	if len(scannerArgs) != 1 {
+		t.Errorf("Expected 1 scanner arg, got %d", len(scannerArgs))
+	}
+
+	if scannerArgs[0] != "--verbose" {
+		t.Errorf("Expected scanner arg '--verbose', got '%s'", scannerArgs[0])
+	}
+
+	// Test multiple scanner args (repeatable flag)
+	scannerArgs = []string{} // Reset
+	err = scanCmd.Flags().Set("scanner-args", "--verbose")
+	if err != nil {
+		t.Fatalf("Failed to set scanner-args flag: %v", err)
+	}
+	err = scanCmd.Flags().Set("scanner-args", "--debug")
+	if err != nil {
+		t.Fatalf("Failed to set scanner-args flag: %v", err)
+	}
+
+	if len(scannerArgs) != 2 {
+		t.Errorf("Expected 2 scanner args, got %d", len(scannerArgs))
+	}
+
+	expectedArgs := map[string]bool{
+		"--verbose": false,
+		"--debug":   false,
+	}
+
+	for _, arg := range scannerArgs {
+		if _, ok := expectedArgs[arg]; ok {
+			expectedArgs[arg] = true
+		}
+	}
+
+	for arg, found := range expectedArgs {
+		if !found {
+			t.Errorf("Expected scanner arg '%s' not found", arg)
+		}
+	}
+}
+
+func TestScanCommandFlagsExist(t *testing.T) {
+	// Verify all expected flags are registered
+	expectedFlags := map[string]string{
+		"rules":            "Rule file path (repeatable)",
+		"rules-dir":        "Rule directory path (repeatable)",
+		"scanner":          "Scanner to use (default: opengrep)",
+		"format":           "Output format: json, cyclonedx (default: json)",
+		"output":           "Output file path (default: stdout)",
+		"languages":        "Override language detection (comma-separated)",
+		"fail-on-findings": "Exit with error if findings detected",
+		"timeout":          "Scan timeout (e.g., 10m, 1h)",
+		"scanner-args":     "Pass additional arguments directly to the scanner (repeatable)",
+	}
+
+	for flagName, expectedUsage := range expectedFlags {
+		flag := scanCmd.Flags().Lookup(flagName)
+		if flag == nil {
+			t.Errorf("Expected flag --%s to be registered", flagName)
+			continue
+		}
+
+		if flag.Usage != expectedUsage {
+			t.Errorf("Flag --%s has unexpected usage.\nExpected: %s\nGot: %s",
+				flagName, expectedUsage, flag.Usage)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--scanner-args` flag (repeatable) to the scan command, enabling users to pass extra arguments directly to the underlying scanner.

* **Documentation**
  * Updated usage documentation with examples demonstrating single and multiple scanner-args usage.

* **Tests**
  * Added test coverage for the new flag and existing CLI command flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->