### PR TITLE
fix: metavar resolution for numbered capture groups ($1, $2, etc.) from Semgrep regex patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.5] - 2026-01-28
+### Fixed
+- Fix metavar resolution for numbered capture groups ($1, $2, etc.) from Semgrep regex patterns
+
+## [0.1.4] - 2026-01-27
 ### Fixed
 - Fix non-deterministic output in deduplicator by preserving asset insertion order
 - Fix deduplicator incorrectly merging assets of different types (e.g., IV and algorithm) detected on the same line by including assetType in deduplication key
@@ -13,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove unused `buildProperties` method from RelatedCryptoMapper (rule information is now properly handled via CycloneDX Evidence structure)
 
-## [0.1.4] - 2026-01-27
+### Added
 ### Added
 - Per-line deduplication of cryptographic findings to eliminate duplicate detections when multiple rules identify the same asset
 - Support for multiple detection rules per cryptographic asset with new `rules` array field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused `buildProperties` method from RelatedCryptoMapper (rule information is now properly handled via CycloneDX Evidence structure)
 
 ### Added
-### Added
 - Per-line deduplication of cryptographic findings to eliminate duplicate detections when multiple rules identify the same asset
 - Support for multiple detection rules per cryptographic asset with new `rules` array field
 - Interim report format v1.1 with enhanced data model for multi-rule assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/scanoss/crypto-finder/compare/v0.1.1...v0.1.2
 [0.1.3]: https://github.com/scanoss/crypto-finder/compare/v0.1.2...v0.1.3
 [0.1.4]: https://github.com/scanoss/crypto-finder/compare/v0.1.3...v0.1.4
+[0.1.5]: https://github.com/scanoss/crypto-finder/compare/v0.1.4...v0.1.5

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -322,15 +322,18 @@ func getMetavarValue(metavars map[string]entities.MetavarInfo, key string) strin
 //   - "SHA-$variant" with $variant=256 becomes "SHA-256"
 //   - "AES-$MODE-$PADDING" becomes "AES-CBC-PKCS5" if those metavars exist
 //   - "SHA-$unknown" stays as "SHA-$unknown" if $unknown is not in metavars
+//   - "ECDSA-$2" with $2=256 becomes "ECDSA-256" (numbered capture groups from regex)
 func resolveMetavars(s string, metavars map[string]entities.MetavarInfo) string {
 	// If the string doesn't contain $, return as-is for efficiency
 	if !strings.Contains(s, "$") {
 		return s
 	}
 
-	// Regular expression to match metavariable names: $WORD
-	// Metavariable names follow identifier rules (letters, numbers, underscores)
-	re := regexp.MustCompile(`\$[a-zA-Z_][a-zA-Z0-9_]*`)
+	// Regular expression to match metavariable names:
+	// - Traditional metavars: $WORD (letters, numbers, underscores, must start with letter/underscore)
+	// - Numbered metavars: $1, $2, etc. (from regex capture groups)
+	// Pattern matches either: $[a-zA-Z_][a-zA-Z0-9_]* OR $[0-9]+
+	re := regexp.MustCompile(`\$(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+)`)
 
 	// Replace all metavariable references with their values
 	result := re.ReplaceAllStringFunc(s, func(match string) string {

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -333,7 +333,7 @@ func resolveMetavars(s string, metavars map[string]entities.MetavarInfo) string 
 	// - Traditional metavars: $WORD (letters, numbers, underscores, must start with letter/underscore)
 	// - Numbered metavars: $1, $2, etc. (from regex capture groups)
 	// Pattern matches either: $[a-zA-Z_][a-zA-Z0-9_]* OR $[0-9]+
-	re := regexp.MustCompile(`\$(?:[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+)`)
+	re := regexp.MustCompile(`\$(?:[a-zA-Z_][a-zA-Z0-9_]*|\d+)`)
 
 	// Replace all metavariable references with their values
 	result := re.ReplaceAllStringFunc(s, func(match string) string {

--- a/internal/scanner/semgrep/transformer_test.go
+++ b/internal/scanner/semgrep/transformer_test.go
@@ -187,6 +187,35 @@ func TestResolveMetavars(t *testing.T) {
 			},
 			want: "first-second",
 		},
+		{
+			name:  "Numbered metavars from regex capture groups",
+			input: "ECDSA-$2",
+			metavars: map[string]entities.MetavarInfo{
+				"$1": {
+					AbstractContent: "elliptic",
+				},
+				"$2": {
+					AbstractContent: "256",
+				},
+			},
+			want: "ECDSA-256",
+		},
+		{
+			name:  "Multiple numbered metavars",
+			input: "$1-$2-$3",
+			metavars: map[string]entities.MetavarInfo{
+				"$1": {
+					AbstractContent: "AES",
+				},
+				"$2": {
+					AbstractContent: "256",
+				},
+				"$3": {
+					AbstractContent: "GCM",
+				},
+			},
+			want: "AES-256-GCM",
+		},
 	}
 
 	for _, tt := range tests {
@@ -440,6 +469,58 @@ func TestExtractCryptoMetadata(t *testing.T) {
 			},
 			wantMetadata: map[string]string{
 				"algorithmName": "SHA-$unknown",
+			},
+		},
+		{
+			name: "ECDSA with numbered metavars from regex capture groups",
+			cryptoMetadata: map[string]any{
+				"algorithmFamily":                 "ECDSA",
+				"algorithmName":                   "ECDSA-$2",
+				"algorithmParameterSetIdentifier": "$2",
+				"algorithmPrimitive":              "signature",
+				"api":                             "ecdsa.GenerateKey",
+				"assetType":                       "algorithm",
+				"curve":                           "$2",
+				"findingType":                     "key_generation",
+				"library":                         "crypto/ecdsa",
+				"materialSource":                  "generated",
+				"operation":                       "keygen",
+			},
+			metavars: map[string]entities.MetavarInfo{
+				"$1": {
+					AbstractContent: "elliptic",
+				},
+				"$2": {
+					AbstractContent: "256",
+				},
+				"$package": {
+					AbstractContent: "elliptic",
+				},
+				"$FUNC": {
+					AbstractContent: "elliptic.P256",
+				},
+				"$curve": {
+					AbstractContent: "256",
+				},
+				"$CURVE": {
+					AbstractContent: "curve",
+					PropagatedValue: &entities.MetavarPropagatedValue{
+						SvalueAbstractContent: "elliptic.P256()",
+					},
+				},
+			},
+			wantMetadata: map[string]string{
+				"algorithmFamily":                 "ECDSA",
+				"algorithmName":                   "ECDSA-256",
+				"algorithmParameterSetIdentifier": "256",
+				"algorithmPrimitive":              "signature",
+				"api":                             "ecdsa.GenerateKey",
+				"assetType":                       "algorithm",
+				"curve":                           "256",
+				"findingType":                     "key_generation",
+				"library":                         "crypto/ecdsa",
+				"materialSource":                  "generated",
+				"operation":                       "keygen",
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed metavar resolution for numbered capture groups from Semgrep regex patterns.

* **Chores**
  * Removed previously proposed feature additions from the Unreleased section of the changelog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->