### PR TITLE
fix: add "name" as field to cdx evidence output

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -205,13 +205,14 @@ func (c *Converter) buildEvidence(aggregated *AggregatedAsset) *cdx.Evidence {
 
 		if identity.RuleID != "" {
 			methods = append(methods, cdx.EvidenceIdentityMethod{
-				Technique:  "source-code-analysis",
+				Technique:  cdx.EvidenceIdentityTechniqueSourceCodeAnalysis,
 				Value:      fmt.Sprintf("scanoss:ruleid,%s", identity.RuleID),
 				Confidence: &confidence,
 			})
 		}
 
 		identities = append(identities, cdx.EvidenceIdentity{
+			Field:      cdx.EvidenceIdentityFieldTypeName,
 			Methods:    &methods,
 			Confidence: &confidence,
 		})

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 
@@ -374,6 +375,15 @@ func TestConverter_MultipleRulesOnSameLine(t *testing.T) {
 
 	// Verify each identity contains methods with rule IDs
 	for i, identity := range identities {
+		if identity.Field != cdx.EvidenceIdentityFieldTypeName {
+			t.Errorf(
+				"Identity[%d] field = %q, want %q",
+				i,
+				identity.Field,
+				cdx.EvidenceIdentityFieldTypeName,
+			)
+		}
+
 		if identity.Methods == nil || len(*identity.Methods) == 0 {
 			t.Errorf("Identity[%d] has no methods", i)
 			continue

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
+
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 

--- a/internal/converter/validator.go
+++ b/internal/converter/validator.go
@@ -121,6 +121,10 @@ func (v *Validator) validateComponent(component *cdx.Component) error {
 		return fmt.Errorf("cryptoProperties: %w", err)
 	}
 
+	if err := v.validateEvidence(component.Evidence); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -209,4 +213,19 @@ func (v *Validator) validatePrimitive(primitive cdx.CryptoPrimitive) error {
 	validPrimitivesStr = validPrimitivesStr[:len(validPrimitivesStr)-2]
 
 	return fmt.Errorf("invalid primitive value: %s (must be one of: %s)", primitive, validPrimitivesStr)
+}
+
+// validateEvidence validates evidence structures used by generated cryptographic assets.
+func (v *Validator) validateEvidence(evidence *cdx.Evidence) error {
+	if evidence == nil || evidence.Identity == nil {
+		return nil
+	}
+
+	for i, identity := range *evidence.Identity {
+		if identity.Field == "" {
+			return fmt.Errorf("evidence.identity[%d].field is required", i)
+		}
+	}
+
+	return nil
 }

--- a/internal/converter/validator_test.go
+++ b/internal/converter/validator_test.go
@@ -258,6 +258,42 @@ func TestValidator_ValidateComponent(t *testing.T) {
 			wantErr:     true,
 			errContains: "cryptoProperties",
 		},
+		{
+			name: "Evidence identity missing field",
+			component: &cdx.Component{
+				Type:   cdx.ComponentTypeCryptographicAsset,
+				BOMRef: "test-ref",
+				Name:   "AES-256-GCM",
+				CryptoProperties: &cdx.CryptoProperties{
+					AssetType: cdx.CryptoAssetTypeAlgorithm,
+					AlgorithmProperties: &cdx.CryptoAlgorithmProperties{
+						Primitive: cdx.CryptoPrimitiveAE,
+					},
+				},
+				Evidence: &cdx.Evidence{
+					Identity: &[]cdx.EvidenceIdentity{
+						{
+							Confidence: func() *float32 {
+								value := float32(1)
+								return &value
+							}(),
+							Methods: &[]cdx.EvidenceIdentityMethod{
+								{
+									Technique:  cdx.EvidenceIdentityTechniqueSourceCodeAnalysis,
+									Value:      "scanoss:ruleid,go-crypto-aes-gcm",
+									Confidence: func() *float32 {
+										value := float32(1)
+										return &value
+									}(),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "evidence.identity[0].field",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/converter/validator_test.go
+++ b/internal/converter/validator_test.go
@@ -279,8 +279,8 @@ func TestValidator_ValidateComponent(t *testing.T) {
 							}(),
 							Methods: &[]cdx.EvidenceIdentityMethod{
 								{
-									Technique:  cdx.EvidenceIdentityTechniqueSourceCodeAnalysis,
-									Value:      "scanoss:ruleid,go-crypto-aes-gcm",
+									Technique: cdx.EvidenceIdentityTechniqueSourceCodeAnalysis,
+									Value:     "scanoss:ruleid,go-crypto-aes-gcm",
 									Confidence: func() *float32 {
 										value := float32(1)
 										return &value


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Evidence identity entries now include required field information and use the correct technique type, improving CycloneDX component integrity.
  * Validator now enforces that each evidence identity has a non-empty field, returning a clear indexed error when missing.

* **Tests**
  * Added and extended tests to cover evidence identity field requirements and multiple-identity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->