### PR TITLE
feat(callgraph): edge resolution classification + pkg/graphfrag fragment stitcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-01
+
+### Added
+- `pkg/graphfrag`: new public package owning the reusable graph-fragment model, the wire schema (`GraphFragmentExport`), `DecodeFragment`, and a tiered fail-closed stitcher that composes per-component fragments into transitive crypto-reachability chains. Downstream services consume this one contract instead of reimplementing schema/merge logic (mirrors `pkg/stitch`).
+- Call-graph edge **resolution classification**: each caller→callee edge is now tagged `exact`, `interface_dispatch`, or `name_only` at build time (`CallGraph.EdgeResolutions`), distinguishing exact typed calls from over-broad name+arity dispatch guesses (interface-dispatch expansion, fluent fallback).
+
+### Changed
+- Graph-fragment export schema bumped to `graph-fragment-1.1`: `internal_edges[]` and `external_calls[]` now carry `resolution`, `declared_type`, `method_name`, and `arity`. The fields are additive (1.0 fragments decode as unresolved/untrusted). See [docs/OUTPUT_FORMATS.md](docs/OUTPUT_FORMATS.md#graph-fragment-export).
+
 ## [0.4.1] - 2026-05-11
 
 ### Changed

--- a/docs/DEPENDENCY_SCANNING.md
+++ b/docs/DEPENDENCY_SCANNING.md
@@ -199,6 +199,19 @@ Callers:    "crypto/aes.NewCipher"         → ["example.com/app.Encrypt"]
 
 The reverse index is what enables **backward tracing** — starting from a crypto finding and walking up to user code.
 
+#### Edge resolution kinds
+
+While building the caller index, the builder records **how** each edge was
+resolved in `CallGraph.EdgeResolutions`: `exact` (receiver type known, unique
+target or overload set on that type), `interface_dispatch` (an interface/abstract
+method expanded to concrete implementations by name+arity within a namespace
+root), or `name_only` (a fluent-fallback guess with no receiver-type anchor).
+This classification is emitted on the graph-fragment export (`graph-fragment-1.1`,
+see [Output Formats](OUTPUT_FORMATS.md#graph-fragment-export)) so a downstream
+stitcher (`pkg/graphfrag`) can fail closed on over-broad dispatch instead of
+reporting it as typed reachability. The dispatch heuristics below (interface
+expansion, fluent fallback) are exactly the edges tagged non-`exact`.
+
 #### Type resolution
 
 After building the caller index, the builder runs additional resolution passes to improve type accuracy:

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -250,6 +250,112 @@ Example:
 - Detailed cryptographic asset tracking
 - Security auditing and compliance
 
+## Graph Fragment Export
+
+When `--export-graph-fragment <file>` is enabled, Crypto Finder writes a
+**reusable structural graph fragment** for the scanned component: its call
+graph plus rules-versioned crypto annotations. Unlike the finding-centric call
+graph export (above), a fragment is designed to be mined and stored **per
+component**, then composed across a dependency tree at query time to answer
+"what crypto is transitively reachable from artifact X?" — without re-scanning.
+The pure model and the stitcher that composes fragments live in the public
+package `github.com/scanoss/crypto-finder/pkg/graphfrag`, so downstream services
+(e.g. a mining/catalog service) consume one contract instead of reimplementing
+schema knowledge.
+
+Current schema version: `graph-fragment-1.1`.
+
+### Structure
+
+| Field | Description |
+|-------|-------------|
+| `schema_version` | Fragment schema version (currently `graph-fragment-1.1`). |
+| `scan_metadata` | Ecosystem, root module, tool/rules versions, and per-array counts. |
+| `functions[]` | Callable nodes. `key` is the stable function identity (`pkg.(Type).name#arity`); also carries `file_path`, `package`, `type`, `name`, signature, etc. |
+| `internal_edges[]` | Caller→callee edges **within** the component (both functions are in this fragment). |
+| `external_calls[]` | Calls whose target may live in **another** component; resolved at stitch time against the dependency tree. |
+| `crypto_annotations[]` | Crypto findings attached to a function (`function_key`, `finding_id`, `rule_id`, `symbol`). A component with no crypto still emits a fragment (zero `crypto_annotations`) so it can serve as a bridge in transitive chains. |
+
+### Edge resolution metadata (v1.1+)
+
+Every `internal_edges[]` and `external_calls[]` entry carries **resolution
+metadata** describing *how confidently* the edge was resolved. This lets a
+consumer distinguish exact typed calls from over-broad name/arity dispatch
+guesses, and refuse to present the latter as typed reachability proof.
+
+| Field | Description |
+|-------|-------------|
+| `resolution` | How the target was resolved: `exact`, `interface_dispatch`, or `name_only`. Absent ⇒ treat as unresolved/untrusted. |
+| `declared_type` | The static/interface type at the call site (e.g. the interface whose method was dispatched). Present on dispatch edges. |
+| `method_name` | The invoked method name, independent of the resolved target. |
+| `arity` | The argument count of the call. |
+
+`resolution` values:
+
+- **`exact`** — the receiver's static type was known and the method resolved to
+  a unique declared target on that type (or an overload set on that exact type).
+- **`interface_dispatch`** — the target was found by expanding an
+  interface/abstract method to concrete implementations matching name + arity
+  within a namespace root. Trustworthy only when exactly one implementation is
+  present in the dependency closure; otherwise it is an ambiguous guess.
+- **`name_only`** — the target was guessed by method name + arity (plus
+  namespace heuristics) with no receiver-type anchor (e.g. fluent-chain
+  fallback).
+
+`method_name` + `arity` + the call-site line let a consumer **group sibling
+candidates of one call site** so ambiguity can be detected across edges that
+span the component boundary. The reference consumer (`pkg/graphfrag`'s stitcher)
+applies a **tiered, fail-closed** policy: traverse `exact` edges and
+`interface_dispatch` edges with exactly one implementation in the dependency
+closure; **drop** ambiguous interface dispatch (>1 impl) and `name_only` edges,
+recording them rather than emitting a chain. This is what prevents a DRBG's
+`generate()` from name-colliding with `BCrypt.generate#3` (or
+`provider.get(...)` fanning out to unrelated `get(...)` methods) from being
+reported as reachable crypto.
+
+> Fragments exported by older versions (without `resolution`) decode as
+> unresolved and are treated as untrusted (fail-closed): under-report, never a
+> false positive.
+
+### Example
+
+```json
+{
+  "schema_version": "graph-fragment-1.1",
+  "scan_metadata": { "ecosystem": "java", "root_module": "org.bouncycastle:bcpkix-jdk18on", "function_count": 4000, "internal_edge_count": 6417, "external_call_count": 9469, "crypto_operation_count": 160 },
+  "functions": [
+    { "key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1", "file_path": "org/bouncycastle/pkcs/PKCS8EncryptedPrivateKeyInfo.java" }
+  ],
+  "external_calls": [
+    {
+      "caller_key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1",
+      "target_key": "org.bouncycastle.operator.(InputDecryptorProvider).get#1",
+      "line": 90,
+      "resolution": "exact",
+      "method_name": "get",
+      "arity": 1
+    },
+    {
+      "caller_key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1",
+      "target_key": "org.bouncycastle.cms.(RecipientInformationStore).get#1",
+      "line": 90,
+      "resolution": "interface_dispatch",
+      "declared_type": "org.bouncycastle.operator.InputDecryptorProvider",
+      "method_name": "get",
+      "arity": 1
+    }
+  ],
+  "crypto_annotations": [
+    { "function_key": "org.bouncycastle.asn1.pkcs.(EncryptedPrivateKeyInfo).getEncryptedData#0", "finding_id": "abc123", "symbol": "getEncryptedData" }
+  ]
+}
+```
+
+In this slice, `decryptPrivateKeyInfo` has one **`exact`** edge to the real
+`InputDecryptorProvider.get` and one over-broad **`interface_dispatch`** edge to
+an unrelated `get#1` from the same call site (`line: 90`). A stitcher that sees
+more than one implementation for that call site drops the ambiguous group.
+
 ## CycloneDX CBOM Format
 
 CycloneDX 1.6 compatible Cryptography Bill of Materials format for standardized reporting.

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -330,7 +330,7 @@ func (b *Builder) expandOverloadCandidates(callee FunctionID, methodsByQualified
 	return methodsByQualifiedArity[qualifiedMethodArityKey(callee.Package, callee.Type, callee.Name)]
 }
 
-// interfaceDispatchAlias is one synthesised interface-dispatch edge target plus
+// interfaceDispatchAlias is one synthesized interface-dispatch edge target plus
 // the interface type that was expanded, so the edge can be classified and
 // grouped with its siblings downstream.
 type interfaceDispatchAlias struct {

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -240,22 +240,23 @@ func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind Ed
 	if graph.EdgeResolutions == nil {
 		graph.EdgeResolutions = make(map[string]EdgeResolution)
 	}
-	key := EdgeResolutionKey(callerKey, calleeKey)
-	if existing, ok := graph.EdgeResolutions[key]; ok && edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
-		return
-	}
 	method, arity := "", 0
 	if calleeID, err := ParseFunctionID(calleeKey); err == nil {
 		method = BaseFunctionName(calleeID.Name)
 		arity = functionArity(calleeID.Name)
 	}
-	graph.EdgeResolutions[key] = EdgeResolution{
+	resolution := EdgeResolution{
 		Kind:         kind,
 		DeclaredType: declaredType,
 		MethodName:   method,
 		Arity:        arity,
 		CallSite:     callSite,
 	}
+	key := EdgeResolutionKey(callerKey, calleeKey, resolution)
+	if existing, ok := graph.EdgeResolutions[key]; ok && edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
+		return
+	}
+	graph.EdgeResolutions[key] = resolution
 }
 
 func indexMethodsByName(graph *CallGraph) map[string][]*FunctionDecl {
@@ -372,9 +373,6 @@ func (b *Builder) expandInterfaceDispatch(
 	}
 
 	sort.Strings(keys)
-	if len(keys) > 8 {
-		keys = keys[:8]
-	}
 	results := make([]interfaceDispatchAlias, 0, len(keys))
 	for _, k := range keys {
 		results = append(results, interfaceDispatchAlias{CalleeKey: k, DeclaredType: declaredType})

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -75,8 +75,9 @@ func (b *Builder) PackageSeparator() string {
 func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) (*CallGraph, error) {
 	buildStart := time.Now()
 	graph := &CallGraph{
-		Functions: make(map[string]*FunctionDecl),
-		Callers:   make(map[string][]string),
+		Functions:       make(map[string]*FunctionDecl),
+		Callers:         make(map[string][]string),
+		EdgeResolutions: make(map[string]EdgeResolution),
 	}
 
 	// Phase 1: Parse source files only for packages that need full analysis
@@ -204,25 +205,56 @@ func (b *Builder) buildCallerIndex(graph *CallGraph) {
 			call := fn.Calls[i]
 			calleeKey := call.Callee.String()
 			addCaller(graph.Callers, calleeKey, callerKey)
+			recordEdgeResolution(graph, callerKey, calleeKey, EdgeKindExact, "", call.Line)
 
 			overloadTargets := b.expandOverloadCandidates(call.Callee, methodsByQualifiedArity)
 			resolvedTargets := make([]string, 1, 1+len(overloadTargets))
 			resolvedTargets[0] = calleeKey
 			for _, target := range overloadTargets {
 				addCaller(graph.Callers, target, callerKey)
+				recordEdgeResolution(graph, callerKey, target, EdgeKindExact, "", call.Line)
 				resolvedTargets = append(resolvedTargets, target)
 			}
 
 			for _, target := range resolvedTargets {
 				for _, alias := range b.expandInterfaceDispatch(target, graph, methodsByName) {
-					addCaller(graph.Callers, alias, callerKey)
+					addCaller(graph.Callers, alias.CalleeKey, callerKey)
+					recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
 				}
 			}
 
 			for _, alias := range b.expandFluentFallback(call, graph, methodsByName) {
 				addCaller(graph.Callers, alias, callerKey)
+				recordEdgeResolution(graph, callerKey, alias, EdgeKindNameOnly, "", call.Line)
 			}
 		}
+	}
+}
+
+// recordEdgeResolution stores how a caller->callee edge was resolved, keeping
+// the highest-trust classification when the same edge is reached via multiple
+// paths (a direct exact call must never be downgraded to a dispatch guess).
+// MethodName and Arity are derived from the callee key so dispatch siblings of
+// one call site share a stable grouping identity downstream.
+func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind EdgeKind, declaredType string, callSite int) {
+	if graph.EdgeResolutions == nil {
+		graph.EdgeResolutions = make(map[string]EdgeResolution)
+	}
+	key := EdgeResolutionKey(callerKey, calleeKey)
+	if existing, ok := graph.EdgeResolutions[key]; ok && edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
+		return
+	}
+	method, arity := "", 0
+	if calleeID, err := ParseFunctionID(calleeKey); err == nil {
+		method = BaseFunctionName(calleeID.Name)
+		arity = functionArity(calleeID.Name)
+	}
+	graph.EdgeResolutions[key] = EdgeResolution{
+		Kind:         kind,
+		DeclaredType: declaredType,
+		MethodName:   method,
+		Arity:        arity,
+		CallSite:     callSite,
 	}
 }
 
@@ -298,13 +330,21 @@ func (b *Builder) expandOverloadCandidates(callee FunctionID, methodsByQualified
 	return methodsByQualifiedArity[qualifiedMethodArityKey(callee.Package, callee.Type, callee.Name)]
 }
 
+// interfaceDispatchAlias is one synthesised interface-dispatch edge target plus
+// the interface type that was expanded, so the edge can be classified and
+// grouped with its siblings downstream.
+type interfaceDispatchAlias struct {
+	CalleeKey    string
+	DeclaredType string
+}
+
 // expandInterfaceDispatch links interface method call-sites to concrete implementations
 // with matching method name/arity in the same namespace root.
 func (b *Builder) expandInterfaceDispatch(
 	calleeKey string,
 	graph *CallGraph,
 	methodsByName map[string][]*FunctionDecl,
-) []string {
+) []interfaceDispatchAlias {
 	calleeDecl, ok := graph.Functions[calleeKey]
 	if !ok || calleeDecl.OwnerType != ownerTypeInterface {
 		return nil
@@ -315,8 +355,9 @@ func (b *Builder) expandInterfaceDispatch(
 		return nil
 	}
 
+	declaredType := interfaceDeclaredType(calleeDecl.ID)
 	baseRoot := namespaceRoot(calleeDecl.ID.Package)
-	results := make([]string, 0, len(targets))
+	keys := make([]string, 0, len(targets))
 	for _, candidate := range targets {
 		if candidate.OwnerType == ownerTypeInterface {
 			continue
@@ -327,14 +368,30 @@ func (b *Builder) expandInterfaceDispatch(
 		if namespaceRoot(candidate.ID.Package) != baseRoot {
 			continue
 		}
-		results = append(results, candidate.ID.String())
+		keys = append(keys, candidate.ID.String())
 	}
 
-	sort.Strings(results)
-	if len(results) > 8 {
-		return results[:8]
+	sort.Strings(keys)
+	if len(keys) > 8 {
+		keys = keys[:8]
+	}
+	results := make([]interfaceDispatchAlias, 0, len(keys))
+	for _, k := range keys {
+		results = append(results, interfaceDispatchAlias{CalleeKey: k, DeclaredType: declaredType})
 	}
 	return results
+}
+
+// interfaceDeclaredType renders the fully-qualified interface type for a method
+// ID (e.g. {Package: "dep", Type: "Sink"} -> "dep.Sink").
+func interfaceDeclaredType(id FunctionID) string {
+	if id.Type == "" {
+		return id.Package
+	}
+	if id.Package == "" {
+		return id.Type
+	}
+	return id.Package + "." + id.Type
 }
 
 // expandFluentFallback links unresolved fluent-chain calls (foo().bar().baz()) to

--- a/internal/callgraph/edge_resolution_test.go
+++ b/internal/callgraph/edge_resolution_test.go
@@ -67,12 +67,23 @@ func TestBuildCallerIndex_ClassifiesEdgeResolution(t *testing.T) {
 	ifaceKey := ifaceRun.ID.String()
 	implKey := implRun.ID.String()
 
-	directKind := graph.EdgeResolutions[EdgeResolutionKey(callerKey, ifaceKey)]
+	directKind := graph.EdgeResolutions[EdgeResolutionKey(callerKey, ifaceKey, EdgeResolution{
+		Kind:       EdgeKindExact,
+		MethodName: "run",
+		Arity:      0,
+		CallSite:   3,
+	})]
 	if directKind.Kind != EdgeKindExact {
 		t.Fatalf("direct edge kind = %q, want %q", directKind.Kind, EdgeKindExact)
 	}
 
-	implRes, ok := graph.EdgeResolutions[EdgeResolutionKey(callerKey, implKey)]
+	implRes, ok := graph.EdgeResolutions[EdgeResolutionKey(callerKey, implKey, EdgeResolution{
+		Kind:         EdgeKindInterfaceDispatch,
+		DeclaredType: "com.dep.Sink",
+		MethodName:   "run",
+		Arity:        0,
+		CallSite:     3,
+	})]
 	if !ok {
 		t.Fatalf("expected an EdgeResolution for the synthesized impl edge %q", implKey)
 	}

--- a/internal/callgraph/edge_resolution_test.go
+++ b/internal/callgraph/edge_resolution_test.go
@@ -11,7 +11,7 @@ import (
 // name/arity dispatch guesses.
 //
 // Scenario: a controller calls an interface method directly. The direct edge to
-// the interface method is exact; the edges the builder synthesises to the
+// the interface method is exact; the edges the builder synthesizes to the
 // concrete implementations (by name+arity+namespace) are interface_dispatch.
 func TestBuildCallerIndex_ClassifiesEdgeResolution(t *testing.T) {
 	root := t.TempDir()
@@ -74,7 +74,7 @@ func TestBuildCallerIndex_ClassifiesEdgeResolution(t *testing.T) {
 
 	implRes, ok := graph.EdgeResolutions[EdgeResolutionKey(callerKey, implKey)]
 	if !ok {
-		t.Fatalf("expected an EdgeResolution for the synthesised impl edge %q", implKey)
+		t.Fatalf("expected an EdgeResolution for the synthesized impl edge %q", implKey)
 	}
 	if implRes.Kind != EdgeKindInterfaceDispatch {
 		t.Fatalf("impl edge kind = %q, want %q", implRes.Kind, EdgeKindInterfaceDispatch)

--- a/internal/callgraph/edge_resolution_test.go
+++ b/internal/callgraph/edge_resolution_test.go
@@ -1,0 +1,91 @@
+package callgraph
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestBuildCallerIndex_ClassifiesEdgeResolution proves the builder records HOW
+// each caller->callee edge was resolved, so the fragment export (and the
+// mining-service stitcher) can distinguish exact typed edges from over-broad
+// name/arity dispatch guesses.
+//
+// Scenario: a controller calls an interface method directly. The direct edge to
+// the interface method is exact; the edges the builder synthesises to the
+// concrete implementations (by name+arity+namespace) are interface_dispatch.
+func TestBuildCallerIndex_ClassifiesEdgeResolution(t *testing.T) {
+	root := t.TempDir()
+
+	controller := FunctionDecl{
+		ID:        FunctionID{Package: "app", Type: "Controller", Name: "handle#0"},
+		FilePath:  filepath.Join(root, "Controller.java"),
+		StartLine: 1,
+		EndLine:   5,
+		OwnerType: "class",
+		OwnerName: "Controller",
+		Calls: []FunctionCall{
+			{
+				Callee:   FunctionID{Package: "com.dep", Type: "Sink", Name: "run#0"},
+				Raw:      "sink.run()",
+				FilePath: filepath.Join(root, "Controller.java"),
+				Line:     3,
+			},
+		},
+	}
+	ifaceRun := FunctionDecl{
+		ID:         FunctionID{Package: "com.dep", Type: "Sink", Name: "run#0"},
+		FilePath:   filepath.Join(root, "Sink.java"),
+		StartLine:  1,
+		EndLine:    2,
+		OwnerType:  "interface",
+		OwnerName:  "Sink",
+		Parameters: []FunctionParameter{},
+	}
+	implRun := FunctionDecl{
+		ID:         FunctionID{Package: "com.dep.impl", Type: "SinkImpl", Name: "run#0"},
+		FilePath:   filepath.Join(root, "SinkImpl.java"),
+		StartLine:  1,
+		EndLine:    4,
+		OwnerType:  "class",
+		OwnerName:  "SinkImpl",
+		Parameters: []FunctionParameter{},
+	}
+
+	parser := &stubParser{
+		sep: ".",
+		analyses: map[string][]*FileAnalysis{
+			root: {{Functions: []FunctionDecl{controller, ifaceRun, implRun}}},
+		},
+	}
+
+	graph, err := NewBuilder(parser).BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "app"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	callerKey := controller.ID.String()
+	ifaceKey := ifaceRun.ID.String()
+	implKey := implRun.ID.String()
+
+	directKind := graph.EdgeResolutions[EdgeResolutionKey(callerKey, ifaceKey)]
+	if directKind.Kind != EdgeKindExact {
+		t.Fatalf("direct edge kind = %q, want %q", directKind.Kind, EdgeKindExact)
+	}
+
+	implRes, ok := graph.EdgeResolutions[EdgeResolutionKey(callerKey, implKey)]
+	if !ok {
+		t.Fatalf("expected an EdgeResolution for the synthesised impl edge %q", implKey)
+	}
+	if implRes.Kind != EdgeKindInterfaceDispatch {
+		t.Fatalf("impl edge kind = %q, want %q", implRes.Kind, EdgeKindInterfaceDispatch)
+	}
+	if implRes.DeclaredType != "com.dep.Sink" {
+		t.Fatalf("impl edge declared type = %q, want %q", implRes.DeclaredType, "com.dep.Sink")
+	}
+	if implRes.MethodName != "run" || implRes.Arity != 0 {
+		t.Fatalf("impl edge method/arity = %q/%d, want run/0", implRes.MethodName, implRes.Arity)
+	}
+	if implRes.CallSite != 3 {
+		t.Fatalf("impl edge call site = %d, want 3 (the call expression line)", implRes.CallSite)
+	}
+}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -263,6 +263,72 @@ type CallGraph struct {
 	// JavaPlatformSignatures records whether Java platform signatures from the
 	// pinned runtime were available and used for this graph build.
 	JavaPlatformSignatures *JavaPlatformSignatureMetadata
+	// EdgeResolutions records how each caller->callee edge in Callers was
+	// resolved. Keyed by EdgeResolutionKey(callerKey, calleeKey). An edge with
+	// no entry is an exact, directly-resolved source call. Consumers (the graph
+	// fragment export and the mining-service stitcher) use this to refuse to
+	// present over-broad name/arity dispatch guesses as typed reachability proof.
+	EdgeResolutions map[string]EdgeResolution
+}
+
+// EdgeKind classifies how confidently a caller->callee edge was resolved.
+type EdgeKind string
+
+const (
+	// EdgeKindExact: the receiver's static type was known and the method
+	// resolved to a unique declared target (or an overload on that exact type).
+	EdgeKindExact EdgeKind = "exact"
+	// EdgeKindInterfaceDispatch: a synthesised edge from an interface/abstract
+	// method call site to a concrete implementation matched by name+arity within
+	// a namespace root.
+	EdgeKindInterfaceDispatch EdgeKind = "interface_dispatch"
+	// EdgeKindNameOnly: a fluent-fallback edge matched by method name+arity (and
+	// namespace heuristics) with no receiver type anchor.
+	EdgeKindNameOnly EdgeKind = "name_only"
+)
+
+// edgeKindRank orders kinds by trust so a stronger classification is never
+// downgraded when the same edge is reached via multiple resolution paths.
+func edgeKindRank(k EdgeKind) int {
+	switch k {
+	case EdgeKindExact:
+		return 3
+	case EdgeKindInterfaceDispatch:
+		return 2
+	case EdgeKindNameOnly:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// EdgeResolution describes how one caller->callee edge was resolved, plus the
+// call-site identity needed to group ambiguous dispatch siblings downstream.
+type EdgeResolution struct {
+	Kind         EdgeKind
+	DeclaredType string // interface/static type for dispatch edges (e.g. "dep.Sink")
+	MethodName   string // base method name (no arity decoration)
+	Arity        int
+	CallSite     int // source line of the call expression
+}
+
+// EdgeResolutionKey is the stable map key for an edge resolution.
+func EdgeResolutionKey(callerKey, calleeKey string) string {
+	return callerKey + "\x00" + calleeKey
+}
+
+// functionArity parses the "#<n>" arity suffix from a decorated function name.
+// Returns 0 when the name carries no arity suffix.
+func functionArity(name string) int {
+	idx := strings.Index(name, "#")
+	if idx < 0 || idx >= len(name)-1 {
+		return 0
+	}
+	n := 0
+	for j := idx + 1; j < len(name) && name[j] >= '0' && name[j] <= '9'; j++ {
+		n = n*10 + int(name[j]-'0')
+	}
+	return n
 }
 
 // ExternalMethodSignatureKey returns the stable graph key for resolver-provided

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -275,14 +275,14 @@ type CallGraph struct {
 type EdgeKind string
 
 const (
-	// EdgeKindExact: the receiver's static type was known and the method
+	// EdgeKindExact means the receiver's static type was known and the method
 	// resolved to a unique declared target (or an overload on that exact type).
 	EdgeKindExact EdgeKind = "exact"
-	// EdgeKindInterfaceDispatch: a synthesised edge from an interface/abstract
+	// EdgeKindInterfaceDispatch is a synthesized edge from an interface/abstract
 	// method call site to a concrete implementation matched by name+arity within
 	// a namespace root.
 	EdgeKindInterfaceDispatch EdgeKind = "interface_dispatch"
-	// EdgeKindNameOnly: a fluent-fallback edge matched by method name+arity (and
+	// EdgeKindNameOnly is a fluent-fallback edge matched by method name+arity (and
 	// namespace heuristics) with no receiver type anchor.
 	EdgeKindNameOnly EdgeKind = "name_only"
 )

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -5,6 +5,7 @@ package callgraph
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -263,11 +264,12 @@ type CallGraph struct {
 	// JavaPlatformSignatures records whether Java platform signatures from the
 	// pinned runtime were available and used for this graph build.
 	JavaPlatformSignatures *JavaPlatformSignatureMetadata
-	// EdgeResolutions records how each caller->callee edge in Callers was
-	// resolved. Keyed by EdgeResolutionKey(callerKey, calleeKey). An edge with
-	// no entry is an exact, directly-resolved source call. Consumers (the graph
-	// fragment export and the mining-service stitcher) use this to refuse to
-	// present over-broad name/arity dispatch guesses as typed reachability proof.
+	// EdgeResolutions records how each caller->callee call-site/dispatch variant
+	// was resolved. Keyed by EdgeResolutionKey(callerKey, calleeKey, resolution).
+	// An edge with no entry is an exact, directly-resolved source call. Consumers
+	// (the graph fragment export and the mining-service stitcher) use this to
+	// refuse to present over-broad name/arity dispatch guesses as typed
+	// reachability proof.
 	EdgeResolutions map[string]EdgeResolution
 }
 
@@ -312,9 +314,20 @@ type EdgeResolution struct {
 	CallSite     int // source line of the call expression
 }
 
-// EdgeResolutionKey is the stable map key for an edge resolution.
-func EdgeResolutionKey(callerKey, calleeKey string) string {
-	return callerKey + "\x00" + calleeKey
+// EdgeResolutionKey is the stable map key for one resolved caller->callee
+// call-site/dispatch variant.
+func EdgeResolutionKey(callerKey, calleeKey string, resolution EdgeResolution) string {
+	return EdgeResolutionKeyPrefix(callerKey, calleeKey) +
+		strconv.Itoa(resolution.CallSite) + "\x00" +
+		resolution.DeclaredType + "\x00" +
+		resolution.MethodName + "\x00" +
+		strconv.Itoa(resolution.Arity)
+}
+
+// EdgeResolutionKeyPrefix returns the stable prefix shared by all resolution
+// variants for one caller->callee pair.
+func EdgeResolutionKeyPrefix(callerKey, calleeKey string) string {
+	return callerKey + "\x00" + calleeKey + "\x00"
 }
 
 // functionArity parses the "#<n>" arity suffix from a decorated function name.

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -73,33 +73,36 @@ var AllowedScanners = []string{opengrep.ScannerName, semgrep.ScannerName}
 var SupportedFormats = []string{formatJSON, "cyclonedx"}
 
 var (
-	scanRules               []string
-	scanRuleDirs            []string
-	scanScanner             string
-	scanFormat              string
-	scanOutput              string
-	scanLanguages           []string
-	scanFailOnFind          bool
-	scanTimeout             string
-	scanNoRemoteRules       bool
-	scanNoCache             bool
-	scanAPIKey              string
-	scanAPIURL              string
-	scanStrict              bool
-	scanMaxStaleAge         string
-	scanNoDedup             bool
-	scanInterfile           bool
-	scanDependencies        bool
-	scanIncludeTests        bool
-	scanNoDefaultExclusions bool     // --no-default-exclusions flag
-	scanExcludePatterns     []string // --exclude flag (repeatable)
-	scanDepEcosystem        string
-	scanExportCallgraph     string
-	scanExportCgFormat      string
-	scanDepWorkers          int
-	scanJavaJDKMajor        string
-	scanJavaJDKHomes        []string
-	scanFindingsCache       string
+	scanRules                []string
+	scanRuleDirs             []string
+	scanScanner              string
+	scanFormat               string
+	scanOutput               string
+	scanLanguages            []string
+	scanFailOnFind           bool
+	scanTimeout              string
+	scanNoRemoteRules        bool
+	scanNoCache              bool
+	scanAPIKey               string
+	scanAPIURL               string
+	scanStrict               bool
+	scanMaxStaleAge          string
+	scanNoDedup              bool
+	scanInterfile            bool
+	scanDependencies         bool
+	scanIncludeTests         bool
+	scanNoDefaultExclusions  bool     // --no-default-exclusions flag
+	scanExcludePatterns      []string // --exclude flag (repeatable)
+	scanDepEcosystem         string
+	scanExportCallgraph      string
+	scanExportCgFormat       string
+	scanExportGraphFragment  string
+	scanExportGfFormat       string
+	scanDepWorkers           int
+	scanJavaJDKMajor         string
+	scanJavaJDKHomes         []string
+	scanJavaCompiledArtifact string
+	scanFindingsCache        string
 )
 
 var scanCmd = &cobra.Command{
@@ -174,8 +177,11 @@ func init() {
 	scanCmd.Flags().StringVar(&scanFindingsCache, "findings-cache", "", fmt.Sprintf("FindingsCache backend: %v (default: %s; can also be set via SCANOSS_FINDINGS_CACHE_BACKEND)", AllowedFindingsCacheBackends, config.DefaultFindingsCacheBackend))
 	scanCmd.Flags().StringVar(&scanExportCallgraph, "export-callgraph", "", "Export the crypto-scoped call graph to a file")
 	scanCmd.Flags().StringVar(&scanExportCgFormat, "export-callgraph-format", "json", "Call graph export format (only json is supported)")
+	scanCmd.Flags().StringVar(&scanExportGraphFragment, "export-graph-fragment", "", "Export a reusable structural graph fragment to a file")
+	scanCmd.Flags().StringVar(&scanExportGfFormat, "export-graph-fragment-format", "json", "Graph fragment export format (only json is supported)")
 	scanCmd.Flags().StringVar(&scanJavaJDKMajor, "java-jdk-major", "", "Java JDK major for Java dependency resolution/type enrichment: auto, 8, 11, 17, 21")
 	scanCmd.Flags().StringArrayVar(&scanJavaJDKHomes, "java-jdk-home", []string{}, "Java JDK home mapping in the form <major>=<path> (repeatable)")
+	scanCmd.Flags().StringVar(&scanJavaCompiledArtifact, "java-compiled-artifact", "", "Compiled Java artifact path used for standalone callgraph/type enrichment")
 }
 
 func callGraphTargetDir(target string) (string, error) {
@@ -342,7 +348,7 @@ func multiSourceLabel(sources []skip.PatternSource, multi *skip.MultiSource) str
 	return strings.Join(names, ", ")
 }
 
-func buildStandaloneCallGraphResult(target string, report *entities.InterimReport, languageHints []string, javaRuntime javaruntime.Config, includeTests bool) (*engine.DepScanResult, error) {
+func buildStandaloneCallGraphResult(target string, report *entities.InterimReport, languageHints []string, javaRuntime javaruntime.Config, includeTests bool, compiledArtifact string) (*engine.DepScanResult, error) {
 	targetDir, err := callGraphTargetDir(target)
 	if err != nil {
 		return nil, fmt.Errorf("resolve call graph target: %w", err)
@@ -360,8 +366,9 @@ func buildStandaloneCallGraphResult(target string, report *entities.InterimRepor
 
 	rootModule := scanutil.DetectRootModule(targetDir, ecosystem)
 	graph, err := cgBuilder.BuildFromDirectories([]callgraph.PackageDir{{
-		Dir:        targetDir,
-		ImportPath: rootModule,
+		Dir:                  targetDir,
+		ImportPath:           rootModule,
+		CompiledArtifactPath: compiledArtifact,
 	}}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build call graph: %w", err)
@@ -416,7 +423,15 @@ func runScan(_ *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	targetDir := filepath.Dir(target)
+	targetDir, err := callGraphTargetDir(target)
+	if err != nil {
+		return failure.WrapUnknown(
+			err,
+			failure.CodeInvalidArguments,
+			failure.StageInput,
+			fmt.Sprintf("failed to resolve target directory for '%s'", target),
+		)
+	}
 
 	// Load skip patterns from multiple sources, honoring --no-default-exclusions and --exclude.
 	skipPatterns, skipSrcLabel := buildSkipPatterns(targetDir, scanNoDefaultExclusions, scanExcludePatterns)
@@ -667,13 +682,13 @@ func runScan(_ *cobra.Command, args []string) error {
 
 	engine.EnsureFindingSources(report)
 
-	if scanExportCallgraph != "" && (callGraphResult == nil || callGraphResult.CallGraph == nil) {
+	if (scanExportCallgraph != "" || scanExportGraphFragment != "") && (callGraphResult == nil || callGraphResult.CallGraph == nil) {
 		if ecosystemFromHints(target, scanLanguages) == "java" {
 			if err := ensureJavaRuntime(); err != nil {
 				return err
 			}
 		}
-		callGraphResult, err = buildStandaloneCallGraphResult(target, report, scanLanguages, javaRuntime, scanIncludeTests)
+		callGraphResult, err = buildStandaloneCallGraphResult(target, report, scanLanguages, javaRuntime, scanIncludeTests, scanJavaCompiledArtifact)
 		if err != nil {
 			return failure.WrapUnknown(
 				err,
@@ -684,16 +699,19 @@ func runScan(_ *cobra.Command, args []string) error {
 		}
 	}
 
+	if scanExportCallgraph != "" || scanExportGraphFragment != "" {
+		engine.AssignFindingIDs(report)
+		if callGraphResult != nil {
+			callGraphResult.Report = report
+		}
+	}
+
 	if scanExportCallgraph != "" {
 		exportStart := time.Now()
 		log.Info().
 			Str("file", scanExportCallgraph).
 			Str("format", scanExportCgFormat).
 			Msg("Starting call graph export")
-		engine.AssignFindingIDs(report)
-		if callGraphResult != nil {
-			callGraphResult.Report = report
-		}
 		if exportErr := scanutil.ExportCallGraph(scanExportCallgraph, scanExportCgFormat, callGraphResult); exportErr != nil {
 			return failure.WrapUnknown(
 				exportErr,
@@ -706,6 +724,26 @@ func runScan(_ *cobra.Command, args []string) error {
 			Str("file", scanExportCallgraph).
 			Dur("duration", time.Since(exportStart)).
 			Msg("Call graph export complete")
+	}
+
+	if scanExportGraphFragment != "" {
+		exportStart := time.Now()
+		log.Info().
+			Str("file", scanExportGraphFragment).
+			Str("format", scanExportGfFormat).
+			Msg("Starting graph fragment export")
+		if exportErr := scanutil.ExportGraphFragment(scanExportGraphFragment, scanExportGfFormat, callGraphResult); exportErr != nil {
+			return failure.WrapUnknown(
+				exportErr,
+				failure.CodeCallGraphExportFailed,
+				failure.StageExport,
+				"failed to export graph fragment",
+			)
+		}
+		log.Info().
+			Str("file", scanExportGraphFragment).
+			Dur("duration", time.Since(exportStart)).
+			Msg("Graph fragment export complete")
 	}
 
 	report.Version = entities.InterimFormatVersion

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -329,7 +329,7 @@ func Encrypt(key []byte) error {
 		}},
 	}
 
-	result, err := buildStandaloneCallGraphResult(tempDir, report, nil, javaruntime.Config{}, false)
+	result, err := buildStandaloneCallGraphResult(tempDir, report, nil, javaruntime.Config{}, false, "")
 	if err != nil {
 		t.Fatalf("buildStandaloneCallGraphResult: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestEncrypt() {
 		}},
 	}
 
-	result, err := buildStandaloneCallGraphResult(tempDir, report, nil, javaruntime.Config{}, true)
+	result, err := buildStandaloneCallGraphResult(tempDir, report, nil, javaruntime.Config{}, true, "")
 	if err != nil {
 		t.Fatalf("buildStandaloneCallGraphResult: %v", err)
 	}

--- a/internal/engine/dependency_scanner.go
+++ b/internal/engine/dependency_scanner.go
@@ -470,17 +470,21 @@ func (ds *DependencyScanner) buildDepScanOptions(dep *dependency.Dependency, rul
 
 // packageSets separates dependencies into two groups for the two-phase callgraph build.
 type packageSets struct {
-	// graphPackages get full source parsing: user code + deps with crypto findings.
+	// graphPackages get full source parsing: user code + every dependency whose
+	// source was resolved and scanned successfully. Non-crypto dependencies must
+	// still be parsed here because they can be bridge nodes in a call chain
+	// (for example A -> B(no crypto) -> C(crypto)).
 	graphPackages []callgraph.PackageDir
 	// typeOnlyPackages are used only for bytecode type indexing (no source parsing).
-	// This preserves type resolution accuracy while avoiding expensive parsing of
-	// deps that have no crypto findings.
+	// This preserves type resolution accuracy for dependencies whose source is
+	// unavailable or whose scan failed, while avoiding duplicate source parsing for
+	// dependencies already listed in graphPackages.
 	typeOnlyPackages []callgraph.PackageDir
 }
 
 // collectPackageSets builds two lists of PackageDirs for the two-phase callgraph build.
-// graphPackages: user code + deps with findings (full source parsing).
-// typeOnlyPackages: deps without findings (bytecode type index only).
+// graphPackages: user code + successfully scanned deps with source, regardless of findings.
+// typeOnlyPackages: Java deps not source-parsed, used for bytecode type resolution only.
 func (ds *DependencyScanner) collectPackageSets(
 	userTarget string,
 	resolved *dependency.ResolveResult,
@@ -504,7 +508,10 @@ func (ds *DependencyScanner) collectPackageSets(
 		})
 	}
 
-	// Split deps: findings deps get full source parsing; others get bytecode-only type index.
+	// Source-available deps participate in reachability even when they have no
+	// direct crypto findings. A non-crypto dep can be the only bridge between
+	// user code and a crypto-bearing transitive dependency. Keep bytecode-only
+	// indexing as a fallback for Java deps that cannot be source-parsed.
 	for i := range depResults {
 		result := &depResults[i]
 		pkg := callgraph.PackageDir{
@@ -513,7 +520,7 @@ func (ds *DependencyScanner) collectPackageSets(
 			Version:              result.dep.Version,
 			CompiledArtifactPath: result.dep.CompiledArtifactPath,
 		}
-		if result.status == depScanStatusScanned && result.report != nil && hasFindings(result.report) && result.dep.Dir != "" {
+		if result.status == depScanStatusScanned && result.dep.Dir != "" {
 			sets.graphPackages = append(sets.graphPackages, pkg)
 			continue
 		}

--- a/internal/engine/dependency_scanner_test.go
+++ b/internal/engine/dependency_scanner_test.go
@@ -153,24 +153,26 @@ func TestDependencyScanner_HelperFunctions(t *testing.T) {
 	}
 
 	sets := javaDS.collectPackageSets("/user/project", resolvedWorkspace, depResults)
-	// 2 workspace members + 1 dep with findings = 3 graphPackages; remaining Java deps stay type-only.
-	if len(sets.graphPackages) != 3 {
-		t.Fatalf("graphPackages len = %d, want 3 (2 workspace + 1 finding dep)", len(sets.graphPackages))
+	// 2 workspace members + 2 successfully scanned deps with source = 4 graphPackages.
+	// dep2 has no crypto findings, but it still needs full source parsing because
+	// it can be a bridge in A -> B(no crypto) -> C(crypto) reachability.
+	if len(sets.graphPackages) != 4 {
+		t.Fatalf("graphPackages len = %d, want 4 (2 workspace + 2 source deps)", len(sets.graphPackages))
 	}
-	if len(sets.typeOnlyPackages) != 3 {
-		t.Fatalf("typeOnlyPackages len = %d, want 3", len(sets.typeOnlyPackages))
+	if len(sets.typeOnlyPackages) != 2 {
+		t.Fatalf("typeOnlyPackages len = %d, want 2", len(sets.typeOnlyPackages))
 	}
-	if sets.graphPackages[2].Version != "v1" {
-		t.Fatalf("graphPackages[2].Version = %q, want v1", sets.graphPackages[2].Version)
+	if sets.graphPackages[2].Version != "v1" || sets.graphPackages[3].Version != "v2" {
+		t.Fatalf("unexpected graphPackages versions: %#v", sets.graphPackages)
 	}
-	if sets.typeOnlyPackages[0].Version != "v2" || sets.typeOnlyPackages[1].Version != "v3" || sets.typeOnlyPackages[2].Version != "v4" {
+	if sets.graphPackages[3].CompiledArtifactPath != "/artifacts/dep2.jar" {
+		t.Fatalf("expected compiled artifact path to propagate for source-parsed dep, got %#v", sets.graphPackages[3])
+	}
+	if sets.typeOnlyPackages[0].Version != "v3" || sets.typeOnlyPackages[1].Version != "v4" {
 		t.Fatalf("unexpected typeOnlyPackages versions: %#v", sets.typeOnlyPackages)
 	}
-	if sets.typeOnlyPackages[0].CompiledArtifactPath != "/artifacts/dep2.jar" {
-		t.Fatalf("expected compiled artifact path to propagate, got %#v", sets.typeOnlyPackages[0])
-	}
-	if sets.typeOnlyPackages[1].CompiledArtifactPath != "/artifacts/dep3.jar" {
-		t.Fatalf("expected compiled artifact path to propagate for source-less dep, got %#v", sets.typeOnlyPackages[1])
+	if sets.typeOnlyPackages[0].CompiledArtifactPath != "/artifacts/dep3.jar" {
+		t.Fatalf("expected compiled artifact path to propagate for source-less dep, got %#v", sets.typeOnlyPackages[0])
 	}
 
 	workspaceUsers := ds.buildUserPackages(resolvedWorkspace)

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -1,0 +1,298 @@
+package scan
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/pkg/graphfrag"
+)
+
+// The graph-fragment export schema (GraphFragmentExport and friends) lives in
+// the public package github.com/scanoss/crypto-finder/pkg/graphfrag: it is
+// crypto-finder's contract with downstream consumers (the mining service, CI
+// plugins). This file only BUILDS that schema from a callgraph.
+
+func ExportGraphFragment(path, format string, result *engine.DepScanResult) error {
+	if result == nil {
+		return fmt.Errorf("cannot export graph fragment: dep scan result is nil")
+	}
+	if result.CallGraph == nil {
+		return fmt.Errorf("cannot export graph fragment: result.CallGraph is nil")
+	}
+	if format != "json" {
+		return fmt.Errorf("unsupported graph fragment format %q (supported: json)", format)
+	}
+
+	payload := BuildGraphFragmentExport(result)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(payload); err != nil {
+		return fmt.Errorf("failed to serialize graph fragment export: %w", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("failed to write graph fragment to %s: %w", path, err)
+	}
+	return nil
+}
+
+func BuildGraphFragmentExport(result *engine.DepScanResult) graphfrag.GraphFragmentExport {
+	out := graphfrag.GraphFragmentExport{
+		SchemaVersion: graphfrag.SchemaVersion,
+		ScanMetadata: graphfrag.GraphFragmentScanMetadata{
+			Ecosystem:  result.Ecosystem,
+			RootModule: result.RootModule,
+			ExportedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+	if result.Report != nil {
+		out.ScanMetadata.ToolName = result.Report.Tool.Name
+		out.ScanMetadata.ToolVersion = result.Report.Tool.Version
+		out.ScanMetadata.RulesVersion = result.Report.Rules.Version
+	}
+	if result.CallGraph == nil {
+		return out
+	}
+
+	functionKeys := make([]string, 0, len(result.CallGraph.Functions))
+	for key := range result.CallGraph.Functions {
+		functionKeys = append(functionKeys, key)
+	}
+	sort.Strings(functionKeys)
+
+	for _, key := range functionKeys {
+		decl := result.CallGraph.Functions[key]
+		out.Functions = append(out.Functions, buildGraphFragmentFunction(result.CallGraph, decl.ID, decl))
+	}
+	out.InternalEdges, out.ExternalCalls = buildGraphFragmentResolvedEdges(result.CallGraph)
+
+	out.CryptoAnnotations = buildGraphFragmentCryptoAnnotations(result)
+	out.ScanMetadata.FunctionCount = len(out.Functions)
+	out.ScanMetadata.InternalEdges = len(out.InternalEdges)
+	out.ScanMetadata.ExternalCalls = len(out.ExternalCalls)
+	out.ScanMetadata.CryptoOps = len(out.CryptoAnnotations)
+	return out
+}
+
+func buildGraphFragmentResolvedEdges(graph *callgraph.CallGraph) ([]graphfrag.GraphFragmentEdge, []graphfrag.GraphFragmentExternal) {
+	if graph == nil {
+		return nil, nil
+	}
+
+	internalByKey := map[string]graphfrag.GraphFragmentEdge{}
+	externalByKey := map[string]graphfrag.GraphFragmentExternal{}
+	calleeKeys := make([]string, 0, len(graph.Callers))
+	for calleeKey := range graph.Callers {
+		calleeKeys = append(calleeKeys, calleeKey)
+	}
+	sort.Strings(calleeKeys)
+
+	for _, calleeKey := range calleeKeys {
+		callers := append([]string(nil), graph.Callers[calleeKey]...)
+		sort.Strings(callers)
+		for _, callerKey := range callers {
+			callerDecl := graph.Functions[callerKey]
+			if callerDecl == nil {
+				continue
+			}
+			line := findFragmentCallLine(callerDecl, calleeKey)
+			res := resolveFragmentEdge(graph, callerKey, calleeKey)
+			if _, ok := graph.Functions[calleeKey]; ok {
+				key := callerKey + "\x00" + calleeKey
+				internalByKey[key] = graphfrag.GraphFragmentEdge{
+					CallerKey:    callerKey,
+					CalleeKey:    calleeKey,
+					Line:         line,
+					Resolution:   res.Resolution,
+					DeclaredType: res.DeclaredType,
+					MethodName:   res.MethodName,
+					Arity:        res.Arity,
+				}
+				continue
+			}
+
+			external := graphfrag.GraphFragmentExternal{
+				CallerKey:    callerKey,
+				TargetKey:    calleeKey,
+				Line:         line,
+				Resolution:   res.Resolution,
+				DeclaredType: res.DeclaredType,
+				MethodName:   res.MethodName,
+				Arity:        res.Arity,
+			}
+			if calleeID, err := callgraph.ParseFunctionID(calleeKey); err == nil {
+				external.TargetFunctionName = fullFunctionName(calleeID)
+			}
+			if call := findCallForCallee(callerDecl, calleeKey); call != nil {
+				external.Raw = call.Raw
+				if external.TargetFunctionName == "" {
+					external.TargetFunctionName = fullFunctionName(call.Callee)
+				}
+			}
+			key := callerKey + "\x00" + calleeKey
+			externalByKey[key] = external
+		}
+	}
+
+	internalKeys := make([]string, 0, len(internalByKey))
+	for key := range internalByKey {
+		internalKeys = append(internalKeys, key)
+	}
+	sort.Strings(internalKeys)
+	internal := make([]graphfrag.GraphFragmentEdge, 0, len(internalKeys))
+	for _, key := range internalKeys {
+		internal = append(internal, internalByKey[key])
+	}
+
+	externalKeys := make([]string, 0, len(externalByKey))
+	for key := range externalByKey {
+		externalKeys = append(externalKeys, key)
+	}
+	sort.Strings(externalKeys)
+	external := make([]graphfrag.GraphFragmentExternal, 0, len(externalKeys))
+	for _, key := range externalKeys {
+		external = append(external, externalByKey[key])
+	}
+
+	return internal, external
+}
+
+type fragmentEdgeResolution struct {
+	Resolution   string
+	DeclaredType string
+	MethodName   string
+	Arity        int
+}
+
+// resolveFragmentEdge returns the resolution metadata for a caller->callee edge.
+// An edge with no recorded resolution is an exact, directly-resolved source
+// call (e.g. a typed re-resolution from the bytecode/type resolver), so it
+// defaults to exact rather than the fail-closed "unknown" — the producer is the
+// authority on resolution quality.
+func resolveFragmentEdge(graph *callgraph.CallGraph, callerKey, calleeKey string) fragmentEdgeResolution {
+	if graph != nil {
+		if res, ok := graph.EdgeResolutions[callgraph.EdgeResolutionKey(callerKey, calleeKey)]; ok {
+			return fragmentEdgeResolution{
+				Resolution:   string(res.Kind),
+				DeclaredType: res.DeclaredType,
+				MethodName:   res.MethodName,
+				Arity:        res.Arity,
+			}
+		}
+	}
+	return fragmentEdgeResolution{Resolution: string(callgraph.EdgeKindExact)}
+}
+
+func findFragmentCallLine(callerDecl *callgraph.FunctionDecl, calleeKey string) int {
+	if callerDecl == nil {
+		return 0
+	}
+	if call := findCallForCallee(callerDecl, calleeKey); call != nil {
+		return call.Line
+	}
+	return callerDecl.StartLine
+}
+
+func findCallForCallee(callerDecl *callgraph.FunctionDecl, calleeKey string) *callgraph.FunctionCall {
+	if callerDecl == nil {
+		return nil
+	}
+	calleeID, err := callgraph.ParseFunctionID(calleeKey)
+	for i := range callerDecl.Calls {
+		call := &callerDecl.Calls[i]
+		if call.Callee.String() == calleeKey {
+			return call
+		}
+		if err == nil &&
+			call.Callee.Package == calleeID.Package &&
+			call.Callee.Type == calleeID.Type &&
+			callgraph.BaseFunctionName(call.Callee.Name) == callgraph.BaseFunctionName(calleeID.Name) {
+			return call
+		}
+	}
+	return nil
+}
+
+func buildGraphFragmentFunction(graph *callgraph.CallGraph, id callgraph.FunctionID, decl *callgraph.FunctionDecl) graphfrag.GraphFragmentFunction {
+	meta := buildExportFunctionMetadata(graph, id, decl)
+	fn := graphfrag.GraphFragmentFunction{
+		Key:                id.String(),
+		FunctionName:       meta.FunctionName,
+		CanonicalSignature: meta.CanonicalSignature,
+		Package:            id.Package,
+		Type:               id.Type,
+		Name:               id.Name,
+		ReturnType:         meta.ReturnType,
+		ParameterTypes:     meta.ParameterTypes,
+		Visibility:         meta.Visibility,
+		OwnerVisibility:    meta.OwnerVisibility,
+	}
+	if decl != nil {
+		fn.FilePath = decl.FilePath
+		fn.StartLine = decl.StartLine
+		fn.EndLine = decl.EndLine
+	}
+	return fn
+}
+
+func buildGraphFragmentCryptoAnnotations(result *engine.DepScanResult) []graphfrag.GraphFragmentCryptoOp {
+	if result == nil || result.Report == nil || result.CallGraph == nil {
+		return nil
+	}
+	ctx := newExportBuildContext(result)
+	var out []graphfrag.GraphFragmentCryptoOp
+	for _, finding := range result.Report.Findings {
+		for i := range finding.CryptographicAssets {
+			asset := finding.CryptographicAssets[i]
+			out = append(out, buildGraphFragmentCryptoAnnotation(ctx, finding, asset))
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].FunctionKey != out[j].FunctionKey {
+			return out[i].FunctionKey < out[j].FunctionKey
+		}
+		if out[i].StartLine != out[j].StartLine {
+			return out[i].StartLine < out[j].StartLine
+		}
+		return out[i].FindingID < out[j].FindingID
+	})
+	return out
+}
+
+func buildGraphFragmentCryptoAnnotation(ctx *exportBuildContext, finding entities.Finding, asset entities.CryptographicAsset) graphfrag.GraphFragmentCryptoOp {
+	matched := buildMatchedOperation(asset)
+	op := graphfrag.GraphFragmentCryptoOp{
+		FindingID:  asset.FindingID,
+		Expression: asset.Match,
+		FilePath:   finding.FilePath,
+		StartLine:  asset.StartLine,
+		EndLine:    asset.EndLine,
+	}
+	if len(asset.Rules) > 0 {
+		op.RuleID = asset.Rules[0].ID
+	}
+	if matched != nil {
+		op.Symbol = matched.Symbol
+		if op.Expression == "" {
+			op.Expression = matched.Expression
+		}
+	}
+	containingFn := ctx.findContainingFunctionByFinding(finding.FilePath, asset.StartLine)
+	if containingFn != nil {
+		op.FunctionKey = containingFn.ID.String()
+		if matched != nil && matched.Kind == matchedOperationCall {
+			if cryptoCall := findCryptoCall(ctx, ctx.graph, containingFn, asset, asset.StartLine, asset.EndLine); cryptoCall != nil {
+				op.Symbol = cryptoCall.FunctionName
+			}
+		}
+	}
+	return op
+}

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph"
@@ -23,13 +24,13 @@ import (
 // graph-fragment export in the requested format.
 func ExportGraphFragment(path, format string, result *engine.DepScanResult) error {
 	if result == nil {
-		return fmt.Errorf("cannot export graph fragment: dep scan result is nil")
+		return fmt.Errorf("scan: cannot export graph fragment: dep scan result is nil")
 	}
 	if result.CallGraph == nil {
-		return fmt.Errorf("cannot export graph fragment: result.CallGraph is nil")
+		return fmt.Errorf("scan: cannot export graph fragment: result.CallGraph is nil")
 	}
 	if format != "json" {
-		return fmt.Errorf("unsupported graph fragment format %q (supported: json)", format)
+		return fmt.Errorf("scan: unsupported graph fragment format %q (supported: json)", format)
 	}
 
 	payload := BuildGraphFragmentExport(result)
@@ -38,10 +39,10 @@ func ExportGraphFragment(path, format string, result *engine.DepScanResult) erro
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(payload); err != nil {
-		return fmt.Errorf("failed to serialize graph fragment export: %w", err)
+		return fmt.Errorf("scan: failed to serialize graph fragment export: %w", err)
 	}
 	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("failed to write graph fragment to %s: %w", path, err)
+		return fmt.Errorf("scan: failed to write graph fragment to %s: %w", path, err)
 	}
 	return nil
 }
@@ -113,14 +114,17 @@ func addResolvedFragmentEdges(
 		if callerDecl == nil {
 			continue
 		}
-		edgeKey := callerKey + "\x00" + calleeKey
-		line := findFragmentCallLine(callerDecl, calleeKey)
-		res := resolveFragmentEdge(graph, callerKey, calleeKey)
-		if _, ok := graph.Functions[calleeKey]; ok {
-			internalByKey[edgeKey] = buildFragmentInternalEdge(callerKey, calleeKey, line, res)
-			continue
+		resolutions := resolveFragmentEdges(graph, callerKey, calleeKey)
+		for i := range resolutions {
+			res := resolutions[i]
+			edgeKey := callgraph.EdgeResolutionKey(callerKey, calleeKey, res.EdgeResolution)
+			line := fragmentEdgeLine(callerDecl, calleeKey, res)
+			if _, ok := graph.Functions[calleeKey]; ok {
+				internalByKey[edgeKey] = buildFragmentInternalEdge(callerKey, calleeKey, line, res)
+				continue
+			}
+			externalByKey[edgeKey] = buildFragmentExternalCall(callerDecl, callerKey, calleeKey, line, res)
 		}
-		externalByKey[edgeKey] = buildFragmentExternalCall(callerDecl, callerKey, calleeKey, line, res)
 	}
 }
 
@@ -202,29 +206,48 @@ func sortedFragmentExternalCalls(values map[string]graphfrag.GraphFragmentExtern
 }
 
 type fragmentEdgeResolution struct {
-	Resolution   string
-	DeclaredType string
-	MethodName   string
-	Arity        int
+	callgraph.EdgeResolution
+	Resolution string
 }
 
-// resolveFragmentEdge returns the resolution metadata for a caller->callee edge.
+// resolveFragmentEdges returns the resolution metadata for a caller->callee edge.
 // An edge with no recorded resolution is an exact, directly-resolved source
 // call (e.g. a typed re-resolution from the bytecode/type resolver), so it
 // defaults to exact rather than the fail-closed "unknown" — the producer is the
 // authority on resolution quality.
-func resolveFragmentEdge(graph *callgraph.CallGraph, callerKey, calleeKey string) fragmentEdgeResolution {
+func resolveFragmentEdges(graph *callgraph.CallGraph, callerKey, calleeKey string) []fragmentEdgeResolution {
 	if graph != nil {
-		if res, ok := graph.EdgeResolutions[callgraph.EdgeResolutionKey(callerKey, calleeKey)]; ok {
-			return fragmentEdgeResolution{
-				Resolution:   string(res.Kind),
-				DeclaredType: res.DeclaredType,
-				MethodName:   res.MethodName,
-				Arity:        res.Arity,
+		prefix := callgraph.EdgeResolutionKeyPrefix(callerKey, calleeKey)
+		keys := make([]string, 0)
+		for key := range graph.EdgeResolutions {
+			if strings.HasPrefix(key, prefix) {
+				keys = append(keys, key)
 			}
 		}
+		sort.Strings(keys)
+		if len(keys) > 0 {
+			out := make([]fragmentEdgeResolution, 0, len(keys))
+			for _, key := range keys {
+				out = append(out, newFragmentEdgeResolution(graph.EdgeResolutions[key]))
+			}
+			return out
+		}
 	}
-	return fragmentEdgeResolution{Resolution: string(callgraph.EdgeKindExact)}
+	return []fragmentEdgeResolution{newFragmentEdgeResolution(callgraph.EdgeResolution{Kind: callgraph.EdgeKindExact})}
+}
+
+func newFragmentEdgeResolution(res callgraph.EdgeResolution) fragmentEdgeResolution {
+	return fragmentEdgeResolution{
+		EdgeResolution: res,
+		Resolution:     string(res.Kind),
+	}
+}
+
+func fragmentEdgeLine(callerDecl *callgraph.FunctionDecl, calleeKey string, res fragmentEdgeResolution) int {
+	if res.CallSite != 0 {
+		return res.CallSite
+	}
+	return findFragmentCallLine(callerDecl, calleeKey)
 }
 
 func findFragmentCallLine(callerDecl *callgraph.FunctionDecl, calleeKey string) int {

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -19,6 +19,8 @@ import (
 // crypto-finder's contract with downstream consumers (the mining service, CI
 // plugins). This file only BUILDS that schema from a callgraph.
 
+// ExportGraphFragment writes the dependency scan result's call graph as a
+// graph-fragment export in the requested format.
 func ExportGraphFragment(path, format string, result *engine.DepScanResult) error {
 	if result == nil {
 		return fmt.Errorf("cannot export graph fragment: dep scan result is nil")
@@ -44,6 +46,8 @@ func ExportGraphFragment(path, format string, result *engine.DepScanResult) erro
 	return nil
 }
 
+// BuildGraphFragmentExport projects a dependency scan result onto the public
+// graph-fragment export schema.
 func BuildGraphFragmentExport(result *engine.DepScanResult) graphfrag.GraphFragmentExport {
 	out := graphfrag.GraphFragmentExport{
 		SchemaVersion: graphfrag.SchemaVersion,
@@ -89,80 +93,112 @@ func buildGraphFragmentResolvedEdges(graph *callgraph.CallGraph) ([]graphfrag.Gr
 
 	internalByKey := map[string]graphfrag.GraphFragmentEdge{}
 	externalByKey := map[string]graphfrag.GraphFragmentExternal{}
-	calleeKeys := make([]string, 0, len(graph.Callers))
-	for calleeKey := range graph.Callers {
-		calleeKeys = append(calleeKeys, calleeKey)
+	for _, calleeKey := range sortedKeys(graph.Callers) {
+		addResolvedFragmentEdges(graph, calleeKey, internalByKey, externalByKey)
 	}
-	sort.Strings(calleeKeys)
 
-	for _, calleeKey := range calleeKeys {
-		callers := append([]string(nil), graph.Callers[calleeKey]...)
-		sort.Strings(callers)
-		for _, callerKey := range callers {
-			callerDecl := graph.Functions[callerKey]
-			if callerDecl == nil {
-				continue
-			}
-			line := findFragmentCallLine(callerDecl, calleeKey)
-			res := resolveFragmentEdge(graph, callerKey, calleeKey)
-			if _, ok := graph.Functions[calleeKey]; ok {
-				key := callerKey + "\x00" + calleeKey
-				internalByKey[key] = graphfrag.GraphFragmentEdge{
-					CallerKey:    callerKey,
-					CalleeKey:    calleeKey,
-					Line:         line,
-					Resolution:   res.Resolution,
-					DeclaredType: res.DeclaredType,
-					MethodName:   res.MethodName,
-					Arity:        res.Arity,
-				}
-				continue
-			}
+	return sortedFragmentEdges(internalByKey), sortedFragmentExternalCalls(externalByKey)
+}
 
-			external := graphfrag.GraphFragmentExternal{
-				CallerKey:    callerKey,
-				TargetKey:    calleeKey,
-				Line:         line,
-				Resolution:   res.Resolution,
-				DeclaredType: res.DeclaredType,
-				MethodName:   res.MethodName,
-				Arity:        res.Arity,
-			}
-			if calleeID, err := callgraph.ParseFunctionID(calleeKey); err == nil {
-				external.TargetFunctionName = fullFunctionName(calleeID)
-			}
-			if call := findCallForCallee(callerDecl, calleeKey); call != nil {
-				external.Raw = call.Raw
-				if external.TargetFunctionName == "" {
-					external.TargetFunctionName = fullFunctionName(call.Callee)
-				}
-			}
-			key := callerKey + "\x00" + calleeKey
-			externalByKey[key] = external
+func addResolvedFragmentEdges(
+	graph *callgraph.CallGraph,
+	calleeKey string,
+	internalByKey map[string]graphfrag.GraphFragmentEdge,
+	externalByKey map[string]graphfrag.GraphFragmentExternal,
+) {
+	callers := append([]string(nil), graph.Callers[calleeKey]...)
+	sort.Strings(callers)
+	for _, callerKey := range callers {
+		callerDecl := graph.Functions[callerKey]
+		if callerDecl == nil {
+			continue
+		}
+		edgeKey := callerKey + "\x00" + calleeKey
+		line := findFragmentCallLine(callerDecl, calleeKey)
+		res := resolveFragmentEdge(graph, callerKey, calleeKey)
+		if _, ok := graph.Functions[calleeKey]; ok {
+			internalByKey[edgeKey] = buildFragmentInternalEdge(callerKey, calleeKey, line, res)
+			continue
+		}
+		externalByKey[edgeKey] = buildFragmentExternalCall(callerDecl, callerKey, calleeKey, line, res)
+	}
+}
+
+func buildFragmentInternalEdge(callerKey, calleeKey string, line int, res fragmentEdgeResolution) graphfrag.GraphFragmentEdge {
+	return graphfrag.GraphFragmentEdge{
+		CallerKey:    callerKey,
+		CalleeKey:    calleeKey,
+		Line:         line,
+		Resolution:   res.Resolution,
+		DeclaredType: res.DeclaredType,
+		MethodName:   res.MethodName,
+		Arity:        res.Arity,
+	}
+}
+
+func buildFragmentExternalCall(
+	callerDecl *callgraph.FunctionDecl,
+	callerKey string,
+	calleeKey string,
+	line int,
+	res fragmentEdgeResolution,
+) graphfrag.GraphFragmentExternal {
+	external := graphfrag.GraphFragmentExternal{
+		CallerKey:    callerKey,
+		TargetKey:    calleeKey,
+		Line:         line,
+		Resolution:   res.Resolution,
+		DeclaredType: res.DeclaredType,
+		MethodName:   res.MethodName,
+		Arity:        res.Arity,
+	}
+	external.TargetFunctionName = fragmentTargetFunctionName(callerDecl, calleeKey, &external)
+	return external
+}
+
+func fragmentTargetFunctionName(
+	callerDecl *callgraph.FunctionDecl,
+	calleeKey string,
+	external *graphfrag.GraphFragmentExternal,
+) string {
+	targetName := ""
+	if calleeID, err := callgraph.ParseFunctionID(calleeKey); err == nil {
+		targetName = fullFunctionName(calleeID)
+	}
+	if call := findCallForCallee(callerDecl, calleeKey); call != nil {
+		external.Raw = call.Raw
+		if targetName == "" {
+			targetName = fullFunctionName(call.Callee)
 		}
 	}
+	return targetName
+}
 
-	internalKeys := make([]string, 0, len(internalByKey))
-	for key := range internalByKey {
-		internalKeys = append(internalKeys, key)
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
 	}
-	sort.Strings(internalKeys)
-	internal := make([]graphfrag.GraphFragmentEdge, 0, len(internalKeys))
-	for _, key := range internalKeys {
-		internal = append(internal, internalByKey[key])
-	}
+	sort.Strings(keys)
+	return keys
+}
 
-	externalKeys := make([]string, 0, len(externalByKey))
-	for key := range externalByKey {
-		externalKeys = append(externalKeys, key)
+func sortedFragmentEdges(values map[string]graphfrag.GraphFragmentEdge) []graphfrag.GraphFragmentEdge {
+	keys := sortedKeys(values)
+	out := make([]graphfrag.GraphFragmentEdge, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, values[key])
 	}
-	sort.Strings(externalKeys)
-	external := make([]graphfrag.GraphFragmentExternal, 0, len(externalKeys))
-	for _, key := range externalKeys {
-		external = append(external, externalByKey[key])
-	}
+	return out
+}
 
-	return internal, external
+func sortedFragmentExternalCalls(values map[string]graphfrag.GraphFragmentExternal) []graphfrag.GraphFragmentExternal {
+	keys := sortedKeys(values)
+	out := make([]graphfrag.GraphFragmentExternal, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, values[key])
+	}
+	return out
 }
 
 type fragmentEdgeResolution struct {

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -305,7 +305,8 @@ func findExternalCall(payload graphfrag.GraphFragmentExport, caller, target stri
 }
 
 func hasFragmentFunction(payload graphfrag.GraphFragmentExport, key string) bool {
-	for _, fn := range payload.Functions {
+	for i := range payload.Functions {
+		fn := &payload.Functions[i]
 		if fn.Key == key {
 			return true
 		}
@@ -314,7 +315,8 @@ func hasFragmentFunction(payload graphfrag.GraphFragmentExport, key string) bool
 }
 
 func hasExternalTarget(payload graphfrag.GraphFragmentExport, target string) bool {
-	for _, call := range payload.ExternalCalls {
+	for i := range payload.ExternalCalls {
+		call := &payload.ExternalCalls[i]
 		if call.TargetKey == target {
 			return true
 		}

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -254,18 +254,14 @@ func TestBuildGraphFragmentExport_CarriesEdgeResolution(t *testing.T) {
 			implID.String():  {controllerID.String()}, // internal, interface_dispatch
 			extID.String():   {controllerID.String()}, // external (no decl), name_only
 		},
-		EdgeResolutions: map[string]callgraph.EdgeResolution{
-			callgraph.EdgeResolutionKey(controllerID.String(), ifaceID.String()): {
-				Kind: callgraph.EdgeKindExact, MethodName: "run", Arity: 0, CallSite: 3,
-			},
-			callgraph.EdgeResolutionKey(controllerID.String(), implID.String()): {
-				Kind: callgraph.EdgeKindInterfaceDispatch, DeclaredType: "com.dep.Sink", MethodName: "run", Arity: 0, CallSite: 3,
-			},
-			callgraph.EdgeResolutionKey(controllerID.String(), extID.String()): {
-				Kind: callgraph.EdgeKindNameOnly, MethodName: "chain", Arity: 0, CallSite: 3,
-			},
-		},
+		EdgeResolutions: map[string]callgraph.EdgeResolution{},
 	}
+	exactRes := callgraph.EdgeResolution{Kind: callgraph.EdgeKindExact, MethodName: "run", Arity: 0, CallSite: 3}
+	ifaceRes := callgraph.EdgeResolution{Kind: callgraph.EdgeKindInterfaceDispatch, DeclaredType: "com.dep.Sink", MethodName: "run", Arity: 0, CallSite: 11}
+	extRes := callgraph.EdgeResolution{Kind: callgraph.EdgeKindNameOnly, MethodName: "chain", Arity: 0, CallSite: 12}
+	graph.EdgeResolutions[callgraph.EdgeResolutionKey(controllerID.String(), ifaceID.String(), exactRes)] = exactRes
+	graph.EdgeResolutions[callgraph.EdgeResolutionKey(controllerID.String(), implID.String(), ifaceRes)] = ifaceRes
+	graph.EdgeResolutions[callgraph.EdgeResolutionKey(controllerID.String(), extID.String(), extRes)] = extRes
 
 	payload := BuildGraphFragmentExport(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
 
@@ -280,9 +276,15 @@ func TestBuildGraphFragmentExport_CarriesEdgeResolution(t *testing.T) {
 	if iface.DeclaredType != "com.dep.Sink" || iface.MethodName != "run" || iface.Arity != 0 {
 		t.Fatalf("internal interface edge metadata = %#v, want declared com.dep.Sink/run/0", iface)
 	}
+	if iface.Line != 11 {
+		t.Fatalf("internal interface edge line = %d, want recorded call site 11", iface.Line)
+	}
 	ext := findExternalCall(payload, controllerID.String(), extID.String())
 	if ext == nil || ext.Resolution != string(callgraph.EdgeKindNameOnly) {
 		t.Fatalf("external name-only call resolution = %#v, want name_only", ext)
+	}
+	if ext.Line != 12 {
+		t.Fatalf("external name-only call line = %d, want recorded call site 12", ext.Line)
 	}
 }
 

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -1,0 +1,332 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/pkg/graphfrag"
+)
+
+func TestBuildGraphFragmentExport_SeparatesInternalAndExternalCalls(t *testing.T) {
+	t.Parallel()
+
+	bridgeID := callgraph.FunctionID{Package: "org.bridge", Type: "Bridge", Name: "bridge#0"}
+	helperID := callgraph.FunctionID{Package: "org.bridge", Type: "Bridge", Name: "helper#0"}
+	cryptoID := callgraph.FunctionID{Package: "net.crypto", Type: "CryptoSink", Name: "encrypt#0"}
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			bridgeID.String(): {
+				ID:         bridgeID,
+				FilePath:   "Bridge.java",
+				StartLine:  4,
+				EndLine:    8,
+				ReturnType: "void",
+				Calls: []callgraph.FunctionCall{
+					{Callee: helperID, FilePath: "Bridge.java", Line: 5, Raw: "helper()"},
+					{Callee: cryptoID, FilePath: "Bridge.java", Line: 6, Raw: "sink.encrypt()"},
+				},
+			},
+			helperID.String(): {
+				ID:         helperID,
+				FilePath:   "Bridge.java",
+				StartLine:  10,
+				EndLine:    10,
+				ReturnType: "void",
+			},
+		},
+		Callers: map[string][]string{
+			helperID.String(): {bridgeID.String()},
+			cryptoID.String(): {bridgeID.String()},
+		},
+	}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{
+		CallGraph:  graph,
+		RootModule: "org.bridge:b-bridge",
+		Ecosystem:  "java",
+	})
+
+	if payload.SchemaVersion != graphfrag.SchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", payload.SchemaVersion, graphfrag.SchemaVersion)
+	}
+	if got, want := len(payload.Functions), 2; got != want {
+		t.Fatalf("functions len = %d, want %d", got, want)
+	}
+	if got, want := len(payload.InternalEdges), 1; got != want {
+		t.Fatalf("internal edges len = %d, want %d", got, want)
+	}
+	if payload.InternalEdges[0].CallerKey != bridgeID.String() || payload.InternalEdges[0].CalleeKey != helperID.String() {
+		t.Fatalf("unexpected internal edge: %#v", payload.InternalEdges[0])
+	}
+	if got, want := len(payload.ExternalCalls), 1; got != want {
+		t.Fatalf("external calls len = %d, want %d", got, want)
+	}
+	if payload.ExternalCalls[0].CallerKey != bridgeID.String() || payload.ExternalCalls[0].TargetKey != cryptoID.String() {
+		t.Fatalf("unexpected external call: %#v", payload.ExternalCalls[0])
+	}
+}
+
+func TestBuildGraphFragmentExport_FromJavaSourceZeroFindingBridge(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := `package org.bridge;
+
+import net.crypto.CryptoSink;
+
+class Bridge {
+    void bridge() {
+        CryptoSink sink = new CryptoSink();
+        sink.encrypt();
+    }
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "Bridge.java"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	builder := callgraph.NewBuilder(callgraph.NewJavaParser())
+	graph, err := builder.BuildFromDirectories([]callgraph.PackageDir{{Dir: dir, ImportPath: "org.bridge:b-bridge"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{
+		CallGraph:   graph,
+		ProjectRoot: dir,
+		RootModule:  "org.bridge:b-bridge",
+		Ecosystem:   "java",
+	})
+
+	bridgeKey := callgraph.FunctionID{Package: "org.bridge", Type: "Bridge", Name: "bridge#0"}.String()
+	if !hasFragmentFunction(payload, bridgeKey) {
+		t.Fatalf("expected function %q in exported fragment: %#v", bridgeKey, payload.Functions)
+	}
+	if !hasExternalTarget(payload, "net.crypto.(CryptoSink).encrypt#0") {
+		t.Fatalf("expected external call to CryptoSink.encrypt in exported fragment: %#v", payload.ExternalCalls)
+	}
+	if got := len(payload.CryptoAnnotations); got != 0 {
+		t.Fatalf("crypto annotations len = %d, want 0 for zero-finding bridge", got)
+	}
+}
+
+func TestBuildGraphFragmentExport_AttachesCryptoAnnotationToContainingFunction(t *testing.T) {
+	t.Parallel()
+
+	cryptoID := callgraph.FunctionID{Package: "net.crypto", Type: "CryptoSink", Name: "encrypt#0"}
+	cipherID := callgraph.FunctionID{Package: "javax.crypto", Type: "Cipher", Name: "getInstance#1"}
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			cryptoID.String(): {
+				ID:         cryptoID,
+				FilePath:   "CryptoSink.java",
+				StartLine:  4,
+				EndLine:    8,
+				ReturnType: "void",
+				Calls: []callgraph.FunctionCall{{
+					Callee:    cipherID,
+					FilePath:  "CryptoSink.java",
+					Line:      6,
+					Raw:       "Cipher.getInstance(\"AES\")",
+					Arguments: []string{"\"AES\""},
+				}},
+			},
+		},
+		Callers: map[string][]string{
+			cipherID.String(): {cryptoID.String()},
+		},
+	}
+	report := &entities.InterimReport{
+		Tool:  entities.ToolInfo{Name: "crypto-finder", Version: "dev"},
+		Rules: entities.RulesInfo{Version: "v-test-rules"},
+		Findings: []entities.Finding{{
+			FilePath: "CryptoSink.java",
+			Language: "java",
+			CryptographicAssets: []entities.CryptographicAsset{{
+				StartLine: 6,
+				EndLine:   6,
+				Match:     "Cipher.getInstance(\"AES\")",
+				FindingID: "beaecdb7",
+				Rules:     []entities.RuleInfo{{ID: "java.crypto.cipher.getinstance"}},
+				Metadata:  map[string]string{"api": "javax.crypto.Cipher.getInstance"},
+			}},
+		}},
+	}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{
+		Report:      report,
+		CallGraph:   graph,
+		ProjectRoot: t.TempDir(),
+		RootModule:  "net.crypto:c-crypto",
+		Ecosystem:   "java",
+	})
+
+	if got, want := len(payload.CryptoAnnotations), 1; got != want {
+		t.Fatalf("crypto annotations len = %d, want %d", got, want)
+	}
+	op := payload.CryptoAnnotations[0]
+	if op.FunctionKey != cryptoID.String() {
+		t.Fatalf("FunctionKey = %q, want %q", op.FunctionKey, cryptoID.String())
+	}
+	if op.FindingID != "beaecdb7" || op.RuleID != "java.crypto.cipher.getinstance" {
+		t.Fatalf("unexpected crypto annotation: %#v", op)
+	}
+	if op.Symbol != "javax.crypto.Cipher.getInstance" {
+		t.Fatalf("Symbol = %q, want javax.crypto.Cipher.getInstance", op.Symbol)
+	}
+}
+
+func TestBuildGraphFragmentExport_UsesResolvedCallerIndexEdges(t *testing.T) {
+	t.Parallel()
+
+	controllerID := callgraph.FunctionID{Package: "com.app", Type: "Controller", Name: "handle#0"}
+	apiID := callgraph.FunctionID{Package: "com.dep", Type: "CryptoApi", Name: "encrypt#0"}
+	implID := callgraph.FunctionID{Package: "com.dep.impl", Type: "CryptoImpl", Name: "encrypt#0"}
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			controllerID.String(): {
+				ID:        controllerID,
+				FilePath:  "Controller.java",
+				StartLine: 1,
+				EndLine:   5,
+				Calls: []callgraph.FunctionCall{{
+					Callee: apiID,
+					Line:   3,
+					Raw:    "api.encrypt()",
+				}},
+			},
+			apiID.String(): {
+				ID:        apiID,
+				FilePath:  "CryptoApi.java",
+				StartLine: 1,
+				EndLine:   3,
+			},
+			implID.String(): {
+				ID:        implID,
+				FilePath:  "CryptoImpl.java",
+				StartLine: 1,
+				EndLine:   3,
+			},
+		},
+		Callers: map[string][]string{
+			apiID.String():  {controllerID.String()},
+			implID.String(): {controllerID.String()},
+		},
+	}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
+
+	if !hasInternalEdge(payload, controllerID.String(), apiID.String()) {
+		t.Fatalf("expected direct caller-index edge to API method: %#v", payload.InternalEdges)
+	}
+	if !hasInternalEdge(payload, controllerID.String(), implID.String()) {
+		t.Fatalf("expected resolved caller-index edge to implementation method: %#v", payload.InternalEdges)
+	}
+}
+
+func TestBuildGraphFragmentExport_CarriesEdgeResolution(t *testing.T) {
+	t.Parallel()
+
+	controllerID := callgraph.FunctionID{Package: "app", Type: "Controller", Name: "handle#0"}
+	ifaceID := callgraph.FunctionID{Package: "com.dep", Type: "Sink", Name: "run#0"}
+	implID := callgraph.FunctionID{Package: "com.dep.impl", Type: "SinkImpl", Name: "run#0"}
+	extID := callgraph.FunctionID{Package: "com.dep", Type: "Fluent", Name: "chain#0"}
+
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			controllerID.String(): {
+				ID:        controllerID,
+				FilePath:  "Controller.java",
+				StartLine: 1,
+				EndLine:   5,
+				Calls: []callgraph.FunctionCall{
+					{Callee: ifaceID, FilePath: "Controller.java", Line: 3, Raw: "sink.run()"},
+				},
+			},
+			ifaceID.String(): {ID: ifaceID, FilePath: "Sink.java", StartLine: 1, EndLine: 2},
+			implID.String():  {ID: implID, FilePath: "SinkImpl.java", StartLine: 1, EndLine: 4},
+		},
+		Callers: map[string][]string{
+			ifaceID.String(): {controllerID.String()}, // internal, exact
+			implID.String():  {controllerID.String()}, // internal, interface_dispatch
+			extID.String():   {controllerID.String()}, // external (no decl), name_only
+		},
+		EdgeResolutions: map[string]callgraph.EdgeResolution{
+			callgraph.EdgeResolutionKey(controllerID.String(), ifaceID.String()): {
+				Kind: callgraph.EdgeKindExact, MethodName: "run", Arity: 0, CallSite: 3,
+			},
+			callgraph.EdgeResolutionKey(controllerID.String(), implID.String()): {
+				Kind: callgraph.EdgeKindInterfaceDispatch, DeclaredType: "com.dep.Sink", MethodName: "run", Arity: 0, CallSite: 3,
+			},
+			callgraph.EdgeResolutionKey(controllerID.String(), extID.String()): {
+				Kind: callgraph.EdgeKindNameOnly, MethodName: "chain", Arity: 0, CallSite: 3,
+			},
+		},
+	}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
+
+	exact := findInternalEdge(payload, controllerID.String(), ifaceID.String())
+	if exact == nil || exact.Resolution != string(callgraph.EdgeKindExact) {
+		t.Fatalf("internal exact edge resolution = %#v, want exact", exact)
+	}
+	iface := findInternalEdge(payload, controllerID.String(), implID.String())
+	if iface == nil || iface.Resolution != string(callgraph.EdgeKindInterfaceDispatch) {
+		t.Fatalf("internal interface edge = %#v, want interface_dispatch", iface)
+	}
+	if iface.DeclaredType != "com.dep.Sink" || iface.MethodName != "run" || iface.Arity != 0 {
+		t.Fatalf("internal interface edge metadata = %#v, want declared com.dep.Sink/run/0", iface)
+	}
+	ext := findExternalCall(payload, controllerID.String(), extID.String())
+	if ext == nil || ext.Resolution != string(callgraph.EdgeKindNameOnly) {
+		t.Fatalf("external name-only call resolution = %#v, want name_only", ext)
+	}
+}
+
+func findInternalEdge(payload graphfrag.GraphFragmentExport, caller, callee string) *graphfrag.GraphFragmentEdge {
+	for i := range payload.InternalEdges {
+		if payload.InternalEdges[i].CallerKey == caller && payload.InternalEdges[i].CalleeKey == callee {
+			return &payload.InternalEdges[i]
+		}
+	}
+	return nil
+}
+
+func findExternalCall(payload graphfrag.GraphFragmentExport, caller, target string) *graphfrag.GraphFragmentExternal {
+	for i := range payload.ExternalCalls {
+		if payload.ExternalCalls[i].CallerKey == caller && payload.ExternalCalls[i].TargetKey == target {
+			return &payload.ExternalCalls[i]
+		}
+	}
+	return nil
+}
+
+func hasFragmentFunction(payload graphfrag.GraphFragmentExport, key string) bool {
+	for _, fn := range payload.Functions {
+		if fn.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExternalTarget(payload graphfrag.GraphFragmentExport, target string) bool {
+	for _, call := range payload.ExternalCalls {
+		if call.TargetKey == target {
+			return true
+		}
+	}
+	return false
+}
+
+func hasInternalEdge(payload graphfrag.GraphFragmentExport, caller, callee string) bool {
+	for _, edge := range payload.InternalEdges {
+		if edge.CallerKey == caller && edge.CalleeKey == callee {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -1,0 +1,94 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "encoding/json"
+
+// SchemaVersion is the current graph-fragment export schema version.
+//
+// 1.1 added per-edge resolution metadata (resolution / declared_type /
+// method_name / arity) on internal_edges and external_calls. The fields are
+// additive: a 1.0 fragment decodes with an empty resolution, which the stitcher
+// treats as untrusted (fail-closed).
+const SchemaVersion = "graph-fragment-1.1"
+
+// GraphFragmentExport is the on-the-wire JSON shape emitted by
+// `crypto-finder scan --export-graph-fragment` for a single component. It is
+// crypto-finder's public contract; the scanner (internal/scan) builds it from a
+// callgraph, and any consumer decodes it into a Fragment via DecodeFragment.
+type GraphFragmentExport struct {
+	SchemaVersion     string                    `json:"schema_version"`
+	ScanMetadata      GraphFragmentScanMetadata `json:"scan_metadata"`
+	Functions         []GraphFragmentFunction   `json:"functions"`
+	InternalEdges     []GraphFragmentEdge       `json:"internal_edges,omitempty"`
+	ExternalCalls     []GraphFragmentExternal   `json:"external_calls,omitempty"`
+	CryptoAnnotations []GraphFragmentCryptoOp   `json:"crypto_annotations,omitempty"`
+}
+
+type GraphFragmentScanMetadata struct {
+	Ecosystem     string `json:"ecosystem,omitempty"`
+	RootModule    string `json:"root_module,omitempty"`
+	ToolName      string `json:"tool_name,omitempty"`
+	ToolVersion   string `json:"tool_version,omitempty"`
+	RulesVersion  string `json:"rules_version,omitempty"`
+	ExportedAt    string `json:"exported_at"`
+	FunctionCount int    `json:"function_count"`
+	InternalEdges int    `json:"internal_edge_count"`
+	ExternalCalls int    `json:"external_call_count"`
+	CryptoOps     int    `json:"crypto_operation_count"`
+}
+
+type GraphFragmentFunction struct {
+	Key                string          `json:"key"`
+	FunctionName       string          `json:"function_name"`
+	CanonicalSignature string          `json:"canonical_signature,omitempty"`
+	Package            string          `json:"package,omitempty"`
+	Type               string          `json:"type,omitempty"`
+	Name               string          `json:"name,omitempty"`
+	FilePath           string          `json:"file_path,omitempty"`
+	StartLine          int             `json:"start_line,omitempty"`
+	EndLine            int             `json:"end_line,omitempty"`
+	ReturnType         string          `json:"return_type,omitempty"`
+	ParameterTypes     []string        `json:"parameter_types,omitempty"`
+	Visibility         string          `json:"visibility,omitempty"`
+	OwnerVisibility    string          `json:"owner_visibility,omitempty"`
+	InferredReturn     json.RawMessage `json:"-"`
+}
+
+// GraphFragmentEdge is one internal (intra-component) call edge plus the
+// resolution metadata that lets a consumer decide whether to traverse it.
+type GraphFragmentEdge struct {
+	CallerKey    string `json:"caller_key"`
+	CalleeKey    string `json:"callee_key"`
+	Line         int    `json:"line,omitempty"`
+	Resolution   string `json:"resolution"`
+	DeclaredType string `json:"declared_type,omitempty"`
+	MethodName   string `json:"method_name,omitempty"`
+	Arity        int    `json:"arity,omitempty"`
+}
+
+// GraphFragmentExternal is one external (cross-component) call edge plus its
+// resolution metadata.
+type GraphFragmentExternal struct {
+	CallerKey          string `json:"caller_key"`
+	TargetKey          string `json:"target_key"`
+	TargetFunctionName string `json:"target_function_name,omitempty"`
+	Raw                string `json:"raw,omitempty"`
+	Line               int    `json:"line,omitempty"`
+	Resolution         string `json:"resolution"`
+	DeclaredType       string `json:"declared_type,omitempty"`
+	MethodName         string `json:"method_name,omitempty"`
+	Arity              int    `json:"arity,omitempty"`
+}
+
+type GraphFragmentCryptoOp struct {
+	FunctionKey string `json:"function_key,omitempty"`
+	FindingID   string `json:"finding_id,omitempty"`
+	RuleID      string `json:"rule_id,omitempty"`
+	Symbol      string `json:"symbol,omitempty"`
+	Expression  string `json:"expression,omitempty"`
+	FilePath    string `json:"file_path,omitempty"`
+	StartLine   int    `json:"start_line,omitempty"`
+	EndLine     int    `json:"end_line,omitempty"`
+}

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -26,6 +26,8 @@ type GraphFragmentExport struct {
 	CryptoAnnotations []GraphFragmentCryptoOp   `json:"crypto_annotations,omitempty"`
 }
 
+// GraphFragmentScanMetadata summarizes the scan that produced a graph-fragment
+// export and the payload counts emitted for that component.
 type GraphFragmentScanMetadata struct {
 	Ecosystem     string `json:"ecosystem,omitempty"`
 	RootModule    string `json:"root_module,omitempty"`
@@ -39,6 +41,8 @@ type GraphFragmentScanMetadata struct {
 	CryptoOps     int    `json:"crypto_operation_count"`
 }
 
+// GraphFragmentFunction is one function declaration included in a component's
+// graph-fragment export.
 type GraphFragmentFunction struct {
 	Key                string          `json:"key"`
 	FunctionName       string          `json:"function_name"`
@@ -82,6 +86,8 @@ type GraphFragmentExternal struct {
 	Arity              int    `json:"arity,omitempty"`
 }
 
+// GraphFragmentCryptoOp is one crypto finding annotation attached to a function
+// in the exported graph fragment.
 type GraphFragmentCryptoOp struct {
 	FunctionKey string `json:"function_key,omitempty"`
 	FindingID   string `json:"finding_id,omitempty"`

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -23,7 +23,7 @@ func (e GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 		frag.InternalEdges = append(frag.InternalEdges, InternalEdge{
 			Caller:       ie.CallerKey,
 			Callee:       ie.CalleeKey,
-			Resolution:   ResolutionKind(ie.Resolution),
+			Resolution:   normalizeResolutionKind(ie.Resolution),
 			DeclaredType: ie.DeclaredType,
 			MethodName:   ie.MethodName,
 			Arity:        ie.Arity,
@@ -35,7 +35,7 @@ func (e GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 		frag.ExternalCalls = append(frag.ExternalCalls, ExternalCall{
 			Caller:          ec.CallerKey,
 			TargetSignature: ec.TargetKey,
-			Resolution:      ResolutionKind(ec.Resolution),
+			Resolution:      normalizeResolutionKind(ec.Resolution),
 			DeclaredType:    ec.DeclaredType,
 			MethodName:      ec.MethodName,
 			Arity:           ec.Arity,
@@ -51,6 +51,15 @@ func (e GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 		})
 	}
 	return frag
+}
+
+func normalizeResolutionKind(value string) ResolutionKind {
+	switch kind := ResolutionKind(value); kind {
+	case ResolutionExact, ResolutionInterfaceDispatch, ResolutionNameOnly, ResolutionUnknown:
+		return kind
+	default:
+		return ResolutionUnknown
+	}
 }
 
 // DecodeFragment parses one graph-fragment export (JSON) into a Fragment for the

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -15,7 +15,8 @@ import (
 func (e GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 	frag := Fragment{Component: component, Module: e.ScanMetadata.RootModule}
 
-	for _, fn := range e.Functions {
+	for i := range e.Functions {
+		fn := &e.Functions[i]
 		frag.Functions = append(frag.Functions, Function{Signature: fn.Key, FilePath: fn.FilePath})
 	}
 	for _, ie := range e.InternalEdges {
@@ -29,7 +30,8 @@ func (e GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			CallSite:     ie.Line,
 		})
 	}
-	for _, ec := range e.ExternalCalls {
+	for i := range e.ExternalCalls {
+		ec := &e.ExternalCalls[i]
 		frag.ExternalCalls = append(frag.ExternalCalls, ExternalCall{
 			Caller:          ec.CallerKey,
 			TargetSignature: ec.TargetKey,

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ToFragment projects an exported graph fragment onto the stitch model for the
+// given component. The component key is supplied by the caller because the
+// export carries source-level identity (module, function keys) but not the
+// (purl, version) it was requested for.
+func (e GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
+	frag := Fragment{Component: component, Module: e.ScanMetadata.RootModule}
+
+	for _, fn := range e.Functions {
+		frag.Functions = append(frag.Functions, Function{Signature: fn.Key, FilePath: fn.FilePath})
+	}
+	for _, ie := range e.InternalEdges {
+		frag.InternalEdges = append(frag.InternalEdges, InternalEdge{
+			Caller:       ie.CallerKey,
+			Callee:       ie.CalleeKey,
+			Resolution:   ResolutionKind(ie.Resolution),
+			DeclaredType: ie.DeclaredType,
+			MethodName:   ie.MethodName,
+			Arity:        ie.Arity,
+			CallSite:     ie.Line,
+		})
+	}
+	for _, ec := range e.ExternalCalls {
+		frag.ExternalCalls = append(frag.ExternalCalls, ExternalCall{
+			Caller:          ec.CallerKey,
+			TargetSignature: ec.TargetKey,
+			Resolution:      ResolutionKind(ec.Resolution),
+			DeclaredType:    ec.DeclaredType,
+			MethodName:      ec.MethodName,
+			Arity:           ec.Arity,
+			CallSite:        ec.Line,
+		})
+	}
+	for _, op := range e.CryptoAnnotations {
+		frag.CryptoOperations = append(frag.CryptoOperations, CryptoOperation{
+			Function:  op.FunctionKey,
+			FindingID: op.FindingID,
+			RuleID:    op.RuleID,
+			Symbol:    op.Symbol,
+		})
+	}
+	return frag
+}
+
+// DecodeFragment parses one graph-fragment export (JSON) into a Fragment for the
+// given component. Legacy fragments exported before the resolution fields
+// existed decode to ResolutionUnknown, which the stitcher fails closed on —
+// safe under-reporting, never a false positive.
+func DecodeFragment(component ComponentKey, data []byte) (Fragment, error) {
+	var e GraphFragmentExport
+	if err := json.Unmarshal(data, &e); err != nil {
+		return Fragment{}, fmt.Errorf("graphfrag: decode fragment for %s: %w", component, err)
+	}
+	return e.ToFragment(component), nil
+}

--- a/pkg/graphfrag/ingest_test.go
+++ b/pkg/graphfrag/ingest_test.go
@@ -100,6 +100,26 @@ func TestDecodeFragment_UnknownResolutionFromLegacyFragment(t *testing.T) {
 	}
 }
 
+func TestDecodeFragment_InvalidResolutionNormalized(t *testing.T) {
+	const invalid = `{
+	  "schema_version": "graph-fragment-1.1",
+	  "functions": [{ "key": "a.(A).f#0" }],
+	  "external_calls": [{
+	    "caller_key": "a.(A).f#0",
+	    "target_key": "b.(B).g#0",
+	    "resolution": "typo"
+	  }]
+	}`
+
+	frag, err := DecodeFragment(ComponentKey{Purl: "pkg:maven/a/a", Version: "1"}, []byte(invalid))
+	if err != nil {
+		t.Fatalf("DecodeFragment: %v", err)
+	}
+	if len(frag.ExternalCalls) != 1 || frag.ExternalCalls[0].Resolution != ResolutionUnknown {
+		t.Fatalf("invalid external edge resolution = %#v, want ResolutionUnknown", frag.ExternalCalls)
+	}
+}
+
 // TestStitch_EndToEnd_BouncyCastleFalsePositiveKilled reproduces the handover's
 // real finding through the full producer-schema -> adapter -> stitch path:
 //

--- a/pkg/graphfrag/ingest_test.go
+++ b/pkg/graphfrag/ingest_test.go
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestDecodeFragment_MapsResolutionMetadata proves the ingestion adapter maps
+// crypto-finder's graph-fragment export JSON (including the resolution fields)
+// onto graphfrag.Fragment, so the stitch policy receives real classifications
+// rather than the fail-closed zero value.
+func TestDecodeFragment_MapsResolutionMetadata(t *testing.T) {
+	const fragmentJSON = `{
+	  "schema_version": "graph-fragment-1.0",
+	  "scan_metadata": { "ecosystem": "java", "root_module": "org.bridge:b-bridge" },
+	  "functions": [
+	    { "key": "org.bridge.(Bridge).bridge#0", "file_path": "Bridge.java" },
+	    { "key": "org.bridge.(Bridge).helper#0", "file_path": "Bridge.java" }
+	  ],
+	  "internal_edges": [
+	    {
+	      "caller_key": "org.bridge.(Bridge).bridge#0",
+	      "callee_key": "org.bridge.(Bridge).helper#0",
+	      "line": 5,
+	      "resolution": "exact"
+	    }
+	  ],
+	  "external_calls": [
+	    {
+	      "caller_key": "org.bridge.(Bridge).bridge#0",
+	      "target_key": "net.crypto.(Sink).encrypt#1",
+	      "line": 6,
+	      "resolution": "interface_dispatch",
+	      "declared_type": "net.crypto.Provider",
+	      "method_name": "encrypt",
+	      "arity": 1
+	    }
+	  ],
+	  "crypto_annotations": [
+	    {
+	      "function_key": "org.bridge.(Bridge).helper#0",
+	      "finding_id": "abc123",
+	      "rule_id": "java.crypto.cipher.getinstance",
+	      "symbol": "javax.crypto.Cipher.getInstance"
+	    }
+	  ]
+	}`
+
+	component := ComponentKey{Purl: "pkg:maven/org.bridge/b-bridge", Version: "1.0.0"}
+	frag, err := DecodeFragment(component, []byte(fragmentJSON))
+	if err != nil {
+		t.Fatalf("DecodeFragment: %v", err)
+	}
+
+	if frag.Component != component {
+		t.Fatalf("Component = %#v, want %#v", frag.Component, component)
+	}
+	if len(frag.Functions) != 2 || frag.Functions[0].Signature != "org.bridge.(Bridge).bridge#0" {
+		t.Fatalf("Functions = %#v", frag.Functions)
+	}
+	if len(frag.InternalEdges) != 1 {
+		t.Fatalf("InternalEdges len = %d, want 1", len(frag.InternalEdges))
+	}
+	ie := frag.InternalEdges[0]
+	if ie.Resolution != ResolutionExact || ie.CallSite != 5 {
+		t.Fatalf("internal edge = %#v, want exact at line 5", ie)
+	}
+	if len(frag.ExternalCalls) != 1 {
+		t.Fatalf("ExternalCalls len = %d, want 1", len(frag.ExternalCalls))
+	}
+	ec := frag.ExternalCalls[0]
+	if ec.TargetSignature != "net.crypto.(Sink).encrypt#1" {
+		t.Fatalf("external target = %q", ec.TargetSignature)
+	}
+	if ec.Resolution != ResolutionInterfaceDispatch || ec.DeclaredType != "net.crypto.Provider" || ec.MethodName != "encrypt" || ec.Arity != 1 || ec.CallSite != 6 {
+		t.Fatalf("external edge metadata = %#v", ec)
+	}
+	if len(frag.CryptoOperations) != 1 || frag.CryptoOperations[0].FindingID != "abc123" {
+		t.Fatalf("CryptoOperations = %#v", frag.CryptoOperations)
+	}
+}
+
+// TestDecodeFragment_UnknownResolutionFromLegacyFragment proves an old fragment
+// (exported before the resolution fields existed) decodes to ResolutionUnknown,
+// which the stitcher fails closed on — safe under-reporting, never a false
+// positive.
+func TestDecodeFragment_UnknownResolutionFromLegacyFragment(t *testing.T) {
+	const legacy = `{
+	  "schema_version": "graph-fragment-1.0",
+	  "functions": [{ "key": "a.(A).f#0" }],
+	  "external_calls": [{ "caller_key": "a.(A).f#0", "target_key": "b.(B).g#0" }]
+	}`
+
+	frag, err := DecodeFragment(ComponentKey{Purl: "pkg:maven/a/a", Version: "1"}, []byte(legacy))
+	if err != nil {
+		t.Fatalf("DecodeFragment: %v", err)
+	}
+	if len(frag.ExternalCalls) != 1 || frag.ExternalCalls[0].Resolution != ResolutionUnknown {
+		t.Fatalf("legacy external edge resolution = %#v, want ResolutionUnknown", frag.ExternalCalls)
+	}
+}
+
+// TestStitch_EndToEnd_BouncyCastleFalsePositiveKilled reproduces the handover's
+// real finding through the full producer-schema -> adapter -> stitch path:
+//
+//   - The REAL path: root.decryptPrivateKey -> bcpkix.decryptPrivateKeyInfo
+//     --exact--> bcprov.EncryptedPrivateKeyInfo.getEncryptedData (a true marker).
+//   - The BOGUS path: bcpkix.decryptPrivateKeyInfo --name_only(get#1)-->
+//     bcprov.SP800SecureRandomBuilder.get --exact--> bcprov.BCrypt.generate.
+//     The get() edge is an over-broad name+arity dispatch guess; crypto-finder's
+//     fluent fallback fabricated it. It must NOT carry reachability into BCrypt.
+//
+// Expectation matches the handover's conclusion exactly: the BCrypt marker is
+// unreachable (false positive killed) while the getEncryptedData marker still
+// stitches (true positive preserved).
+func TestStitch_EndToEnd_BouncyCastleFalsePositiveKilled(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:maven/com.mastercard.developer/client-encryption-java", Version: "1.6.0"}
+	bcpkix := ComponentKey{Purl: "pkg:maven/org.bouncycastle/bcpkix-jdk18on", Version: "1.78.1"}
+	bcprov := ComponentKey{Purl: "pkg:maven/org.bouncycastle/bcprov-jdk18on", Version: "1.78.1"}
+
+	rootJSON := `{
+	  "schema_version": "graph-fragment-1.0",
+	  "functions": [{ "key": "com.mastercard.developer.crypto.thirdparty.(BouncyCastlePkixCrypto).decryptPrivateKey#2" }],
+	  "external_calls": [{
+	    "caller_key": "com.mastercard.developer.crypto.thirdparty.(BouncyCastlePkixCrypto).decryptPrivateKey#2",
+	    "target_key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1",
+	    "resolution": "exact", "line": 42
+	  }]
+	}`
+
+	bcpkixJSON := `{
+	  "schema_version": "graph-fragment-1.0",
+	  "functions": [{ "key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1" }],
+	  "external_calls": [
+	    {
+	      "caller_key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1",
+	      "target_key": "org.bouncycastle.crypto.prng.(SP800SecureRandomBuilder).get#1",
+	      "resolution": "name_only", "method_name": "get", "arity": 1, "line": 88
+	    },
+	    {
+	      "caller_key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1",
+	      "target_key": "org.bouncycastle.asn1.pkcs.(EncryptedPrivateKeyInfo).getEncryptedData#0",
+	      "resolution": "exact", "line": 90
+	    }
+	  ]
+	}`
+
+	bcprovJSON := `{
+	  "schema_version": "graph-fragment-1.0",
+	  "functions": [
+	    { "key": "org.bouncycastle.crypto.prng.(SP800SecureRandomBuilder).get#1" },
+	    { "key": "org.bouncycastle.crypto.generators.(BCrypt).generate#3" },
+	    { "key": "org.bouncycastle.asn1.pkcs.(EncryptedPrivateKeyInfo).getEncryptedData#0" }
+	  ],
+	  "internal_edges": [{
+	    "caller_key": "org.bouncycastle.crypto.prng.(SP800SecureRandomBuilder).get#1",
+	    "callee_key": "org.bouncycastle.crypto.generators.(BCrypt).generate#3",
+	    "resolution": "exact", "line": 120
+	  }],
+	  "crypto_annotations": [
+	    { "function_key": "org.bouncycastle.crypto.generators.(BCrypt).generate#3", "finding_id": "bogus-bcrypt", "symbol": "BCrypt.generate" },
+	    { "function_key": "org.bouncycastle.asn1.pkcs.(EncryptedPrivateKeyInfo).getEncryptedData#0", "finding_id": "real-getencrypteddata", "symbol": "getEncryptedData" }
+	  ]
+	}`
+
+	fragments := map[ComponentKey]Fragment{}
+	for ck, raw := range map[ComponentKey]string{root: rootJSON, bcpkix: bcpkixJSON, bcprov: bcprovJSON} {
+		frag, err := DecodeFragment(ck, []byte(raw))
+		if err != nil {
+			t.Fatalf("DecodeFragment(%s): %v", ck, err)
+		}
+		fragments[ck] = frag
+	}
+
+	deps := DependencyGraph{
+		root:   {bcpkix},
+		bcpkix: {bcprov},
+	}
+
+	res, err := Stitch(root, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+
+	reached := map[string]bool{}
+	for _, ch := range res.Chains {
+		reached[ch.FindingID] = true
+	}
+	if reached["bogus-bcrypt"] {
+		t.Fatalf("BCrypt false positive was NOT killed: %#v", res.Chains)
+	}
+	if !reached["real-getencrypteddata"] {
+		t.Fatalf("true-positive getEncryptedData path was lost; chains = %#v", res.Chains)
+	}
+
+	var sawNameOnlyGet bool
+	for _, s := range res.Suppressed {
+		if s.Reason == SuppressReasonNameOnly && s.MethodName == "get" {
+			sawNameOnlyGet = true
+		}
+	}
+	if !sawNameOnlyGet {
+		t.Fatalf("expected the over-broad get() edge to be recorded as suppressed name_only: %#v", res.Suppressed)
+	}
+}

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package graphfrag is crypto-finder's public contract for reusable component
+// graph fragments: the structural call-graph + rules-versioned crypto
+// annotations that `crypto-finder scan --export-graph-fragment` emits for a
+// single component, plus the pure stitcher that composes a dependency closure
+// of those fragments into root-to-crypto reachability chains.
+//
+// Why this lives in crypto-finder (not a downstream service): the graph
+// fragment schema and the resolution-quality semantics are crypto-finder's
+// public contract — the scanner produces them, so the rules for consuming them
+// (which edges may extend a chain) belong with the contract owner. A
+// reimplementation in a downstream catalog/mining service would drift the
+// moment the schema bumps. Mirrors the rationale of pkg/stitch.
+//
+// The package is intentionally dependency-light: it does NOT import the scanner
+// or callgraph builder, read storage, or gzip. Inputs are exported fragments
+// (or decoded Fragments); the caller fetches and decompresses them.
+package graphfrag
+
+import "strings"
+
+// ComponentKey identifies one mined component version.
+type ComponentKey struct {
+	Purl    string
+	Version string
+}
+
+func (k ComponentKey) String() string {
+	if k.Version == "" {
+		return k.Purl
+	}
+	return k.Purl + "@" + k.Version
+}
+
+// DependencyGraph is the authoritative component-version graph resolved from
+// build metadata. Stitching only crosses into components reachable through this
+// graph, even if extra fragments are available in storage.
+type DependencyGraph map[ComponentKey][]ComponentKey
+
+// Fragment is one reusable structural graph fragment plus rules-versioned
+// crypto annotations for a single component version. The production storage
+// layer may split this into structural graph blobs and separate crypto
+// annotation blobs, but the stitcher consumes the combined view.
+type Fragment struct {
+	Component ComponentKey
+	Module    string
+
+	Functions        []Function
+	InternalEdges    []InternalEdge
+	ExternalCalls    []ExternalCall
+	CryptoOperations []CryptoOperation
+}
+
+// Function identifies one callable node inside a component graph.
+type Function struct {
+	Signature string
+	FilePath  string
+}
+
+// InternalEdge connects two functions inside the same component fragment.
+//
+// Internal edges carry the same resolution metadata as ExternalCall: an
+// interface or fluent call resolved by name+arity can land on a co-located
+// implementation just as easily as a cross-component one, so it must be gated
+// by the same policy. The dispatch-group identity (Caller + CallSite +
+// MethodName + Arity) is shared with ExternalCall so that siblings of one call
+// site that span the component boundary are judged together.
+type InternalEdge struct {
+	Caller string
+	Callee string
+
+	// Resolution classifies how the producer resolved Callee. Zero value
+	// (ResolutionUnknown) is fail-closed.
+	Resolution ResolutionKind
+
+	// DeclaredType, MethodName, Arity, CallSite mirror ExternalCall and identify
+	// the dispatched method / call site for ambiguity grouping.
+	DeclaredType string
+	MethodName   string
+	Arity        int
+	CallSite     int
+}
+
+// ResolutionKind classifies how confidently the producer resolved a call to its
+// target. The stitcher uses this to decide whether an edge is allowed to extend
+// a reachability chain. The zero value is ResolutionUnknown, which is treated as
+// untrusted: the stitcher fails closed rather than guessing.
+//
+// This is the central guard against over-broad dispatch false positives. An
+// interface or fluent call resolved purely by method name + arity (no receiver
+// type anchor) must never be presented as typed reachability proof.
+type ResolutionKind string
+
+const (
+	// ResolutionUnknown is the zero value: the producer did not classify the
+	// edge. Treated as untrusted and never traversed. Its presence usually means
+	// a producer bug (an edge exported without a resolution kind).
+	ResolutionUnknown ResolutionKind = ""
+
+	// ResolutionExact means the receiver's static type was known and the method
+	// resolved to a unique declared target on that type (or an overload set on
+	// that exact type). Always traversed.
+	ResolutionExact ResolutionKind = "exact"
+
+	// ResolutionInterfaceDispatch means the target was found by expanding an
+	// interface/abstract method to concrete implementations matching name+arity
+	// within a namespace root. Trusted ONLY when exactly one implementation is
+	// present in the dependency closure; ambiguous (>1) call sites fail closed.
+	ResolutionInterfaceDispatch ResolutionKind = "interface_dispatch"
+
+	// ResolutionNameOnly means the target was guessed by method name + arity
+	// (plus namespace heuristics) with no receiver type anchor — e.g. fluent
+	// fallback. Never traversed.
+	ResolutionNameOnly ResolutionKind = "name_only"
+)
+
+// ExternalCall is a call from this component to a function whose implementation
+// may live in another component from the dependency graph.
+type ExternalCall struct {
+	Caller          string
+	TargetSignature string
+
+	// Resolution classifies how the producer resolved TargetSignature. The zero
+	// value (ResolutionUnknown) is fail-closed: the stitcher will not traverse it.
+	Resolution ResolutionKind
+
+	// DeclaredType is the static/interface type observed at the call site (e.g.
+	// the interface whose method was dispatched). Provenance plus part of the
+	// dispatch-group identity used to detect ambiguous interface dispatch.
+	DeclaredType string
+
+	// MethodName and Arity identify the invoked method independently of the
+	// resolved target, so sibling candidates of one ambiguous call site can be
+	// grouped together.
+	MethodName string
+	Arity      int
+
+	// CallSite is the source line of the call expression. Together with Caller,
+	// MethodName, and Arity it discriminates distinct call sites that happen to
+	// share a method name within the same caller.
+	CallSite int
+}
+
+// CryptoOperation is a crypto finding attached to a function.
+type CryptoOperation struct {
+	Function  string
+	FindingID string
+	RuleID    string
+	Symbol    string
+}
+
+// ConfidenceHigh is the confidence of every chain emitted under the default
+// fail-closed policy (only exact and unique-implementation interface edges are
+// traversed). The constant exists so a future opt-in mode can surface
+// lower-confidence chains explicitly.
+const ConfidenceHigh = "high"
+
+// Suppression reasons recorded on a SuppressedEdge.
+const (
+	// SuppressReasonUnknown: an edge had no resolution kind (producer bug or an
+	// intentionally untrusted edge).
+	SuppressReasonUnknown = "unknown_resolution"
+	// SuppressReasonNameOnly: a name+arity guess with no receiver type anchor.
+	SuppressReasonNameOnly = "name_only"
+	// SuppressReasonAmbiguousDispatch: an interface call site with more than one
+	// concrete implementation present in the dependency closure.
+	SuppressReasonAmbiguousDispatch = "interface_dispatch_ambiguous"
+)
+
+// Result is the stitched reachability output in its minimal semantic form.
+// Rendering into crypto-finder's customer-facing callgraph schema is a later
+// adapter concern.
+type Result struct {
+	Chains []FindingChain
+
+	// Suppressed records call edges the policy refused to traverse. It is the
+	// audit trail for fail-closed decisions and the data source for a future
+	// opt-in "show me the uncertain paths too" mode. It never affects Chains.
+	Suppressed []SuppressedEdge
+}
+
+// FindingChain is one root-to-crypto path.
+type FindingChain struct {
+	FindingID string
+	RuleID    string
+	Symbol    string
+	Frames    []CallFrame
+
+	// Confidence is the weakest-link confidence of the traversed edges. Under
+	// the default policy this is always ConfidenceHigh.
+	Confidence string
+}
+
+// SuppressedEdge is one call edge (or grouped call site) the stitcher declined
+// to traverse, with the reason and the candidate targets it would have reached.
+type SuppressedEdge struct {
+	Caller     CallFrame
+	MethodName string
+	Arity      int
+	Reason     string
+	Candidates []ComponentKey
+}
+
+// CallFrame is one frame in a stitched path.
+type CallFrame struct {
+	Component ComponentKey
+	Function  string
+}
+
+// ErrMissingFragment means the dependency closure references components whose
+// graph fragments are absent. The stitcher fails closed instead of returning a
+// partial graph.
+type ErrMissingFragment struct {
+	Components []ComponentKey
+}
+
+func (e *ErrMissingFragment) Error() string {
+	if e == nil || len(e.Components) == 0 {
+		return "graphfrag: missing graph fragments"
+	}
+	parts := make([]string, len(e.Components))
+	for i, c := range e.Components {
+		parts[i] = c.String()
+	}
+	return "graphfrag: missing graph fragments for " + strings.Join(parts, ", ")
+}

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -107,7 +107,8 @@ const (
 	// ResolutionInterfaceDispatch means the target was found by expanding an
 	// interface/abstract method to concrete implementations matching name+arity
 	// within a namespace root. Trusted ONLY when exactly one implementation is
-	// present in the dependency closure; ambiguous (>1) call sites fail closed.
+	// present in the current component's direct dependencies; ambiguous (>1)
+	// call sites fail closed.
 	ResolutionInterfaceDispatch ResolutionKind = "interface_dispatch"
 
 	// ResolutionNameOnly means the target was guessed by method name + arity
@@ -165,7 +166,7 @@ const (
 	// SuppressReasonNameOnly: a name+arity guess with no receiver type anchor.
 	SuppressReasonNameOnly = "name_only"
 	// SuppressReasonAmbiguousDispatch: an interface call site with more than one
-	// concrete implementation present in the dependency closure.
+	// concrete implementation present in the current component's direct dependencies.
 	SuppressReasonAmbiguousDispatch = "interface_dispatch_ambiguous"
 )
 

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -1,0 +1,308 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "sort"
+
+// Stitch composes reusable component graph fragments into root-to-crypto
+// reachability chains for root.
+//
+// This is the pure graph algorithm. It deliberately does not know about
+// storage, compression, or HTTP response DTOs.
+func Stitch(root ComponentKey, deps DependencyGraph, fragments map[ComponentKey]Fragment) (*Result, error) {
+	closure := dependencyClosure(root, deps)
+	missing := missingFragments(closure, fragments)
+	if len(missing) > 0 {
+		return nil, &ErrMissingFragment{Components: missing}
+	}
+
+	functionsBySignature := indexFunctions(closure, fragments)
+	adjacency, suppressed := buildAdjacency(closure, fragments, functionsBySignature)
+	opsByNode := indexCryptoOperations(closure, fragments)
+
+	rootFragment := fragments[root]
+	out := Result{Suppressed: suppressed}
+	for _, fn := range rootFragment.Functions {
+		start := graphNode{Component: root, Function: fn.Signature}
+		trace(start, adjacency, opsByNode, nil, map[graphNode]bool{}, &out)
+	}
+	return &out, nil
+}
+
+type graphNode struct {
+	Component ComponentKey
+	Function  string
+}
+
+func dependencyClosure(root ComponentKey, deps DependencyGraph) []ComponentKey {
+	seen := map[ComponentKey]bool{root: true}
+	queue := []ComponentKey{root}
+	out := []ComponentKey{root}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, dep := range deps[current] {
+			if seen[dep] {
+				continue
+			}
+			seen[dep] = true
+			queue = append(queue, dep)
+			out = append(out, dep)
+		}
+	}
+	return out
+}
+
+func missingFragments(closure []ComponentKey, fragments map[ComponentKey]Fragment) []ComponentKey {
+	var missing []ComponentKey
+	for _, key := range closure {
+		if _, ok := fragments[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+func indexFunctions(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[string][]graphNode {
+	out := make(map[string][]graphNode)
+	for _, key := range closure {
+		fragment := fragments[key]
+		for _, fn := range fragment.Functions {
+			node := graphNode{Component: key, Function: fn.Signature}
+			out[fn.Signature] = append(out[fn.Signature], node)
+		}
+	}
+	return out
+}
+
+// dispatchGroupKey identifies one interface call site so that the sibling
+// candidate edges the producer emitted for it can be grouped and judged
+// together: a single source call expression that the producer expanded into N
+// concrete implementations.
+type dispatchGroupKey struct {
+	Component  ComponentKey
+	Caller     string
+	CallSite   int
+	MethodName string
+	Arity      int
+}
+
+// callEdge is the scope-agnostic view of one resolved call edge. Internal and
+// external edges are normalised into this shape so the resolution policy — and
+// crucially the per-call-site ambiguity check — can span both: an interface
+// call site whose implementations straddle the component boundary must be judged
+// as one group, not two.
+type callEdge struct {
+	caller     string
+	target     string
+	resolution ResolutionKind
+	method     string
+	arity      int
+	callSite   int
+	internal   bool
+}
+
+// buildAdjacency composes the traversable call graph from the fragment closure
+// while applying the edge-resolution policy. It returns the adjacency map plus
+// the list of edges/call sites it refused to traverse (fail-closed audit trail).
+//
+// Policy (tiered, fail-closed by default):
+//   - exact              -> always traversed.
+//   - interface_dispatch -> traversed only if exactly one concrete impl is
+//     present in the dependency closure for that call site; >1 is ambiguous and
+//     fails closed (recorded). 0-in-closure is simply unreachable.
+//   - name_only          -> never traversed (recorded).
+//   - unknown (zero)     -> never traversed (recorded); usually a producer bug.
+func buildAdjacency(
+	closure []ComponentKey,
+	fragments map[ComponentKey]Fragment,
+	functionsBySignature map[string][]graphNode,
+) (map[graphNode][]graphNode, []SuppressedEdge) {
+	out := make(map[graphNode][]graphNode)
+	var suppressed []SuppressedEdge
+	inClosure := make(map[ComponentKey]bool, len(closure))
+	for _, key := range closure {
+		inClosure[key] = true
+	}
+
+	for _, key := range closure {
+		fragment := fragments[key]
+
+		componentSigs := make(map[string]bool, len(fragment.Functions))
+		for _, fn := range fragment.Functions {
+			node := graphNode{Component: key, Function: fn.Signature}
+			if _, ok := out[node]; !ok {
+				out[node] = nil
+			}
+			componentSigs[fn.Signature] = true
+		}
+
+		// resolve maps one edge to the concrete target nodes it could reach.
+		// Internal edges resolve within the component; external edges resolve to
+		// other components in the dependency closure.
+		resolve := func(e callEdge) []graphNode {
+			if e.internal {
+				if componentSigs[e.target] {
+					return []graphNode{{Component: key, Function: e.target}}
+				}
+				return nil
+			}
+			var targets []graphNode
+			for _, callee := range functionsBySignature[e.target] {
+				if callee.Component == key || !inClosure[callee.Component] {
+					continue
+				}
+				targets = append(targets, callee)
+			}
+			return targets
+		}
+
+		edges := make([]callEdge, 0, len(fragment.InternalEdges)+len(fragment.ExternalCalls))
+		for _, e := range fragment.InternalEdges {
+			edges = append(edges, callEdge{
+				caller: e.Caller, target: e.Callee, resolution: e.Resolution,
+				method: e.MethodName, arity: e.Arity, callSite: e.CallSite, internal: true,
+			})
+		}
+		for _, c := range fragment.ExternalCalls {
+			edges = append(edges, callEdge{
+				caller: c.Caller, target: c.TargetSignature, resolution: c.Resolution,
+				method: c.MethodName, arity: c.Arity, callSite: c.CallSite, internal: false,
+			})
+		}
+
+		// Interface-dispatch candidates are deferred and grouped per call site so
+		// ambiguity (>1 impl in closure) is detected across all sibling edges,
+		// including siblings that cross the internal/external boundary.
+		dispatchGroups := make(map[dispatchGroupKey][]callEdge)
+		for _, e := range edges {
+			caller := graphNode{Component: key, Function: e.caller}
+			switch e.resolution {
+			case ResolutionExact:
+				for _, callee := range resolve(e) {
+					out[caller] = append(out[caller], callee)
+				}
+			case ResolutionInterfaceDispatch:
+				gk := dispatchGroupKey{Component: key, Caller: e.caller, CallSite: e.callSite, MethodName: e.method, Arity: e.arity}
+				dispatchGroups[gk] = append(dispatchGroups[gk], e)
+			case ResolutionNameOnly:
+				suppressed = append(suppressed, suppressedEdge(key, e, SuppressReasonNameOnly, candidateComponents(resolve(e))))
+			default: // ResolutionUnknown and any future unhandled kind: fail closed.
+				suppressed = append(suppressed, suppressedEdge(key, e, SuppressReasonUnknown, candidateComponents(resolve(e))))
+			}
+		}
+
+		for _, gk := range sortedDispatchKeys(dispatchGroups) {
+			caller := graphNode{Component: key, Function: gk.Caller}
+			distinct := map[graphNode]bool{}
+			var targets []graphNode
+			for _, e := range dispatchGroups[gk] {
+				for _, t := range resolve(e) {
+					if !distinct[t] {
+						distinct[t] = true
+						targets = append(targets, t)
+					}
+				}
+			}
+			switch {
+			case len(targets) == 1:
+				out[caller] = append(out[caller], targets[0])
+			case len(targets) > 1:
+				suppressed = append(suppressed, SuppressedEdge{
+					Caller:     CallFrame{Component: key, Function: gk.Caller},
+					MethodName: gk.MethodName,
+					Arity:      gk.Arity,
+					Reason:     SuppressReasonAmbiguousDispatch,
+					Candidates: candidateComponents(targets),
+				})
+				// len(targets) == 0: no implementation in closure -> unreachable,
+				// nothing to traverse and nothing to record.
+			}
+		}
+	}
+	return out, suppressed
+}
+
+func candidateComponents(targets []graphNode) []ComponentKey {
+	candidates := make([]ComponentKey, 0, len(targets))
+	for _, t := range targets {
+		candidates = append(candidates, t.Component)
+	}
+	return candidates
+}
+
+func suppressedEdge(from ComponentKey, e callEdge, reason string, candidates []ComponentKey) SuppressedEdge {
+	return SuppressedEdge{
+		Caller:     CallFrame{Component: from, Function: e.caller},
+		MethodName: e.method,
+		Arity:      e.arity,
+		Reason:     reason,
+		Candidates: candidates,
+	}
+}
+
+func sortedDispatchKeys(groups map[dispatchGroupKey][]callEdge) []dispatchGroupKey {
+	keys := make([]dispatchGroupKey, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.Caller != b.Caller {
+			return a.Caller < b.Caller
+		}
+		if a.CallSite != b.CallSite {
+			return a.CallSite < b.CallSite
+		}
+		if a.MethodName != b.MethodName {
+			return a.MethodName < b.MethodName
+		}
+		return a.Arity < b.Arity
+	})
+	return keys
+}
+
+func indexCryptoOperations(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[graphNode][]CryptoOperation {
+	out := make(map[graphNode][]CryptoOperation)
+	for _, key := range closure {
+		fragment := fragments[key]
+		for _, op := range fragment.CryptoOperations {
+			node := graphNode{Component: key, Function: op.Function}
+			out[node] = append(out[node], op)
+		}
+	}
+	return out
+}
+
+func trace(
+	current graphNode,
+	adjacency map[graphNode][]graphNode,
+	opsByNode map[graphNode][]CryptoOperation,
+	path []CallFrame,
+	visiting map[graphNode]bool,
+	out *Result,
+) {
+	if visiting[current] {
+		return
+	}
+	visiting[current] = true
+	defer delete(visiting, current)
+
+	path = append(path, CallFrame{Component: current.Component, Function: current.Function})
+	for _, op := range opsByNode[current] {
+		frames := append([]CallFrame(nil), path...)
+		out.Chains = append(out.Chains, FindingChain{
+			FindingID:  op.FindingID,
+			RuleID:     op.RuleID,
+			Symbol:     op.Symbol,
+			Frames:     frames,
+			Confidence: ConfidenceHigh,
+		})
+	}
+	for _, next := range adjacency[current] {
+		trace(next, adjacency, opsByNode, path, visiting, out)
+	}
+}

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -18,7 +18,7 @@ func Stitch(root ComponentKey, deps DependencyGraph, fragments map[ComponentKey]
 	}
 
 	functionsBySignature := indexFunctions(closure, fragments)
-	adjacency, suppressed := buildAdjacency(closure, fragments, functionsBySignature)
+	adjacency, suppressed := buildAdjacency(closure, deps, fragments, functionsBySignature)
 	opsByNode := indexCryptoOperations(closure, fragments)
 
 	rootFragment := fragments[root]
@@ -112,24 +112,25 @@ type callEdge struct {
 // Policy (tiered, fail-closed by default):
 //   - exact              -> always traversed.
 //   - interface_dispatch -> traversed only if exactly one concrete impl is
-//     present in the dependency closure for that call site; >1 is ambiguous and
-//     fails closed (recorded). 0-in-closure is simply unreachable.
+//     present in the current component's direct dependencies for that call
+//     site; >1 is ambiguous and fails closed (recorded). 0 is simply
+//     unreachable.
 //   - name_only          -> never traversed (recorded).
 //   - unknown (zero)     -> never traversed (recorded); usually a producer bug.
 func buildAdjacency(
 	closure []ComponentKey,
+	deps DependencyGraph,
 	fragments map[ComponentKey]Fragment,
 	functionsBySignature map[string][]graphNode,
 ) (map[graphNode][]graphNode, []SuppressedEdge) {
 	out := make(map[graphNode][]graphNode)
 	var suppressed []SuppressedEdge
-	inClosure := componentSet(closure)
 
 	for _, key := range closure {
 		fragment := fragments[key]
 		componentSigs := indexComponentSignatures(key, fragment, out)
 		edges := collectCallEdges(fragment)
-		resolve := callEdgeResolver(key, componentSigs, inClosure, functionsBySignature)
+		resolve := callEdgeResolver(key, componentSigs, componentSet(deps[key]), functionsBySignature)
 
 		dispatchGroups := applyImmediateEdgePolicy(key, edges, resolve, out, &suppressed)
 		applyDispatchGroups(key, dispatchGroups, resolve, out, &suppressed)
@@ -178,11 +179,11 @@ type edgeResolver func(callEdge) []graphNode
 
 // callEdgeResolver maps one edge to the concrete target nodes it could reach.
 // Internal edges resolve within the component; external edges resolve to other
-// components in the dependency closure.
+// components that are direct dependencies of the current component.
 func callEdgeResolver(
 	key ComponentKey,
 	componentSigs map[string]bool,
-	inClosure map[ComponentKey]bool,
+	directDeps map[ComponentKey]bool,
 	functionsBySignature map[string][]graphNode,
 ) edgeResolver {
 	return func(e callEdge) []graphNode {
@@ -192,19 +193,18 @@ func callEdgeResolver(
 			}
 			return nil
 		}
-		return externalTargets(key, e.target, inClosure, functionsBySignature)
+		return externalTargets(e.target, directDeps, functionsBySignature)
 	}
 }
 
 func externalTargets(
-	current ComponentKey,
 	target string,
-	inClosure map[ComponentKey]bool,
+	directDeps map[ComponentKey]bool,
 	functionsBySignature map[string][]graphNode,
 ) []graphNode {
 	var targets []graphNode
 	for _, callee := range functionsBySignature[target] {
-		if callee.Component == current || !inClosure[callee.Component] {
+		if !directDeps[callee.Component] {
 			continue
 		}
 		targets = append(targets, callee)

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -123,107 +123,179 @@ func buildAdjacency(
 ) (map[graphNode][]graphNode, []SuppressedEdge) {
 	out := make(map[graphNode][]graphNode)
 	var suppressed []SuppressedEdge
-	inClosure := make(map[ComponentKey]bool, len(closure))
-	for _, key := range closure {
-		inClosure[key] = true
-	}
+	inClosure := componentSet(closure)
 
 	for _, key := range closure {
 		fragment := fragments[key]
+		componentSigs := indexComponentSignatures(key, fragment, out)
+		edges := collectCallEdges(fragment)
+		resolve := callEdgeResolver(key, componentSigs, inClosure, functionsBySignature)
 
-		componentSigs := make(map[string]bool, len(fragment.Functions))
-		for _, fn := range fragment.Functions {
-			node := graphNode{Component: key, Function: fn.Signature}
-			if _, ok := out[node]; !ok {
-				out[node] = nil
-			}
-			componentSigs[fn.Signature] = true
-		}
-
-		// resolve maps one edge to the concrete target nodes it could reach.
-		// Internal edges resolve within the component; external edges resolve to
-		// other components in the dependency closure.
-		resolve := func(e callEdge) []graphNode {
-			if e.internal {
-				if componentSigs[e.target] {
-					return []graphNode{{Component: key, Function: e.target}}
-				}
-				return nil
-			}
-			var targets []graphNode
-			for _, callee := range functionsBySignature[e.target] {
-				if callee.Component == key || !inClosure[callee.Component] {
-					continue
-				}
-				targets = append(targets, callee)
-			}
-			return targets
-		}
-
-		edges := make([]callEdge, 0, len(fragment.InternalEdges)+len(fragment.ExternalCalls))
-		for _, e := range fragment.InternalEdges {
-			edges = append(edges, callEdge{
-				caller: e.Caller, target: e.Callee, resolution: e.Resolution,
-				method: e.MethodName, arity: e.Arity, callSite: e.CallSite, internal: true,
-			})
-		}
-		for _, c := range fragment.ExternalCalls {
-			edges = append(edges, callEdge{
-				caller: c.Caller, target: c.TargetSignature, resolution: c.Resolution,
-				method: c.MethodName, arity: c.Arity, callSite: c.CallSite, internal: false,
-			})
-		}
-
-		// Interface-dispatch candidates are deferred and grouped per call site so
-		// ambiguity (>1 impl in closure) is detected across all sibling edges,
-		// including siblings that cross the internal/external boundary.
-		dispatchGroups := make(map[dispatchGroupKey][]callEdge)
-		for _, e := range edges {
-			caller := graphNode{Component: key, Function: e.caller}
-			switch e.resolution {
-			case ResolutionExact:
-				for _, callee := range resolve(e) {
-					out[caller] = append(out[caller], callee)
-				}
-			case ResolutionInterfaceDispatch:
-				gk := dispatchGroupKey{Component: key, Caller: e.caller, CallSite: e.callSite, MethodName: e.method, Arity: e.arity}
-				dispatchGroups[gk] = append(dispatchGroups[gk], e)
-			case ResolutionNameOnly:
-				suppressed = append(suppressed, suppressedEdge(key, e, SuppressReasonNameOnly, candidateComponents(resolve(e))))
-			default: // ResolutionUnknown and any future unhandled kind: fail closed.
-				suppressed = append(suppressed, suppressedEdge(key, e, SuppressReasonUnknown, candidateComponents(resolve(e))))
-			}
-		}
-
-		for _, gk := range sortedDispatchKeys(dispatchGroups) {
-			caller := graphNode{Component: key, Function: gk.Caller}
-			distinct := map[graphNode]bool{}
-			var targets []graphNode
-			for _, e := range dispatchGroups[gk] {
-				for _, t := range resolve(e) {
-					if !distinct[t] {
-						distinct[t] = true
-						targets = append(targets, t)
-					}
-				}
-			}
-			switch {
-			case len(targets) == 1:
-				out[caller] = append(out[caller], targets[0])
-			case len(targets) > 1:
-				suppressed = append(suppressed, SuppressedEdge{
-					Caller:     CallFrame{Component: key, Function: gk.Caller},
-					MethodName: gk.MethodName,
-					Arity:      gk.Arity,
-					Reason:     SuppressReasonAmbiguousDispatch,
-					Candidates: candidateComponents(targets),
-				})
-				// len(targets) == 0: no implementation in closure -> unreachable,
-				// nothing to traverse and nothing to record.
-			}
-		}
+		dispatchGroups := applyImmediateEdgePolicy(key, edges, resolve, out, &suppressed)
+		applyDispatchGroups(key, dispatchGroups, resolve, out, &suppressed)
 	}
 	return out, suppressed
+}
+
+func componentSet(closure []ComponentKey) map[ComponentKey]bool {
+	out := make(map[ComponentKey]bool, len(closure))
+	for _, key := range closure {
+		out[key] = true
+	}
+	return out
+}
+
+func indexComponentSignatures(key ComponentKey, fragment Fragment, adjacency map[graphNode][]graphNode) map[string]bool {
+	componentSigs := make(map[string]bool, len(fragment.Functions))
+	for _, fn := range fragment.Functions {
+		node := graphNode{Component: key, Function: fn.Signature}
+		if _, ok := adjacency[node]; !ok {
+			adjacency[node] = nil
+		}
+		componentSigs[fn.Signature] = true
+	}
+	return componentSigs
+}
+
+func collectCallEdges(fragment Fragment) []callEdge {
+	edges := make([]callEdge, 0, len(fragment.InternalEdges)+len(fragment.ExternalCalls))
+	for _, e := range fragment.InternalEdges {
+		edges = append(edges, callEdge{
+			caller: e.Caller, target: e.Callee, resolution: e.Resolution,
+			method: e.MethodName, arity: e.Arity, callSite: e.CallSite, internal: true,
+		})
+	}
+	for _, c := range fragment.ExternalCalls {
+		edges = append(edges, callEdge{
+			caller: c.Caller, target: c.TargetSignature, resolution: c.Resolution,
+			method: c.MethodName, arity: c.Arity, callSite: c.CallSite, internal: false,
+		})
+	}
+	return edges
+}
+
+type edgeResolver func(callEdge) []graphNode
+
+// callEdgeResolver maps one edge to the concrete target nodes it could reach.
+// Internal edges resolve within the component; external edges resolve to other
+// components in the dependency closure.
+func callEdgeResolver(
+	key ComponentKey,
+	componentSigs map[string]bool,
+	inClosure map[ComponentKey]bool,
+	functionsBySignature map[string][]graphNode,
+) edgeResolver {
+	return func(e callEdge) []graphNode {
+		if e.internal {
+			if componentSigs[e.target] {
+				return []graphNode{{Component: key, Function: e.target}}
+			}
+			return nil
+		}
+		return externalTargets(key, e.target, inClosure, functionsBySignature)
+	}
+}
+
+func externalTargets(
+	current ComponentKey,
+	target string,
+	inClosure map[ComponentKey]bool,
+	functionsBySignature map[string][]graphNode,
+) []graphNode {
+	var targets []graphNode
+	for _, callee := range functionsBySignature[target] {
+		if callee.Component == current || !inClosure[callee.Component] {
+			continue
+		}
+		targets = append(targets, callee)
+	}
+	return targets
+}
+
+func applyImmediateEdgePolicy(
+	key ComponentKey,
+	edges []callEdge,
+	resolve edgeResolver,
+	adjacency map[graphNode][]graphNode,
+	suppressed *[]SuppressedEdge,
+) map[dispatchGroupKey][]callEdge {
+	// Interface-dispatch candidates are deferred and grouped per call site so
+	// ambiguity (>1 impl in closure) is detected across all sibling edges,
+	// including siblings that cross the internal/external boundary.
+	dispatchGroups := make(map[dispatchGroupKey][]callEdge)
+	for _, e := range edges {
+		caller := graphNode{Component: key, Function: e.caller}
+		switch e.resolution {
+		case ResolutionExact:
+			adjacency[caller] = append(adjacency[caller], resolve(e)...)
+		case ResolutionInterfaceDispatch:
+			gk := dispatchKey(key, e)
+			dispatchGroups[gk] = append(dispatchGroups[gk], e)
+		case ResolutionNameOnly:
+			*suppressed = append(*suppressed, suppressedEdge(key, e, SuppressReasonNameOnly, candidateComponents(resolve(e))))
+		case ResolutionUnknown:
+			*suppressed = append(*suppressed, suppressedEdge(key, e, SuppressReasonUnknown, candidateComponents(resolve(e))))
+		default: // Future unhandled kind: fail closed.
+			*suppressed = append(*suppressed, suppressedEdge(key, e, SuppressReasonUnknown, candidateComponents(resolve(e))))
+		}
+	}
+	return dispatchGroups
+}
+
+func dispatchKey(key ComponentKey, e callEdge) dispatchGroupKey {
+	return dispatchGroupKey{
+		Component:  key,
+		Caller:     e.caller,
+		CallSite:   e.callSite,
+		MethodName: e.method,
+		Arity:      e.arity,
+	}
+}
+
+func applyDispatchGroups(
+	key ComponentKey,
+	groups map[dispatchGroupKey][]callEdge,
+	resolve edgeResolver,
+	adjacency map[graphNode][]graphNode,
+	suppressed *[]SuppressedEdge,
+) {
+	for _, gk := range sortedDispatchKeys(groups) {
+		targets := distinctTargets(groups[gk], resolve)
+		caller := graphNode{Component: key, Function: gk.Caller}
+		switch {
+		case len(targets) == 1:
+			adjacency[caller] = append(adjacency[caller], targets[0])
+		case len(targets) > 1:
+			*suppressed = append(*suppressed, ambiguousDispatchEdge(key, gk, targets))
+			// len(targets) == 0: no implementation in closure -> unreachable,
+			// nothing to traverse and nothing to record.
+		}
+	}
+}
+
+func distinctTargets(edges []callEdge, resolve edgeResolver) []graphNode {
+	distinct := map[graphNode]bool{}
+	var targets []graphNode
+	for _, e := range edges {
+		for _, t := range resolve(e) {
+			if distinct[t] {
+				continue
+			}
+			distinct[t] = true
+			targets = append(targets, t)
+		}
+	}
+	return targets
+}
+
+func ambiguousDispatchEdge(key ComponentKey, gk dispatchGroupKey, targets []graphNode) SuppressedEdge {
+	return SuppressedEdge{
+		Caller:     CallFrame{Component: key, Function: gk.Caller},
+		MethodName: gk.MethodName,
+		Arity:      gk.Arity,
+		Reason:     SuppressReasonAmbiguousDispatch,
+		Candidates: candidateComponents(targets),
+	}
 }
 
 func candidateComponents(targets []graphNode) []ComponentKey {
@@ -291,7 +363,7 @@ func trace(
 	visiting[current] = true
 	defer delete(visiting, current)
 
-	path = append(path, CallFrame{Component: current.Component, Function: current.Function})
+	path = append(path, CallFrame(current))
 	for _, op := range opsByNode[current] {
 		frames := append([]CallFrame(nil), path...)
 		out.Chains = append(out.Chains, FindingChain{

--- a/pkg/graphfrag/stitch_resolution_test.go
+++ b/pkg/graphfrag/stitch_resolution_test.go
@@ -102,8 +102,9 @@ func TestStitch_UnknownResolutionFailsClosed(t *testing.T) {
 }
 
 // TestStitch_InterfaceDispatchUniqueImplReaches proves that interface dispatch
-// is trusted when exactly one concrete implementation is present in the
-// dependency closure — the legitimate single-impl case we must NOT lose.
+// is trusted when exactly one concrete implementation is present in the current
+// component's direct dependencies — the legitimate single-impl case we must NOT
+// lose.
 func TestStitch_InterfaceDispatchUniqueImplReaches(t *testing.T) {
 	fragments := map[ComponentKey]Fragment{
 		componentA: {
@@ -216,11 +217,11 @@ func TestStitch_InterfaceDispatchAmbiguousDropsClosed(t *testing.T) {
 	}
 }
 
-// TestStitch_InterfaceDispatchUniqueInClosureReaches proves "unique" is judged
-// against the dependency closure, not the universe of fragments: a sibling
-// implementation that exists in storage but is NOT in the closure does not make
-// the call site ambiguous.
-func TestStitch_InterfaceDispatchUniqueInClosureReaches(t *testing.T) {
+// TestStitch_InterfaceDispatchUniqueInDirectDependenciesReaches proves "unique"
+// is judged against direct dependencies, not the universe of fragments: a
+// sibling implementation that exists in storage but is NOT a direct dependency
+// does not make the call site ambiguous.
+func TestStitch_InterfaceDispatchUniqueInDirectDependenciesReaches(t *testing.T) {
 	fragments := map[ComponentKey]Fragment{
 		componentA: {
 			Component: componentA,

--- a/pkg/graphfrag/stitch_resolution_test.go
+++ b/pkg/graphfrag/stitch_resolution_test.go
@@ -1,0 +1,464 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// componentE is a second concrete implementation host used to model ambiguous
+// interface dispatch (two impls of the same interface method live in closure).
+var componentE = ComponentKey{Purl: "pkg:maven/net.crypto/e-benign", Version: "1.0.0"}
+
+// TestStitch_NameOnlyDispatchDoesNotReach proves the core false-positive guard:
+// an edge the producer could only resolve by method name + arity (no receiver
+// type anchor) must NOT extend a reachability chain, even when a name-matching
+// crypto sink exists in the closure. This is the `inputDecryptorProvider.get(...)`
+// over-broad dispatch case that produced the bogus BCrypt chain.
+func TestStitch_NameOnlyDispatchDoesNotReach(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionNameOnly,
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "should-not-appear"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (name-only dispatch must fail closed): %#v", len(res.Chains), res.Chains)
+	}
+	if len(res.Suppressed) != 1 {
+		t.Fatalf("suppressed len = %d, want 1", len(res.Suppressed))
+	}
+	if res.Suppressed[0].Reason != SuppressReasonNameOnly {
+		t.Fatalf("suppressed reason = %q, want %q", res.Suppressed[0].Reason, SuppressReasonNameOnly)
+	}
+}
+
+// TestStitch_UnknownResolutionFailsClosed proves the schema default is safe:
+// an unclassified edge (zero-value resolution) is treated as untrusted and is
+// never traversed. This protects against a producer that forgets to classify.
+func TestStitch_UnknownResolutionFailsClosed(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					// Resolution intentionally left zero-value.
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "should-not-appear"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (unknown resolution must fail closed)", len(res.Chains))
+	}
+	if len(res.Suppressed) != 1 || res.Suppressed[0].Reason != SuppressReasonUnknown {
+		t.Fatalf("suppressed = %#v, want one unknown-resolution entry", res.Suppressed)
+	}
+}
+
+// TestStitch_InterfaceDispatchUniqueImplReaches proves that interface dispatch
+// is trusted when exactly one concrete implementation is present in the
+// dependency closure — the legitimate single-impl case we must NOT lose.
+func TestStitch_InterfaceDispatchUniqueImplReaches(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "iface-unique"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 {
+		t.Fatalf("chains len = %d, want 1 (unique interface impl must reach)", len(res.Chains))
+	}
+	if res.Chains[0].FindingID != "iface-unique" {
+		t.Fatalf("FindingID = %q, want iface-unique", res.Chains[0].FindingID)
+	}
+	if res.Chains[0].Confidence != ConfidenceHigh {
+		t.Fatalf("Confidence = %q, want %q", res.Chains[0].Confidence, ConfidenceHigh)
+	}
+}
+
+// TestStitch_InterfaceDispatchAmbiguousDropsClosed proves that when more than
+// one concrete implementation of the dispatched interface method is present in
+// the closure, the stitcher refuses to guess: it drops the whole call site and
+// records it. Name+arity dispatch would otherwise fabricate a crypto chain
+// through the wrong implementation.
+func TestStitch_InterfaceDispatchAmbiguousDropsClosed(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.BenignSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "should-not-appear"},
+			},
+		},
+		componentE: {
+			Component: componentE,
+			Functions: []Function{
+				{Signature: "net.crypto.BenignSink.encrypt(): void"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC, componentE}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (ambiguous interface dispatch must fail closed): %#v", len(res.Chains), res.Chains)
+	}
+	if len(res.Suppressed) != 1 {
+		t.Fatalf("suppressed len = %d, want 1 grouped ambiguous call site", len(res.Suppressed))
+	}
+	if res.Suppressed[0].Reason != SuppressReasonAmbiguousDispatch {
+		t.Fatalf("suppressed reason = %q, want %q", res.Suppressed[0].Reason, SuppressReasonAmbiguousDispatch)
+	}
+}
+
+// TestStitch_InterfaceDispatchUniqueInClosureReaches proves "unique" is judged
+// against the dependency closure, not the universe of fragments: a sibling
+// implementation that exists in storage but is NOT in the closure does not make
+// the call site ambiguous.
+func TestStitch_InterfaceDispatchUniqueInClosureReaches(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.BenignSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "iface-unique-closure"},
+			},
+		},
+		// componentE provides BenignSink but is NOT in the closure below.
+		componentE: {
+			Component: componentE,
+			Functions: []Function{
+				{Signature: "net.crypto.BenignSink.encrypt(): void"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC}} // only C in closure
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 {
+		t.Fatalf("chains len = %d, want 1 (only one impl in closure)", len(res.Chains))
+	}
+	if res.Chains[0].FindingID != "iface-unique-closure" {
+		t.Fatalf("FindingID = %q, want iface-unique-closure", res.Chains[0].FindingID)
+	}
+}
+
+// TestStitch_InternalNameOnlyEdgeDoesNotReach proves the policy applies to
+// intra-component (internal) edges too. The internal edge lives in the bridge
+// component B (not the root), so reachability depends on the edge being
+// traversed — not on the sink happening to be a root entry point.
+func TestStitch_InternalNameOnlyEdgeDoesNotReach(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "org.bridge.Bridge.bridge(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentB: {
+			Component: componentB,
+			Functions: []Function{
+				{Signature: "org.bridge.Bridge.bridge(): void"},
+				{Signature: "org.bridge.LocalSink.run(): void"},
+			},
+			InternalEdges: []InternalEdge{
+				{
+					Caller:     "org.bridge.Bridge.bridge(): void",
+					Callee:     "org.bridge.LocalSink.run(): void",
+					Resolution: ResolutionNameOnly,
+					MethodName: "run",
+					Arity:      0,
+					CallSite:   20,
+				},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "org.bridge.LocalSink.run(): void", FindingID: "should-not-appear"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentB}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (internal name-only must fail closed): %#v", len(res.Chains), res.Chains)
+	}
+	if len(res.Suppressed) != 1 || res.Suppressed[0].Reason != SuppressReasonNameOnly {
+		t.Fatalf("suppressed = %#v, want one name_only entry", res.Suppressed)
+	}
+}
+
+// TestStitch_InternalInterfaceUniqueImplReaches proves a unique-impl internal
+// interface dispatch is trusted (the legitimate single-impl intra-component case).
+func TestStitch_InternalInterfaceUniqueImplReaches(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "org.bridge.Bridge.bridge(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentB: {
+			Component: componentB,
+			Functions: []Function{
+				{Signature: "org.bridge.Bridge.bridge(): void"},
+				{Signature: "org.bridge.LocalSink.run(): void"},
+			},
+			InternalEdges: []InternalEdge{
+				{
+					Caller:       "org.bridge.Bridge.bridge(): void",
+					Callee:       "org.bridge.LocalSink.run(): void",
+					Resolution:   ResolutionInterfaceDispatch,
+					DeclaredType: "org.bridge.Sink",
+					MethodName:   "run",
+					Arity:        0,
+					CallSite:     20,
+				},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "org.bridge.LocalSink.run(): void", FindingID: "internal-iface-unique"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentB}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 || res.Chains[0].FindingID != "internal-iface-unique" {
+		t.Fatalf("chains = %#v, want one internal-iface-unique chain", res.Chains)
+	}
+}
+
+// TestStitch_CrossBoundaryDispatchSiblingsAreAmbiguous is the key correctness
+// case for "gate both": one interface call site in the bridge component expands
+// to a co-located impl (internal edge) AND a dependency impl (external call).
+// Judged separately each looks unique; judged together (same call site) they are
+// ambiguous and MUST fail closed. This guards against fabricated reachability
+// through the wrong implementation when impls straddle the component boundary.
+func TestStitch_CrossBoundaryDispatchSiblingsAreAmbiguous(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "org.bridge.Bridge.bridge(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentB: {
+			Component: componentB,
+			Functions: []Function{
+				{Signature: "org.bridge.Bridge.bridge(): void"},
+				{Signature: "org.bridge.LocalSink.run(): void"},
+			},
+			InternalEdges: []InternalEdge{
+				{
+					Caller:       "org.bridge.Bridge.bridge(): void",
+					Callee:       "org.bridge.LocalSink.run(): void",
+					Resolution:   ResolutionInterfaceDispatch,
+					DeclaredType: "org.bridge.Sink",
+					MethodName:   "run",
+					Arity:        0,
+					CallSite:     20,
+				},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "org.bridge.Bridge.bridge(): void",
+					TargetSignature: "net.crypto.RemoteSink.run(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "org.bridge.Sink",
+					MethodName:      "run",
+					Arity:           0,
+					CallSite:        20,
+				},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "org.bridge.LocalSink.run(): void", FindingID: "local-should-not-appear"},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.RemoteSink.run(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.RemoteSink.run(): void", FindingID: "remote-should-not-appear"},
+			},
+		},
+	}
+	deps := DependencyGraph{
+		componentA: {componentB},
+		componentB: {componentC},
+	}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (cross-boundary dispatch siblings are ambiguous): %#v", len(res.Chains), res.Chains)
+	}
+	if len(res.Suppressed) != 1 || res.Suppressed[0].Reason != SuppressReasonAmbiguousDispatch {
+		t.Fatalf("suppressed = %#v, want one ambiguous-dispatch entry grouped across the boundary", res.Suppressed)
+	}
+}

--- a/pkg/graphfrag/stitch_test.go
+++ b/pkg/graphfrag/stitch_test.go
@@ -180,6 +180,51 @@ func TestStitch_UsesDependencyGraphVersionsForExternalCalls(t *testing.T) {
 	})
 }
 
+func TestStitch_DoesNotResolveExternalCallsThroughTransitiveDependencies(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentB: {
+			Component: componentB,
+			Functions: []Function{
+				{Signature: "org.bridge.Bridge.bridge(): void"},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "transitive-only"},
+			},
+		},
+	}
+	deps := DependencyGraph{
+		componentA: {componentB},
+		componentB: {componentC},
+	}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 because C is not a direct dependency of A: %#v", len(res.Chains), res.Chains)
+	}
+}
+
 func assertChain(t *testing.T, got FindingChain, want []CallFrame) {
 	t.Helper()
 	if len(got.Frames) != len(want) {

--- a/pkg/graphfrag/stitch_test.go
+++ b/pkg/graphfrag/stitch_test.go
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import (
+	"errors"
+	"testing"
+)
+
+var (
+	componentA = ComponentKey{Purl: "pkg:maven/com.acme/a-app", Version: "1.0.0"}
+	componentB = ComponentKey{Purl: "pkg:maven/org.bridge/b-bridge", Version: "1.0.0"}
+	componentC = ComponentKey{Purl: "pkg:maven/net.crypto/c-crypto", Version: "1.0.0"}
+	componentD = ComponentKey{Purl: "pkg:maven/net.crypto/c-crypto", Version: "2.0.0"}
+)
+
+func TestStitch_ZeroFindingBridgeConnectsRootToTransitiveCrypto(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Module:    "com.acme:a-app",
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void", FilePath: "AppEntry.java"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "org.bridge.Bridge.bridge(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentB: {
+			Component: componentB,
+			Module:    "org.bridge:b-bridge",
+			Functions: []Function{
+				{Signature: "org.bridge.Bridge.bridge(): void", FilePath: "Bridge.java"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "org.bridge.Bridge.bridge(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+			// This is the point of the test: B has no crypto operations, but
+			// it is still required as the bridge between A and C.
+			CryptoOperations: nil,
+		},
+		componentC: {
+			Component: componentC,
+			Module:    "net.crypto:c-crypto",
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void", FilePath: "CryptoSink.java"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{
+					Function:  "net.crypto.CryptoSink.encrypt(): void",
+					FindingID: "beaecdb7",
+					RuleID:    "java.crypto.cipher.getinstance",
+					Symbol:    "javax.crypto.Cipher.getInstance",
+				},
+			},
+		},
+	}
+	deps := DependencyGraph{
+		componentA: {componentB},
+		componentB: {componentC},
+	}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 {
+		t.Fatalf("chains len = %d, want 1", len(res.Chains))
+	}
+	assertChain(t, res.Chains[0], []CallFrame{
+		{Component: componentA, Function: "com.acme.app.AppEntry.entry(): void"},
+		{Component: componentB, Function: "org.bridge.Bridge.bridge(): void"},
+		{Component: componentC, Function: "net.crypto.CryptoSink.encrypt(): void"},
+	})
+	if res.Chains[0].FindingID != "beaecdb7" {
+		t.Fatalf("FindingID = %q, want beaecdb7", res.Chains[0].FindingID)
+	}
+}
+
+func TestStitch_MissingBridgeFragmentFailsClosed(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "org.bridge.Bridge.bridge(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "beaecdb7"},
+			},
+		},
+	}
+	deps := DependencyGraph{
+		componentA: {componentB},
+		componentB: {componentC},
+	}
+
+	_, err := Stitch(componentA, deps, fragments)
+	var missing *ErrMissingFragment
+	if !errors.As(err, &missing) {
+		t.Fatalf("err = %v, want *ErrMissingFragment", err)
+	}
+	if len(missing.Components) != 1 || missing.Components[0] != componentB {
+		t.Fatalf("missing components = %#v, want only B", missing.Components)
+	}
+}
+
+func TestStitch_UsesDependencyGraphVersionsForExternalCalls(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionExact,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "v1-finding"},
+			},
+		},
+		componentD: {
+			Component: componentD,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "v2-finding"},
+			},
+		},
+	}
+	deps := DependencyGraph{
+		componentA: {componentC},
+	}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 {
+		t.Fatalf("chains len = %d, want 1", len(res.Chains))
+	}
+	if res.Chains[0].FindingID != "v1-finding" {
+		t.Fatalf("FindingID = %q, want v1-finding from dependency graph version", res.Chains[0].FindingID)
+	}
+	assertChain(t, res.Chains[0], []CallFrame{
+		{Component: componentA, Function: "com.acme.app.AppEntry.entry(): void"},
+		{Component: componentC, Function: "net.crypto.CryptoSink.encrypt(): void"},
+	})
+}
+
+func assertChain(t *testing.T, got FindingChain, want []CallFrame) {
+	t.Helper()
+	if len(got.Frames) != len(want) {
+		t.Fatalf("frames len = %d, want %d: %#v", len(got.Frames), len(want), got.Frames)
+	}
+	for i := range want {
+		if got.Frames[i] != want[i] {
+			t.Fatalf("frame[%d] = %#v, want %#v", i, got.Frames[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Introduces **edge-resolution classification** in the call-graph builder and a new public **`pkg/graphfrag`** package: the reusable graph-fragment model + a tiered fail-closed stitcher that composes per-component fragments into transitive crypto-reachability chains. Also wires the graph-fragment export into the CLI and makes `--scan-dependencies` parse non-crypto bridge dependencies. This is the foundation for graph-fragment mining/stitching (the mining service consumes `pkg/graphfrag` in a separate PR).

## Problem

A merged `--scan-dependencies` graph synthesizes cross-component edges by **dispatch heuristics** — interface methods expanded to every name+arity match in a namespace, fluent chains guessed by name. These fabricate impressive-but-wrong deep chains. Canonical case: a DRBG's `generate()` name-collides with `BCrypt.generate#3`, so an app appears to reach bcrypt password hashing it never calls.

## What changed

- **Edge classification (`internal/callgraph`)**: every caller→callee edge is tagged `exact`, `interface_dispatch`, or `name_only` at build time (`CallGraph.EdgeResolutions`).
- **Wire schema**: graph-fragment export bumped to **`graph-fragment-1.1`** — `internal_edges[]`/`external_calls[]` carry `resolution`, `declared_type`, `method_name`, `arity`. Additive (1.0 fragments decode as unresolved/untrusted). Docs: `docs/OUTPUT_FORMATS.md` → *Graph Fragment Export*.
- **`pkg/graphfrag`** (new, public, dependency-light): fragment model, `GraphFragmentExport` schema, `DecodeFragment`, and `Stitch`. Policy is **tiered, fail-closed**: traverse `exact` and unique-impl `interface_dispatch`; drop ambiguous interface dispatch (>1 impl in closure) and `name_only`, recording rather than emitting. Mirrors the `pkg/stitch` ownership rationale.
- **CLI (`internal/cli/scan.go`)**: `--export-graph-fragment`, `--export-graph-fragment-format`, `--java-compiled-artifact`.
- **Non-crypto bridge deps (`internal/engine/dependency_scanner.go`)**: `--scan-dependencies` now source-parses every resolved dependency, not just crypto-bearing ones, so a non-crypto dep can bridge `A → B(no crypto) → C(crypto)`.

## Validation (real BouncyCastle + client-encryption-java)

- **False positive killed**: `SP800SecureRandom.nextBytes → BCrypt.generate#3` (3 `interface_dispatch` edges) suppressed; app→BCrypt drops to **0 paths**.
- **True positives preserved**: BCrypt's genuine callers (`OpenBSDBCrypt`, 5 `exact` edges) intact; 25 distinct real JCA/JCE symbols still reachable; clean `--scan-dependencies` is 96.7% exact-reachable.
- **Zero-crypto bridge**: `A → B(no crypto) → C(crypto)` mined separately stitches across B; if B is **not** mined the stitch fails closed (`ErrMissingFragment`) rather than silently dropping the path.

## Notes

- Version: targets **v0.6.0** (CHANGELOG updated).
- No change to the customer-facing `--export-callgraph` schema; resolution lives only on the graph-fragment export.