### PR TITLE
fix(cli): pre-detect languages and surface error cause

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -177,10 +177,14 @@ func callGraphTargetDir(target string) (string, error) {
 }
 
 func ecosystemFromHints(target string, languageHints []string) string {
-	if len(languageHints) > 0 {
-		switch languageHints[0] {
+	// Pick the first supported ecosystem from the hints. Hints may include
+	// non-source languages (e.g. "html") alongside the real source language,
+	// so checking only languageHints[0] would miss "java" when sorted hints
+	// arrive as ["html", "java"].
+	for _, hint := range languageHints {
+		switch hint {
 		case "go", ecosystemJava, "python", "rust":
-			return languageHints[0]
+			return hint
 		}
 	}
 
@@ -349,6 +353,26 @@ func runScan(_ *cobra.Command, args []string) error {
 
 	// Create skip matcher for language detection
 	skipMatcher := skip.NewGitIgnoreMatcher(skipPatterns)
+
+	// Pre-detect source languages at the CLI layer when the user did not pass
+	// --languages. This makes the detected languages available to ancillary
+	// features (notably --export-callgraph) that need to know the source
+	// ecosystem before the scanner runs. Without this, repositories without
+	// a build manifest (pom.xml, build.gradle, setup.py, go.mod, Cargo.toml)
+	// fail callgraph export with "could not determine a supported ecosystem".
+	// The orchestrator will reuse these hints instead of redetecting.
+	if len(scanLanguages) == 0 {
+		detected, detectErr := language.NewEnryDetector(skipMatcher).Detect(target)
+		if detectErr != nil {
+			return failure.WrapUnknown(
+				detectErr,
+				failure.CodeLanguageDetectionFailed,
+				failure.StageScan,
+				"failed to detect languages",
+			)
+		}
+		scanLanguages = detected
+	}
 
 	cfg := config.GetInstance()
 	if err := cfg.Initialize(config.InitOptions{

--- a/internal/failure/error.go
+++ b/internal/failure/error.go
@@ -156,11 +156,16 @@ func WrapUnknown(err error, code Code, stage Stage, message string, opts ...Opti
 }
 
 // Error implements the error interface.
+// When both Message and Cause are present, the cause is appended so the
+// underlying reason surfaces in CLI output instead of being silently dropped.
 func (e *Error) Error() string {
 	if e == nil {
 		return ""
 	}
 	if e.Message != "" {
+		if e.Cause != nil {
+			return e.Message + ": " + e.Cause.Error()
+		}
 		return e.Message
 	}
 	if e.Cause != nil {


### PR DESCRIPTION
## Summary

Fixes three CLI defects discovered while debugging a "broken" scan on a Java repo that had no build manifest. The user-facing symptom was:

```
ERROR: failed to build call graph for export
```

…with no further detail unless `--error-format=json` was used. Two root causes plus one diagnostic defect:

### 1. Language hints not pre-populated for callgraph export
`buildStandaloneCallGraphResult` → `ecosystemFromHints` calls `scanutil.DetectEcosystem(targetDir)` which requires a build manifest (`pom.xml`, `build.gradle`, `setup.py`, `go.mod`, `Cargo.toml`). For a directory of bare `.java` files with no manifest, that detection returns empty and callgraph export fails. The orchestrator separately *does* run language detection internally (`internal/language/enry.go`) and stores the result as a local variable — but it never reaches `ecosystemFromHints`.

Fix: detect languages at the CLI layer when `--languages` is empty, populate `scanLanguages` once, and let the orchestrator reuse the hint instead of redetecting. Single source of truth, no extra walk.

### 2. `ecosystemFromHints` only inspected `hints[0]`
For a sorted hint list like `["html", "java"]`, the function picked `"html"` (unsupported), fell through, and returned `""`. Now iterates and returns the first supported entry, so HTML+Java mixed repos resolve to `"java"`.

### 3. `failure.Error()` dropped `Cause` when `Message` was set
The CLI error printer (`internal/cli/root.go`) calls `err.Error()`. With both `Message` and `Cause` populated, `Error()` returned only `Message`. The wrapped cause was reachable from the structured chain (and from `--error-format=json`) but never printed in default text mode. Users saw "failed to build call graph for export" with no hint that the actual cause was "could not determine a supported ecosystem for call graph export". Now `Error()` concatenates `"<message>: <cause>"`.

## Files

| File | Change |
|---|---|
| `internal/cli/scan.go` | pre-detect languages when `--languages` empty; iterate hints in `ecosystemFromHints` |
| `internal/failure/error.go` | `Error()` includes `Cause` when both are set |

## Test plan

- [x] `go test ./internal/failure/... ./internal/cli/...` → all pass
- [x] Manual repro: scan a Java repo with no build manifest using `--export-callgraph`. Before: exit 1 with opaque error. After: exit 0, valid callgraph emitted
- [x] Sanity: scan a repo with a `build.gradle` (manifest present) — unchanged behavior, ecosystem detection still works the same way
- [x] Error surface: triggered a synthetic failure with both Message and Cause set; CLI now prints `"<message>: <cause>"` in text mode, JSON output unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced language detection to evaluate all provided language hints instead of just the first one.
  * Improved error reporting for language detection failures with clearer diagnostic information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scanoss/crypto-finder/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->