### PR TITLE
chore: add oid mapping for LMS algorithm family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-02-11
+### Added
+- Add OID mapping for LMS/HSS hash-based signature algorithm (RFC 8554 / RFC 8708)
+
 ## [0.2.3] - 2026-02-09
 ### Removed
 - Remove `timestamp_utc` from JSON output
@@ -86,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.4]: https://github.com/scanoss/crypto-finder/compare/v0.1.3...v0.1.4
 [0.1.5]: https://github.com/scanoss/crypto-finder/compare/v0.1.4...v0.1.5
 [0.2.0]: https://github.com/scanoss/crypto-finder/compare/v0.1.5...v0.2.0
-[0.2.2]: https://github.com/scanoss/crypto-finder/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/scanoss/crypto-finder/compare/v0.2.0...v0.2.1
 [0.2.2]: https://github.com/scanoss/crypto-finder/compare/v0.2.1...v0.2.2
+[0.2.3]: https://github.com/scanoss/crypto-finder/compare/v0.2.2...v0.2.3
+[0.2.4]: https://github.com/scanoss/crypto-finder/compare/v0.2.3...v0.2.4

--- a/internal/converter/oid_constants.go
+++ b/internal/converter/oid_constants.go
@@ -273,3 +273,10 @@ const (
 	OIDDSAWithSHA  = OIDOIWSECSIG + ".13" // dsaWithSHA
 	OIDDSAWithSHA1 = OIDOIWSECSIG + ".27" // dsaWithSHA1
 )
+
+// HSS/LMS (Leighton-Micali Signature) Algorithm OID (1.2.840.113549.1.9.16.3.17).
+// Source: RFC 8554 (LMS), RFC 8708 (HSS/LMS in CMS). https://www.rfc-editor.org/rfc/rfc8708.html.
+const (
+	OIDSMIMEAlg = "1.2.840.113549.1.9.16.3"
+	OIDLMS      = OIDSMIMEAlg + ".17" // id-alg-hss-lms-hashsig
+)

--- a/internal/converter/oid_mapper.go
+++ b/internal/converter/oid_mapper.go
@@ -182,6 +182,12 @@ func (m *OIDMapper) initializeMappings() {
 	m.addNameMapping("SLH-DSA-SHAKE-256S", OIDSLHDSASHAKE256s)
 	m.addNameMapping("SLH-DSA-SHAKE-256F", OIDSLHDSASHAKE256f)
 
+	// LMS/HSS Family (RFC 8554 / RFC 8708).
+	m.addFamilyMapping("LMS", OIDLMS)
+	m.addNameMapping("LMS", OIDLMS)
+	m.addNameMapping("HSS", OIDLMS)
+	m.addNameMapping("HSS-LMS", OIDLMS)
+
 	// MD5 (RFC 1321).
 	m.addFamilyMapping("MD5", OIDMD5)
 	m.addNameMapping("MD5", OIDMD5)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OID mappings for LMS/HSS (Leighton-Micali Signature) hash-based signature algorithms as specified in RFC 8554 and RFC 8708.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->