### PR TITLE
feat: remove timestamp_utc from output schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Add `--interfile` flag for cross-file analysis support when using Semgrep Pro (`--scanner semgrep --interfile`)
+## [0.2.3] - 2026-02-09
+### Removed
+- Remove `timestamp_utc` from JSON output
 
 ## [0.2.2] - 2026-02-06
 ### Added
 - Add OID mappings for post-quantum algorithms: ML-DSA (FIPS 204), ML-KEM (FIPS 203), and SLH-DSA (FIPS 205) with all parameter set variants
 - Add OID mappings for classic algorithms: MD5, MD4, PBKDF2, scrypt, X25519, X448, Ed25519, Ed448, DH, ECDH, SM2, SM3, RC4, RSA-OAEP, and HMAC family
+- Add `--interfile` flag for cross-file analysis support when using Semgrep Pro (`--scanner semgrep --interfile`)
 
 ## [0.2.1] - 2026-02-03
 ### Changed
@@ -86,3 +88,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/scanoss/crypto-finder/compare/v0.1.5...v0.2.0
 [0.2.2]: https://github.com/scanoss/crypto-finder/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/scanoss/crypto-finder/compare/v0.2.0...v0.2.1
+[0.2.2]: https://github.com/scanoss/crypto-finder/compare/v0.2.1...v0.2.2

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -42,7 +42,6 @@ The default output format containing detailed cryptographic asset information op
           }
         }
       ],
-      "timestamp_utc": "2025-01-15T10:00:00Z"
     }
   ]
 }
@@ -114,7 +113,6 @@ The default output format containing detailed cryptographic asset information op
           }
         }
       ],
-      "timestamp_utc": "2025-10-22T10:00:00Z"
     }
   ]
 }
@@ -160,7 +158,6 @@ The default output format containing detailed cryptographic asset information op
           }
         }
       ],
-      "timestamp_utc": "2025-01-27T10:00:00Z"
     }
   ]
 }

--- a/internal/entities/interim.go
+++ b/internal/entities/interim.go
@@ -61,9 +61,6 @@ type Finding struct {
 
 	// CryptographicAssets contains all cryptographic materials found in this file
 	CryptographicAssets []CryptographicAsset `json:"cryptographic_assets"`
-
-	// TimestampUTC is the ISO 8601 timestamp when this file was scanned
-	TimestampUTC string `json:"timestamp_utc"`
 }
 
 // CryptographicAsset represents a single detected cryptographic element.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -34,8 +34,8 @@ func createTestReport() *entities.InterimReport {
 		},
 		Findings: []entities.Finding{
 			{
-				FilePath:     "test.go",
-				Language:     "go",
+				FilePath: "test.go",
+				Language: "go",
 				CryptographicAssets: []entities.CryptographicAsset{
 					{
 						MatchType: "semgrep",

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
@@ -37,7 +36,6 @@ func createTestReport() *entities.InterimReport {
 			{
 				FilePath:     "test.go",
 				Language:     "go",
-				TimestampUTC: time.Now().UTC().Format(time.RFC3339),
 				CryptographicAssets: []entities.CryptographicAsset{
 					{
 						MatchType: "semgrep",

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/go-enry/go-enry/v2"
 	"github.com/rs/zerolog/log"
@@ -96,7 +95,6 @@ func transformFileFinding(filePath string, results []entities.SemgrepResult, tar
 		FilePath:            relativePath,
 		Language:            language,
 		CryptographicAssets: assets,
-		TimestampUTC:        time.Now().UTC().Format(time.RFC3339),
 	}
 }
 

--- a/internal/scanner/semgrep/transformer_test.go
+++ b/internal/scanner/semgrep/transformer_test.go
@@ -721,7 +721,6 @@ func TestTransformFileFinding(t *testing.T) {
 	if len(finding.CryptographicAssets) != 2 {
 		t.Fatalf("Expected 2 assets, got %d", len(finding.CryptographicAssets))
 	}
-
 }
 
 func TestTransformToCryptographicAsset(t *testing.T) {

--- a/internal/scanner/semgrep/transformer_test.go
+++ b/internal/scanner/semgrep/transformer_test.go
@@ -722,9 +722,6 @@ func TestTransformFileFinding(t *testing.T) {
 		t.Fatalf("Expected 2 assets, got %d", len(finding.CryptographicAssets))
 	}
 
-	if finding.TimestampUTC == "" {
-		t.Error("Expected non-empty timestamp")
-	}
 }
 
 func TestTransformToCryptographicAsset(t *testing.T) {

--- a/schemas/interim-report-schema.json
+++ b/schemas/interim-report-schema.json
@@ -46,8 +46,7 @@
       "required": [
         "file_path",
         "language",
-        "cryptographic_assets",
-        "timestamp_utc"
+        "cryptographic_assets"
       ],
       "properties": {
         "file_path": {
@@ -65,11 +64,6 @@
           "items": {
             "$ref": "#/$defs/CryptographicAsset"
           }
-        },
-        "timestamp_utc": {
-          "type": "string",
-          "format": "date-time",
-          "description": "ISO 8601 timestamp when this file was scanned"
         }
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated interim report format documentation, JSON schema definitions, and example outputs to remove the timestamp_utc metadata field from findings, reducing the overall metadata footprint in interim reports.

* **Tests**
  * Removed timestamp validation assertions and updated test cases and test data to reflect the modified interim report structure without timestamp metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->