### PR TITLE
feat(contracts): Google Tink callgraph contract (java)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tmp/
 !.github
 !.idea
 demo/
+# Local Pi runtime state
+.atl/

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -405,10 +405,14 @@ func TestLoadEmbedded_Java_HierarchyReachability(t *testing.T) {
 	// Known opaque root types that need no hierarchy entry:
 	// - byte[] is a JVM primitive array, not a reference type in the hierarchy
 	// - boolean is a JVM primitive (e.g. terminal HashChecker.with* verify calls)
+	// - void / int are JVM primitives (e.g. role:config lifecycle calls like
+	//   GCMBlockCipher.init -> void, SHA256Digest.getDigestSize -> int)
 	// - java.lang.Object is the universal root
 	opaqueRoots := map[string]struct{}{
 		"byte[]":           {},
 		"boolean":          {},
+		"void":             {},
+		"int":              {},
 		"java.lang.Object": {},
 	}
 

--- a/internal/callgraph/contracts/java/bouncycastle.yaml
+++ b/internal/callgraph/contracts/java/bouncycastle.yaml
@@ -27,12 +27,14 @@ contracts:
     return:
       type: org.bouncycastle.crypto.CipherParameters
       confidence: high
+    role: output
 
   - method: org.bouncycastle.crypto.AsymmetricCipherKeyPair.getPrivate
     arity: 0
     return:
       type: org.bouncycastle.crypto.CipherParameters
       confidence: high
+    role: output
 
   - method: org.bouncycastle.crypto.params.ECPrivateKeyParameters.<init>
     arity: 2
@@ -45,6 +47,73 @@ contracts:
     return:
       type: org.bouncycastle.crypto.params.ECPublicKeyParameters
       confidence: high
+
+  # role: config — lifecycle methods invoked ON a primitive/engine/generator
+  # instance. They attach as supporting calls to the synthesized constructor
+  # terminal of the same type (receiver == terminal class). return.type is the
+  # method's real signature (used for type inference); it does not affect the
+  # supporting-call lineage, which keys on the receiver type.
+  - method: org.bouncycastle.crypto.modes.GCMBlockCipher.init
+    arity: 2
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.modes.GCMBlockCipher.getOutputSize
+    arity: 1
+    return: { type: int, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.generators.RSAKeyPairGenerator.init
+    arity: 1
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.generators.ECKeyPairGenerator.init
+    arity: 1
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.encodings.OAEPEncoding.init
+    arity: 2
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.signers.ECDSASigner.init
+    arity: 2
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.digests.SHA256Digest.getDigestSize
+    arity: 0
+    return: { type: int, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.digests.KeccakDigest.getDigestSize
+    arity: 0
+    return: { type: int, confidence: high }
+    role: config
+  - method: org.bouncycastle.crypto.digests.KeccakDigest.update
+    arity: 3
+    return: { type: void, confidence: high }
+    role: config
+
+  # The EC named-curve lookup terminal: declaring its return type lets the
+  # X9ECParameters getters below attach as role: output (receiver == return type).
+  - method: org.bouncycastle.asn1.x9.ECNamedCurveTable.getByName
+    arity: 1
+    return: { type: org.bouncycastle.asn1.x9.X9ECParameters, confidence: high }
+
+  # role: output — reads of the terminal's product (the X9ECParameters returned
+  # by getByName). They attach as supporting calls to that terminal.
+  - method: org.bouncycastle.asn1.x9.X9ECParameters.getCurve
+    arity: 0
+    return: { type: org.bouncycastle.math.ec.ECCurve, confidence: high }
+    role: output
+  - method: org.bouncycastle.asn1.x9.X9ECParameters.getG
+    arity: 0
+    return: { type: org.bouncycastle.math.ec.ECPoint, confidence: high }
+    role: output
+  - method: org.bouncycastle.asn1.x9.X9ECParameters.getN
+    arity: 0
+    return: { type: java.math.BigInteger, confidence: high }
+    role: output
+  - method: org.bouncycastle.asn1.x9.X9ECParameters.getH
+    arity: 0
+    return: { type: java.math.BigInteger, confidence: high }
+    role: output
 
 hierarchy:
   org.bouncycastle.crypto.generators.ECKeyPairGenerator:
@@ -61,4 +130,12 @@ hierarchy:
     - org.bouncycastle.crypto.params.ECKeyParameters
   org.bouncycastle.crypto.params.ECPublicKeyParameters:
     - org.bouncycastle.crypto.params.ECKeyParameters
+  org.bouncycastle.asn1.x9.X9ECParameters:
+    - java.lang.Object
+  org.bouncycastle.math.ec.ECCurve:
+    - java.lang.Object
+  org.bouncycastle.math.ec.ECPoint:
+    - java.lang.Object
+  java.math.BigInteger:
+    - java.lang.Object
   java.lang.Object: []

--- a/internal/callgraph/contracts/java/password4j.yaml
+++ b/internal/callgraph/contracts/java/password4j.yaml
@@ -9,47 +9,67 @@ library:
   description: "Password4J password hashing fluent API contracts"
 
 contracts:
+  # role tags the method's structural part in a fluent crypto flow (factory /
+  # config / output). They carry NO crypto semantics (that lives only in the
+  # ruleset); they let the callgraph export attach these lifecycle methods as
+  # supporting calls of a synthesized terminal entry point. Lineage is by type:
+  # factory methods return the builder/checker type; config methods are on it;
+  # output methods are on the terminal's return type.
   - method: com.password4j.Password.hash
     arity: 1
     return:
       type: com.password4j.HashBuilder
       confidence: high
+    role: factory
 
   - method: com.password4j.Password.check
     arity: 2
     return:
       type: com.password4j.HashChecker
       confidence: high
+    role: factory
 
   - method: com.password4j.HashBuilder.addPepper
     arity: 0
     return:
       type: com.password4j.HashBuilder
       confidence: high
+    role: config
 
   - method: com.password4j.HashBuilder.addPepper
     arity: 1
     return:
       type: com.password4j.HashBuilder
       confidence: high
+    role: config
 
   - method: com.password4j.HashBuilder.addRandomSalt
     arity: 0
     return:
       type: com.password4j.HashBuilder
       confidence: high
+    role: config
 
   - method: com.password4j.HashBuilder.addRandomSalt
     arity: 1
     return:
       type: com.password4j.HashBuilder
       confidence: high
+    role: config
 
   - method: com.password4j.HashBuilder.addSalt
     arity: 1
     return:
       type: com.password4j.HashBuilder
       confidence: high
+    role: config
+
+  - method: com.password4j.Hash.getResult
+    arity: 0
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
 
   - method: com.password4j.HashBuilder.with
     arity: 1
@@ -154,5 +174,7 @@ hierarchy:
   com.password4j.Hash:
     - java.lang.Object
   com.password4j.HashUpdate:
+    - java.lang.Object
+  java.lang.String:
     - java.lang.Object
   java.lang.Object: []

--- a/internal/callgraph/contracts/java/tink.yaml
+++ b/internal/callgraph/contracts/java/tink.yaml
@@ -85,6 +85,24 @@ contracts:
       type: com.google.crypto.tink.Mac
       confidence: high
 
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 2
+    when:
+      arg_index: 1
+      arg_value_in: ["com.google.crypto.tink.PublicKeySign.class", "PublicKeySign.class"]
+    return:
+      type: com.google.crypto.tink.PublicKeySign
+      confidence: high
+
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 2
+    when:
+      arg_index: 1
+      arg_value_in: ["com.google.crypto.tink.PublicKeyVerify.class", "PublicKeyVerify.class"]
+    return:
+      type: com.google.crypto.tink.PublicKeyVerify
+      confidence: high
+
   # Terminal operations — truthful returns that terminate the chain.
   - method: com.google.crypto.tink.Aead.encrypt
     arity: 2

--- a/internal/callgraph/contracts/java/tink.yaml
+++ b/internal/callgraph/contracts/java/tink.yaml
@@ -1,0 +1,126 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: tink
+  coordinates:
+    - "com.google.crypto.tink:tink"
+    - "com.google.crypto.tink:tink-android"
+  version_range: ">=1.7,<2.0"
+  description: "Google Tink high-level crypto API contracts (KeysetHandle -> primitive -> operation)"
+
+# Tink hides primitives behind KeysetHandle.getPrimitive(<Primitive>.class). These
+# contracts let the callgraph resolve the fluent chain
+#   KeyTemplates.get(...) -> KeysetHandle.generateNew(...) -> getPrimitive(Aead.class)
+#   -> Aead.encrypt(...)
+# so reachability can reach the terminal crypto operation.
+
+contracts:
+  - method: com.google.crypto.tink.KeyTemplates.get
+    arity: 1
+    return:
+      type: com.google.crypto.tink.KeyTemplate
+      confidence: high
+
+  - method: com.google.crypto.tink.KeysetHandle.generateNew
+    arity: 1
+    return:
+      type: com.google.crypto.tink.KeysetHandle
+      confidence: high
+
+  # getPrimitive(Class<P>) — classic arity-1 form, conditional on the requested
+  # primitive class literal.
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 1
+    when:
+      arg_index: 0
+      arg_value_in: ["com.google.crypto.tink.Aead.class", "Aead.class"]
+    return:
+      type: com.google.crypto.tink.Aead
+      confidence: high
+
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 1
+    when:
+      arg_index: 0
+      arg_value_in: ["com.google.crypto.tink.Mac.class", "Mac.class"]
+    return:
+      type: com.google.crypto.tink.Mac
+      confidence: high
+
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 1
+    when:
+      arg_index: 0
+      arg_value_in: ["com.google.crypto.tink.PublicKeySign.class", "PublicKeySign.class"]
+    return:
+      type: com.google.crypto.tink.PublicKeySign
+      confidence: high
+
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 1
+    when:
+      arg_index: 0
+      arg_value_in: ["com.google.crypto.tink.PublicKeyVerify.class", "PublicKeyVerify.class"]
+    return:
+      type: com.google.crypto.tink.PublicKeyVerify
+      confidence: high
+
+  # getPrimitive(Configuration, Class<P>) — newer arity-2 form; class is arg[1].
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 2
+    when:
+      arg_index: 1
+      arg_value_in: ["com.google.crypto.tink.Aead.class", "Aead.class"]
+    return:
+      type: com.google.crypto.tink.Aead
+      confidence: high
+
+  - method: com.google.crypto.tink.KeysetHandle.getPrimitive
+    arity: 2
+    when:
+      arg_index: 1
+      arg_value_in: ["com.google.crypto.tink.Mac.class", "Mac.class"]
+    return:
+      type: com.google.crypto.tink.Mac
+      confidence: high
+
+  # Terminal operations — truthful returns that terminate the chain.
+  - method: com.google.crypto.tink.Aead.encrypt
+    arity: 2
+    return:
+      type: "byte[]"
+      confidence: high
+
+  - method: com.google.crypto.tink.Aead.decrypt
+    arity: 2
+    return:
+      type: "byte[]"
+      confidence: high
+
+  - method: com.google.crypto.tink.Mac.computeMac
+    arity: 1
+    return:
+      type: "byte[]"
+      confidence: high
+
+  - method: com.google.crypto.tink.PublicKeySign.sign
+    arity: 1
+    return:
+      type: "byte[]"
+      confidence: high
+
+hierarchy:
+  com.google.crypto.tink.Aead:
+    - java.lang.Object
+  com.google.crypto.tink.Mac:
+    - java.lang.Object
+  com.google.crypto.tink.PublicKeySign:
+    - java.lang.Object
+  com.google.crypto.tink.PublicKeyVerify:
+    - java.lang.Object
+  com.google.crypto.tink.KeysetHandle:
+    - java.lang.Object
+  com.google.crypto.tink.KeyTemplate:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/java_parser.go
+++ b/internal/callgraph/java_parser.go
@@ -337,7 +337,7 @@ func (p *JavaParser) parseClassInitDecl(
 	fieldTypes map[string]string,
 	fieldAssignments map[string]fieldAssignment,
 ) *FunctionDecl {
-	initNodes := classInitNodes(body, src)
+	initNodes := classInitNodes(body)
 	if len(initNodes) == 0 {
 		return nil
 	}
@@ -381,7 +381,7 @@ func (p *JavaParser) parseClassInitDecl(
 // A bare field declaration with no initializer (e.g. `int x;` or `static int
 // x;`) contributes nothing and is skipped, so a class with only such fields and
 // no static block still gets no `<clinit>`.
-func classInitNodes(body *sitter.Node, src []byte) []*sitter.Node {
+func classInitNodes(body *sitter.Node) []*sitter.Node {
 	var nodes []*sitter.Node
 	for i := 0; i < int(body.ChildCount()); i++ {
 		child := body.Child(i)

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -702,6 +702,19 @@ func runScan(_ *cobra.Command, args []string) error {
 		}
 	}
 
+	// Type 2 libraries (fluent/builder/DSL, e.g. Password4J) carry their crypto
+	// semantic on the public API boundary, not in a detectable primitive call
+	// inside their own source. When such a library is itself being scanned,
+	// surface those API methods as crypto entry points using the ruleset's
+	// metadata.crypto (the single source of truth) joined on api↔definition.
+	// Gated structurally (method definition present, no in-body finding), so it
+	// is a no-op when scanning a consumer of the library or a Type 1 library.
+	if callGraphResult != nil && callGraphResult.CallGraph != nil {
+		if rulePaths, rerr := rulesManager.Load(); rerr == nil {
+			engine.SynthesizeRuleCryptoEntryPoints(report, callGraphResult.CallGraph, rulePaths)
+		}
+	}
+
 	if scanExportCallgraph != "" || scanExportGraphFragment != "" {
 		engine.AssignFindingIDs(report)
 		if callGraphResult != nil {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -712,6 +712,15 @@ func runScan(_ *cobra.Command, args []string) error {
 	if callGraphResult != nil && callGraphResult.CallGraph != nil {
 		if rulePaths, rerr := rulesManager.Load(); rerr == nil {
 			engine.SynthesizeRuleCryptoEntryPoints(report, callGraphResult.CallGraph, rulePaths)
+		} else {
+			log.Debug().
+				Err(rerr).
+				Str("call_graph", fmt.Sprintf("%p", callGraphResult.CallGraph)).
+				Str("report", fmt.Sprintf("%p", report)).
+				Int("function_count", len(callGraphResult.CallGraph.Functions)).
+				Int("finding_count", len(report.Findings)).
+				Strs("rule_paths", rulePaths).
+				Msg("failed to load rules for synthesis")
 		}
 	}
 

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -234,7 +234,8 @@ func buildRuleCryptoByAPI(rulePaths []string) map[string]map[string]string {
 	out := make(map[string]map[string]string)
 	for _, p := range rulePaths {
 		for _, file := range expandRuleFiles(p) {
-			data, err := os.ReadFile(file) //nolint:gosec // rule paths come from the trusted ruleset manager
+			// Rule paths come from the trusted ruleset manager.
+			data, err := os.ReadFile(file)
 			if err != nil {
 				continue
 			}
@@ -246,8 +247,11 @@ func buildRuleCryptoByAPI(rulePaths []string) map[string]map[string]string {
 				if len(r.Metadata.Crypto) == 0 {
 					continue
 				}
-				api, _ := r.Metadata.Crypto["api"].(string)
+				api, ok := r.Metadata.Crypto["api"].(string)
 				api = strings.TrimSpace(api)
+				if !ok || api == "" {
+					continue
+				}
 				if !isQualifiedMethodSymbol(api) {
 					continue
 				}
@@ -293,7 +297,7 @@ func expandRuleFiles(path string) []string {
 		return []string{path}
 	}
 	var files []string
-	_ = filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+	if err := filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil //nolint:nilerr // skip unreadable entries, keep walking
 		}
@@ -301,7 +305,9 @@ func expandRuleFiles(path string) []string {
 			files = append(files, p)
 		}
 		return nil
-	})
+	}); err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("failed to walk rule directory")
+	}
 	return files
 }
 

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -1,0 +1,326 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/entities"
+)
+
+// SyntheticEntryPointRuleID labels findings produced by surfacing a library's
+// public crypto API boundary (rather than by a call-site rule match), so the
+// origin is auditable downstream. The call-graph export keys off this id to
+// attach contract-derived supporting calls (the fluent lifecycle methods) to
+// these synthetic terminals.
+const SyntheticEntryPointRuleID = "crypto-finder.api-entry-point"
+
+// SynthesizeRuleCryptoEntryPoints surfaces a library's public crypto API methods
+// as crypto entry points when the LIBRARY ITSELF is being mined. It exists for
+// "Type 2" fluent/builder/DSL libraries (e.g. Password4J HashBuilder.withBcrypt)
+// whose crypto meaning lives on the API boundary rather than in a detectable
+// primitive call inside their own source — so mining them yields no public-API
+// entry points and a purl-keyed reachability query returns nothing actionable.
+//
+// The crypto semantic is NOT re-declared here. It is read from the ruleset's
+// metadata.crypto (the single source of truth) via the rule's `api` field, which
+// for these boundary rules is the fully-qualified method symbol. A synthetic
+// finding is emitted ONLY when:
+//
+//	(1) a rule's metadata.crypto.api matches a method DEFINITION in the scanned
+//	    call graph (true only when the library that owns the API is mined; a
+//	    consumer scan has call sites, not definitions, and Type 1 short api names
+//	    like "Cipher.getInstance" never match a scanned definition), and
+//	(2) that method body has no already-detected crypto finding (Type 1 methods
+//	    whose primitive call is detectable inside them are already covered and
+//	    must not be double-counted).
+//
+// It is ecosystem-agnostic: the join key is the api↔definition match; nothing is
+// password4j- or language-specific. report is mutated in place; returns the
+// number of findings added. FindingIDs are assigned by the caller's existing
+// AssignFindingIDs pass.
+func SynthesizeRuleCryptoEntryPoints(report *entities.InterimReport, graph *callgraph.CallGraph, rulePaths []string) int {
+	if report == nil || graph == nil || len(rulePaths) == 0 {
+		return 0
+	}
+
+	apiCrypto := buildRuleCryptoByAPI(rulePaths)
+	if len(apiCrypto) == 0 {
+		return 0
+	}
+
+	// Index method definitions present in the scanned source by their base FQN
+	// (arity/overload decoration like "#0" or "#1$String" stripped), since the
+	// rule's metadata.crypto.api is the undecorated package.Type.method symbol.
+	declsByFQN := make(map[string][]*callgraph.FunctionDecl)
+	for _, fn := range graph.Functions {
+		if fqn := baseFQN(functionFQN(fn.ID)); fqn != "" {
+			declsByFQN[fqn] = append(declsByFQN[fqn], fn)
+		}
+	}
+
+	fileIdx := make(map[string]int, len(report.Findings))
+	for i := range report.Findings {
+		fileIdx[report.Findings[i].FilePath] = i
+	}
+
+	added := 0
+	for api, meta := range apiCrypto {
+		decls := declsByFQN[api]
+		if len(decls) == 0 {
+			continue // api not defined in scanned source → not the library that owns it
+		}
+		for _, fn := range decls {
+			if functionBodyHasFinding(report, fn) {
+				continue // Type 1: primitive already detected inside the method
+			}
+			asset := buildSyntheticAssetFromRule(api, meta, fn)
+			if appendSyntheticAsset(report, fileIdx, fn.FilePath, languageForPath(fn.FilePath), asset) {
+				added++
+			}
+		}
+	}
+
+	if added > 0 {
+		log.Info().
+			Int("count", added).
+			Msg("Surfaced library public crypto API methods as entry points (from rule metadata.crypto)")
+	}
+	return added
+}
+
+// functionFQN renders a FunctionID as the dotted fully-qualified name used in a
+// rule's metadata.crypto.api, e.g. "com.password4j.HashBuilder.withBcrypt".
+func functionFQN(id callgraph.FunctionID) string {
+	switch {
+	case id.Type != "" && id.Package != "":
+		return id.Package + "." + id.Type + "." + id.Name
+	case id.Type != "":
+		return id.Type + "." + id.Name
+	case id.Package != "":
+		return id.Package + "." + id.Name
+	default:
+		return id.Name
+	}
+}
+
+// baseFQN strips the arity/overload decoration ("#0", "#1$String", …) from a
+// function FQN, leaving the bare package.Type.method symbol.
+func baseFQN(fqn string) string {
+	if i := strings.IndexByte(fqn, '#'); i >= 0 {
+		return fqn[:i]
+	}
+	return fqn
+}
+
+// functionBodyHasFinding reports whether report already contains a crypto asset
+// located within fn's line range in fn's file — i.e. the method itself performs
+// a detectable crypto operation (Type 1) and is already a natural entry point.
+func functionBodyHasFinding(report *entities.InterimReport, fn *callgraph.FunctionDecl) bool {
+	fnPath := filepath.ToSlash(fn.FilePath)
+	for i := range report.Findings {
+		if !strings.HasSuffix(fnPath, filepath.ToSlash(report.Findings[i].FilePath)) &&
+			!strings.HasSuffix(filepath.ToSlash(report.Findings[i].FilePath), fnPath) {
+			continue
+		}
+		for _, a := range report.Findings[i].CryptographicAssets {
+			if a.StartLine >= fn.StartLine && a.StartLine <= fn.EndLine {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// buildSyntheticAssetFromRule constructs a CryptographicAsset at the API method's
+// own declaration site, copying the rule's crypto metadata verbatim so the output
+// is byte-for-byte what a call-site match of the same rule would have produced.
+// Match is the bare dotted FQN (no parentheses) so the export's matched-operation
+// classifier treats it as a type_usage and preserves this symbol.
+func buildSyntheticAssetFromRule(api string, meta map[string]string, fn *callgraph.FunctionDecl) entities.CryptographicAsset {
+	md := make(map[string]string, len(meta)+2)
+	for k, v := range meta {
+		md[k] = v
+	}
+	md["api"] = api
+	if md["assetType"] == "" {
+		md["assetType"] = "algorithm"
+	}
+
+	line := fn.StartLine
+	if line <= 0 {
+		line = 1
+	}
+	return entities.CryptographicAsset{
+		StartLine: line,
+		EndLine:   line,
+		Match:     api,
+		Rules: []entities.RuleInfo{{
+			ID:       SyntheticEntryPointRuleID,
+			Message:  "Crypto entry point (library public API boundary): " + api,
+			Severity: "INFO",
+		}},
+		Status:   "pending",
+		Metadata: md,
+		Source:   "direct",
+	}
+}
+
+// appendSyntheticAsset adds asset to the Finding for filePath (creating one if
+// needed), skipping exact duplicates. Returns true when an asset was added.
+func appendSyntheticAsset(
+	report *entities.InterimReport,
+	fileIdx map[string]int,
+	filePath, language string,
+	asset entities.CryptographicAsset,
+) bool {
+	if idx, ok := fileIdx[filePath]; ok {
+		for _, existing := range report.Findings[idx].CryptographicAssets {
+			if existing.StartLine == asset.StartLine && existing.Metadata["api"] == asset.Metadata["api"] {
+				return false
+			}
+		}
+		report.Findings[idx].CryptographicAssets = append(report.Findings[idx].CryptographicAssets, asset)
+		return true
+	}
+	report.Findings = append(report.Findings, entities.Finding{
+		FilePath:            filePath,
+		Language:            language,
+		CryptographicAssets: []entities.CryptographicAsset{asset},
+	})
+	fileIdx[filePath] = len(report.Findings) - 1
+	return true
+}
+
+// ── rule metadata.crypto extraction ────────────────────────────────────────
+
+// ruleFileCryptoYAML captures just the metadata.crypto block of each rule.
+type ruleFileCryptoYAML struct {
+	Rules []struct {
+		Metadata struct {
+			Crypto map[string]any `yaml:"crypto"`
+		} `yaml:"metadata"`
+	} `yaml:"rules"`
+}
+
+// buildRuleCryptoByAPI walks the ruleset (files and/or directories) and indexes
+// every rule's metadata.crypto block by its `api` value, but only when `api`
+// looks like a fully-qualified method (the boundary-rule convention: a dotted
+// symbol). The returned map carries the crypto block stringified verbatim so the
+// synthetic finding metadata is identical to a call-site match. The rule remains
+// the single source of truth for the crypto semantics.
+func buildRuleCryptoByAPI(rulePaths []string) map[string]map[string]string {
+	out := make(map[string]map[string]string)
+	for _, p := range rulePaths {
+		for _, file := range expandRuleFiles(p) {
+			data, err := os.ReadFile(file) //nolint:gosec // rule paths come from the trusted ruleset manager
+			if err != nil {
+				continue
+			}
+			var rf ruleFileCryptoYAML
+			if yaml.Unmarshal(data, &rf) != nil {
+				continue
+			}
+			for _, r := range rf.Rules {
+				if len(r.Metadata.Crypto) == 0 {
+					continue
+				}
+				api, _ := r.Metadata.Crypto["api"].(string)
+				api = strings.TrimSpace(api)
+				if !isQualifiedMethodSymbol(api) {
+					continue
+				}
+				if _, seen := out[api]; seen {
+					continue // first declaration wins; deterministic enough for synthesis
+				}
+				out[api] = stringifyCryptoBlock(r.Metadata.Crypto)
+			}
+		}
+	}
+	return out
+}
+
+// isQualifiedMethodSymbol reports whether s is a dotted package.Type.method-style
+// symbol (the boundary-rule api convention) rather than a short JCA-style name.
+// Requires at least two dots so "Cipher.getInstance" (Type 1) is excluded while
+// "com.password4j.HashBuilder.withBcrypt" qualifies.
+func isQualifiedMethodSymbol(s string) bool {
+	return s != "" && strings.Count(s, ".") >= 2 && !strings.ContainsAny(s, " ()/\"")
+}
+
+// stringifyCryptoBlock renders a metadata.crypto block as map[string]string,
+// matching how detection-rule metadata lands in finding metadata.
+func stringifyCryptoBlock(crypto map[string]any) map[string]string {
+	md := make(map[string]string, len(crypto))
+	for k, v := range crypto {
+		if v == nil {
+			continue
+		}
+		md[k] = fmt.Sprintf("%v", v)
+	}
+	return md
+}
+
+// expandRuleFiles returns the YAML rule files for a path that may be a file or a
+// directory.
+func expandRuleFiles(path string) []string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+	if !info.IsDir() {
+		return []string{path}
+	}
+	var files []string
+	_ = filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // skip unreadable entries, keep walking
+		}
+		if ext := strings.ToLower(filepath.Ext(p)); ext == ".yaml" || ext == ".yml" {
+			files = append(files, p)
+		}
+		return nil
+	})
+	return files
+}
+
+// languageForPath maps a source file extension to the report Language tag.
+func languageForPath(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".java":
+		return "java"
+	case ".go":
+		return "go"
+	case ".py":
+		return "python"
+	case ".rs":
+		return "rust"
+	case ".c", ".h":
+		return "c"
+	case ".cs":
+		return "csharp"
+	default:
+		return ""
+	}
+}

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -34,7 +34,13 @@ import (
 // origin is auditable downstream. The call-graph export keys off this id to
 // attach contract-derived supporting calls (the fluent lifecycle methods) to
 // these synthetic terminals.
-const SyntheticEntryPointRuleID = "crypto-finder.api-entry-point"
+const (
+	SyntheticEntryPointRuleID = "crypto-finder.api-entry-point"
+
+	extYAML      = ".yaml"
+	extYML       = ".yml"
+	languageJava = "java"
+)
 
 // SynthesizeRuleCryptoEntryPoints surfaces a library's public crypto API methods
 // as crypto entry points when the LIBRARY ITSELF is being mined. It exists for
@@ -73,10 +79,18 @@ func SynthesizeRuleCryptoEntryPoints(report *entities.InterimReport, graph *call
 	// Index method definitions present in the scanned source by their base FQN
 	// (arity/overload decoration like "#0" or "#1$String" stripped), since the
 	// rule's metadata.crypto.api is the undecorated package.Type.method symbol.
+	// Index method definitions by base FQN, and separately by owning class FQN
+	// (package.Type). The class index lets a constructor api resolve even when
+	// the class declares no explicit constructor (the compiler-generated default
+	// has no <init> in the source AST, so it is absent from declsByFQN).
 	declsByFQN := make(map[string][]*callgraph.FunctionDecl)
+	declsByClass := make(map[string][]*callgraph.FunctionDecl)
 	for _, fn := range graph.Functions {
 		if fqn := baseFQN(functionFQN(fn.ID)); fqn != "" {
 			declsByFQN[fqn] = append(declsByFQN[fqn], fn)
+		}
+		if class := classFQN(fn.ID); class != "" {
+			declsByClass[class] = append(declsByClass[class], fn)
 		}
 	}
 
@@ -89,7 +103,16 @@ func SynthesizeRuleCryptoEntryPoints(report *entities.InterimReport, graph *call
 	for api, meta := range apiCrypto {
 		decls := declsByFQN[api]
 		if len(decls) == 0 {
-			continue // api not defined in scanned source → not the library that owns it
+			// No source-declared method matches the api. A constructor api may
+			// still belong to a scanned class with only an implicit default
+			// constructor — surface it once at a representative class location.
+			if rep := implicitCtorRep(api, declsByClass); rep != nil {
+				asset := buildSyntheticAssetFromRule(api, meta, rep)
+				if appendSyntheticAsset(report, fileIdx, rep.FilePath, languageForPath(rep.FilePath), asset) {
+					added++
+				}
+			}
+			continue // otherwise: api not defined in scanned source → not the owning library
 		}
 		for _, fn := range decls {
 			if functionBodyHasFinding(report, fn) {
@@ -125,6 +148,44 @@ func functionFQN(id callgraph.FunctionID) string {
 	}
 }
 
+// classFQN renders the owning class of a FunctionID as a dotted package.Type
+// symbol (no method), e.g. "org.bouncycastle.crypto.engines.RSAEngine". Empty
+// when the function has no owning type (e.g. a package-level function).
+func classFQN(id callgraph.FunctionID) string {
+	switch {
+	case id.Package != "" && id.Type != "":
+		return id.Package + "." + id.Type
+	case id.Type != "":
+		return id.Type
+	default:
+		return ""
+	}
+}
+
+// implicitCtorRep resolves a constructor api ("package.Type.<init>") to a
+// representative declaration of its owning class when the class is scanned but
+// declares no explicit constructor (only a compiler-generated default exists,
+// absent from the source AST). It returns nil for non-constructor apis or
+// classes not present in the scan. The representative is the class member with
+// the lowest start line, giving a stable, auditable location near the class top.
+func implicitCtorRep(api string, declsByClass map[string][]*callgraph.FunctionDecl) *callgraph.FunctionDecl {
+	const ctorSuffix = ".<init>"
+	if !strings.HasSuffix(api, ctorSuffix) {
+		return nil
+	}
+	decls := declsByClass[strings.TrimSuffix(api, ctorSuffix)]
+	if len(decls) == 0 {
+		return nil
+	}
+	rep := decls[0]
+	for _, d := range decls[1:] {
+		if d.StartLine > 0 && (rep.StartLine <= 0 || d.StartLine < rep.StartLine) {
+			rep = d
+		}
+	}
+	return rep
+}
+
 // baseFQN strips the arity/overload decoration ("#0", "#1$String", …) from a
 // function FQN, leaving the bare package.Type.method symbol.
 func baseFQN(fqn string) string {
@@ -144,7 +205,8 @@ func functionBodyHasFinding(report *entities.InterimReport, fn *callgraph.Functi
 			!strings.HasSuffix(filepath.ToSlash(report.Findings[i].FilePath), fnPath) {
 			continue
 		}
-		for _, a := range report.Findings[i].CryptographicAssets {
+		for j := range report.Findings[i].CryptographicAssets {
+			a := &report.Findings[i].CryptographicAssets[j]
 			if a.StartLine >= fn.StartLine && a.StartLine <= fn.EndLine {
 				return true
 			}
@@ -196,7 +258,8 @@ func appendSyntheticAsset(
 	asset entities.CryptographicAsset,
 ) bool {
 	if idx, ok := fileIdx[filePath]; ok {
-		for _, existing := range report.Findings[idx].CryptographicAssets {
+		for i := range report.Findings[idx].CryptographicAssets {
+			existing := &report.Findings[idx].CryptographicAssets[i]
 			if existing.StartLine == asset.StartLine && existing.Metadata["api"] == asset.Metadata["api"] {
 				return false
 			}
@@ -234,35 +297,53 @@ func buildRuleCryptoByAPI(rulePaths []string) map[string]map[string]string {
 	out := make(map[string]map[string]string)
 	for _, p := range rulePaths {
 		for _, file := range expandRuleFiles(p) {
-			// Rule paths come from the trusted ruleset manager.
-			data, err := os.ReadFile(file)
-			if err != nil {
-				continue
-			}
-			var rf ruleFileCryptoYAML
-			if yaml.Unmarshal(data, &rf) != nil {
-				continue
-			}
-			for _, r := range rf.Rules {
-				if len(r.Metadata.Crypto) == 0 {
-					continue
-				}
-				api, ok := r.Metadata.Crypto["api"].(string)
-				api = strings.TrimSpace(api)
-				if !ok || api == "" {
-					continue
-				}
-				if !isQualifiedMethodSymbol(api) {
-					continue
-				}
-				if _, seen := out[api]; seen {
-					continue // first declaration wins; deterministic enough for synthesis
-				}
-				out[api] = stringifyCryptoBlock(r.Metadata.Crypto)
-			}
+			addRuleCryptoFile(out, file)
 		}
 	}
 	return out
+}
+
+func addRuleCryptoFile(out map[string]map[string]string, file string) {
+	// Rule paths come from the trusted ruleset manager.
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return
+	}
+
+	var rf ruleFileCryptoYAML
+	if yaml.Unmarshal(data, &rf) != nil {
+		return
+	}
+
+	for _, r := range rf.Rules {
+		addRuleCrypto(out, r.Metadata.Crypto)
+	}
+}
+
+func addRuleCrypto(out map[string]map[string]string, crypto map[string]any) {
+	api, ok := cryptoAPI(crypto)
+	if !ok {
+		return
+	}
+	if _, seen := out[api]; seen {
+		return // first declaration wins; deterministic enough for synthesis
+	}
+	out[api] = stringifyCryptoBlock(crypto)
+}
+
+func cryptoAPI(crypto map[string]any) (string, bool) {
+	if len(crypto) == 0 {
+		return "", false
+	}
+	api, ok := crypto["api"].(string)
+	api = strings.TrimSpace(api)
+	if !ok || api == "" {
+		return "", false
+	}
+	if !isQualifiedMethodSymbol(api) {
+		return "", false
+	}
+	return api, true
 }
 
 // isQualifiedMethodSymbol reports whether s is a dotted package.Type.method-style
@@ -301,7 +382,7 @@ func expandRuleFiles(path string) []string {
 		if err != nil || d.IsDir() {
 			return nil //nolint:nilerr // skip unreadable entries, keep walking
 		}
-		if ext := strings.ToLower(filepath.Ext(p)); ext == ".yaml" || ext == ".yml" {
+		if ext := strings.ToLower(filepath.Ext(p)); ext == extYAML || ext == extYML {
 			files = append(files, p)
 		}
 		return nil
@@ -314,8 +395,8 @@ func expandRuleFiles(path string) []string {
 // languageForPath maps a source file extension to the report Language tag.
 func languageForPath(path string) string {
 	switch strings.ToLower(filepath.Ext(path)) {
-	case ".java":
-		return "java"
+	case "." + languageJava:
+		return languageJava
 	case ".go":
 		return "go"
 	case ".py":

--- a/internal/engine/rule_entrypoint_synthesis_test.go
+++ b/internal/engine/rule_entrypoint_synthesis_test.go
@@ -99,6 +99,32 @@ func TestSynthesize_NoOpForShortAPI(t *testing.T) {
 	}
 }
 
+func TestSynthesize_NoOpForNonStringAPI(t *testing.T) {
+	dir := t.TempDir()
+	rule := filepath.Join(dir, "rule.yaml")
+	body := "" +
+		"rules:\n" +
+		"  - id: test.rule\n" +
+		"    metadata:\n" +
+		"      crypto:\n" +
+		"        assetType: algorithm\n" +
+		"        algorithmPrimitive: kdf\n" +
+		"        algorithmFamily: bcrypt\n" +
+		"        operation: keyderive\n" +
+		"        api:\n" +
+		"          - com.example.Builder.withBcrypt\n"
+	if err := os.WriteFile(rule, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := &entities.InterimReport{}
+	graph := graphWith(builderWithBcrypt())
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{rule}); n != 0 {
+		t.Fatalf("expected 0 synthesized findings for a non-string api, got %d", n)
+	}
+}
+
 func TestSynthesize_NoOpWhenBodyAlreadyDetected(t *testing.T) {
 	// Type 1: the method body already has a detected crypto finding, so it is
 	// already a natural entry point and must not be double-counted.

--- a/internal/engine/rule_entrypoint_synthesis_test.go
+++ b/internal/engine/rule_entrypoint_synthesis_test.go
@@ -76,6 +76,70 @@ func TestSynthesize_FiresForOwningLibrary(t *testing.T) {
 	}
 }
 
+func bcprovAESEngineCtor() *callgraph.FunctionDecl {
+	return &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "org.bouncycastle.crypto.engines", Type: "AESEngine", Name: "<init>"},
+		FilePath:  "org/bouncycastle/crypto/engines/AESEngine.java",
+		StartLine: 42,
+		EndLine:   60,
+	}
+}
+
+func TestSynthesize_FiresForConstructor(t *testing.T) {
+	// A library public-API constructor (e.g. new AESEngine()) must surface as a
+	// synthetic entry point. The join key is the canonical FQN with ".<init>",
+	// NOT the Class.Class display form — this is the form functionFQN computes
+	// for a constructor definition and is what a boundary rule's api must use.
+	dir := t.TempDir()
+	api := "org.bouncycastle.crypto.engines.AESEngine.<init>"
+	rule := writeRule(t, dir, api, "AES")
+	report := &entities.InterimReport{}
+	graph := graphWith(bcprovAESEngineCtor())
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{rule})
+	if n != 1 {
+		t.Fatalf("expected 1 synthesized finding for constructor api, got %d", n)
+	}
+	if got := report.Findings[0].CryptographicAssets[0].Metadata["api"]; got != api {
+		t.Errorf("api = %q, want %q", got, api)
+	}
+}
+
+func TestSynthesize_FiresForImplicitConstructor(t *testing.T) {
+	// A class with no explicit constructor (only a default) has no <init> in the
+	// source AST — but if the class is scanned (another method is defined), a
+	// constructor boundary rule must still surface it. RSAEngine is the real case.
+	dir := t.TempDir()
+	api := "org.bouncycastle.crypto.engines.RSAEngine.<init>"
+	rule := writeRule(t, dir, api, "RSA")
+	report := &entities.InterimReport{}
+	// Only a method definition exists for the class — no <init>.
+	graph := graphWith(&callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "org.bouncycastle.crypto.engines", Type: "RSAEngine", Name: "init"},
+		FilePath:  "org/bouncycastle/crypto/engines/RSAEngine.java",
+		StartLine: 20,
+		EndLine:   30,
+	})
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{rule})
+	if n != 1 {
+		t.Fatalf("expected 1 synthesized finding for implicit constructor, got %d", n)
+	}
+	if got := report.Findings[0].CryptographicAssets[0].Metadata["api"]; got != api {
+		t.Errorf("api = %q, want %q", got, api)
+	}
+}
+
+func TestSynthesize_NoOpForImplicitCtorWhenClassAbsent(t *testing.T) {
+	// A constructor api whose class is not scanned at all must NOT synthesize.
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "org.bouncycastle.crypto.engines.RSAEngine.<init>", "RSA")
+	report := &entities.InterimReport{}
+	if n := SynthesizeRuleCryptoEntryPoints(report, graphWith(nil), []string{rule}); n != 0 {
+		t.Fatalf("expected 0 synthesized findings when class absent, got %d", n)
+	}
+}
+
 func TestSynthesize_NoOpForConsumerScan(t *testing.T) {
 	// Definition absent (a consumer calls the method but does not define it).
 	dir := t.TempDir()

--- a/internal/engine/rule_entrypoint_synthesis_test.go
+++ b/internal/engine/rule_entrypoint_synthesis_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/entities"
+)
+
+// writeRule writes a minimal rule file carrying one metadata.crypto block and
+// returns its path.
+func writeRule(t *testing.T, dir, api, family string) string {
+	t.Helper()
+	body := "" +
+		"rules:\n" +
+		"  - id: test.rule\n" +
+		"    metadata:\n" +
+		"      crypto:\n" +
+		"        assetType: algorithm\n" +
+		"        algorithmPrimitive: kdf\n" +
+		"        algorithmFamily: " + family + "\n" +
+		"        operation: keyderive\n" +
+		"        api: " + api + "\n"
+	p := filepath.Join(dir, "rule.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func graphWith(decl *callgraph.FunctionDecl) *callgraph.CallGraph {
+	g := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{}}
+	if decl != nil {
+		g.Functions[decl.ID.String()] = decl
+	}
+	return g
+}
+
+func builderWithBcrypt() *callgraph.FunctionDecl {
+	return &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "com.example", Type: "Builder", Name: "withBcrypt"},
+		FilePath:  "src/main/java/com/example/Builder.java",
+		StartLine: 10,
+		EndLine:   12,
+	}
+}
+
+func TestSynthesize_FiresForOwningLibrary(t *testing.T) {
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "com.example.Builder.withBcrypt", "bcrypt")
+	report := &entities.InterimReport{}
+	graph := graphWith(builderWithBcrypt())
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{rule})
+	if n != 1 {
+		t.Fatalf("expected 1 synthesized finding, got %d", n)
+	}
+	asset := report.Findings[0].CryptographicAssets[0]
+	if got := asset.Metadata["algorithmFamily"]; got != "bcrypt" {
+		t.Errorf("algorithmFamily = %q, want bcrypt (verbatim from rule)", got)
+	}
+	if got := asset.Metadata["api"]; got != "com.example.Builder.withBcrypt" {
+		t.Errorf("api = %q", got)
+	}
+	if asset.StartLine != 10 {
+		t.Errorf("synthetic finding should sit at the method definition line, got %d", asset.StartLine)
+	}
+}
+
+func TestSynthesize_NoOpForConsumerScan(t *testing.T) {
+	// Definition absent (a consumer calls the method but does not define it).
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "com.example.Builder.withBcrypt", "bcrypt")
+	report := &entities.InterimReport{}
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graphWith(nil), []string{rule}); n != 0 {
+		t.Fatalf("expected 0 synthesized findings when definition is absent, got %d", n)
+	}
+}
+
+func TestSynthesize_NoOpForShortAPI(t *testing.T) {
+	// Type 1 short api (e.g. "Cipher.getInstance") must never become a join key.
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "Cipher.getInstance", "AES")
+	report := &entities.InterimReport{}
+	graph := graphWith(builderWithBcrypt())
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{rule}); n != 0 {
+		t.Fatalf("expected 0 synthesized findings for a non-qualified api, got %d", n)
+	}
+}
+
+func TestSynthesize_NoOpWhenBodyAlreadyDetected(t *testing.T) {
+	// Type 1: the method body already has a detected crypto finding, so it is
+	// already a natural entry point and must not be double-counted.
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "com.example.Builder.withBcrypt", "bcrypt")
+	decl := builderWithBcrypt()
+	report := &entities.InterimReport{
+		Findings: []entities.Finding{{
+			FilePath: decl.FilePath,
+			CryptographicAssets: []entities.CryptographicAsset{
+				{StartLine: 11, Metadata: map[string]string{"algorithmFamily": "bcrypt"}},
+			},
+		}},
+	}
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graphWith(decl), []string{rule}); n != 0 {
+		t.Fatalf("expected 0 synthesized findings when body already detected, got %d", n)
+	}
+}

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -736,8 +736,19 @@ func newExportBuildContext(result *engine.DepScanResult) *exportBuildContext {
 	// points can attach their fluent lifecycle methods as supporting calls.
 	if kb, err := contracts.LoadEmbedded(result.Ecosystem); err == nil {
 		ctx.kb = kb
+	} else {
+		log.Debug().
+			Err(err).
+			Str("ecosystem", result.Ecosystem).
+			Msg("failed to load embedded callgraph contracts")
 	}
 	if result.CallGraph != nil {
+		// declIndex is keyed by base FQN only (no arity/overload suffix), so the
+		// first encountered overload for a base FQN wins. deriveContractSupportingCalls
+		// therefore resolves contract methods by base FQN to whichever overload was
+		// indexed first; exact overload matching is not supported by this index.
+		// Future overload-aware lookup should store []*callgraph.FunctionDecl per
+		// base FQN instead.
 		ctx.declIndex = make(map[string]*callgraph.FunctionDecl, len(result.CallGraph.Functions))
 		for _, fn := range result.CallGraph.Functions {
 			if fqn := exportFunctionFQN(fn.ID); fqn != "" {

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
 	"github.com/scanoss/crypto-finder/internal/engine"
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/pkg/graphfrag"
@@ -47,6 +48,11 @@ type exportBuildContext struct {
 	fragmentEdgeResolutions map[string][]fragmentEdgeResolution
 	userPackages            map[string]bool
 	packageSeparator        string
+	// kb holds the ecosystem's callgraph contracts, used to attach contract-role
+	// supporting calls (fluent lifecycle methods) to synthesized terminal entry
+	// points. nil for ecosystems with no contracts.
+	kb        *contracts.KnowledgeBase
+	declIndex map[string]*callgraph.FunctionDecl // base FQN → definition
 }
 
 type cachedContainingFunction struct {
@@ -725,7 +731,43 @@ func newExportBuildContext(result *engine.DepScanResult) *exportBuildContext {
 		return len(ctx.dependencies[i].Dir) > len(ctx.dependencies[j].Dir)
 	})
 	ctx.populateCallChainUsageCounts(result.Report)
+
+	// Load contracts + index method definitions so synthesized terminal entry
+	// points can attach their fluent lifecycle methods as supporting calls.
+	if kb, err := contracts.LoadEmbedded(result.Ecosystem); err == nil {
+		ctx.kb = kb
+	}
+	if result.CallGraph != nil {
+		ctx.declIndex = make(map[string]*callgraph.FunctionDecl, len(result.CallGraph.Functions))
+		for _, fn := range result.CallGraph.Functions {
+			if fqn := exportFunctionFQN(fn.ID); fqn != "" {
+				if _, exists := ctx.declIndex[fqn]; !exists {
+					ctx.declIndex[fqn] = fn
+				}
+			}
+		}
+	}
 	return ctx
+}
+
+// exportFunctionFQN renders a FunctionID as its undecorated package.Type.method
+// symbol (no arity/overload suffix), matching contract method keys.
+func exportFunctionFQN(id callgraph.FunctionID) string {
+	var fqn string
+	switch {
+	case id.Type != "" && id.Package != "":
+		fqn = id.Package + "." + id.Type + "." + id.Name
+	case id.Type != "":
+		fqn = id.Type + "." + id.Name
+	case id.Package != "":
+		fqn = id.Package + "." + id.Name
+	default:
+		fqn = id.Name
+	}
+	if i := strings.IndexByte(fqn, '#'); i >= 0 {
+		return fqn[:i]
+	}
+	return fqn
 }
 
 // --- Per-finding graph builder ---
@@ -782,6 +824,12 @@ func buildFindingGraph(ctx *exportBuildContext, finding entities.Finding, asset 
 // crypto call, enumerates the lifecycle calls of the crypto object it identifies
 // (see deriveObjectLifecycleCalls), and renders each as a supporting-call entry.
 func deriveSupportingCallsForFinding(ctx *exportBuildContext, finding entities.Finding, asset entities.CryptographicAsset) []callGraphSupportingCall {
+	// Synthesized terminal entry points (library API boundary, no in-source call
+	// chain) get their fluent lifecycle methods from the contract KB by type
+	// lineage, since there are no chain siblings to derive structurally.
+	if isSyntheticEntryPoint(asset) {
+		return deriveContractSupportingCalls(ctx, asset)
+	}
 	containingFn := ctx.findContainingFunctionByFinding(finding.FilePath, asset.StartLine)
 	if containingFn == nil {
 		return nil
@@ -800,6 +848,114 @@ func deriveSupportingCallsForFinding(ctx *exportBuildContext, finding entities.F
 		out = append(out, buildDerivedSupportingCall(ctx, containingFn, c))
 	}
 	return out
+}
+
+// isSyntheticEntryPoint reports whether an asset was produced by the rule-derived
+// API-boundary synthesis (engine.SynthesizeRuleCryptoEntryPoints).
+func isSyntheticEntryPoint(asset entities.CryptographicAsset) bool {
+	for _, r := range asset.Rules {
+		if r.ID == engine.SyntheticEntryPointRuleID {
+			return true
+		}
+	}
+	return false
+}
+
+// receiverType returns the owning type FQN of a fully-qualified method symbol,
+// e.g. "com.password4j.HashBuilder.withBcrypt" → "com.password4j.HashBuilder".
+func receiverType(method string) string {
+	if i := strings.LastIndex(method, "."); i >= 0 {
+		return method[:i]
+	}
+	return ""
+}
+
+// contractReturnType returns the contract-declared return type of a method FQN
+// (any arity), or "" when unknown.
+func (ctx *exportBuildContext) contractReturnType(method string) string {
+	if ctx.kb == nil {
+		return ""
+	}
+	for _, group := range ctx.kb.Contracts {
+		for i := range group {
+			if group[i].Method == method {
+				return group[i].Return.Type
+			}
+		}
+	}
+	return ""
+}
+
+// deriveContractSupportingCalls returns the fluent lifecycle methods of a
+// synthesized terminal as supporting calls, by contract type lineage. For
+// HashBuilder.withBcrypt (builder=HashBuilder, return=Hash): factory methods that
+// return the builder (Password.hash), config methods on the builder
+// (addRandomSalt/addSalt/addPepper), and output methods on the return type
+// (Hash.getResult). Gated on the method definition being present in the scanned
+// source; Category carries the contract role.
+func deriveContractSupportingCalls(ctx *exportBuildContext, asset entities.CryptographicAsset) []callGraphSupportingCall {
+	if ctx.kb == nil || len(ctx.kb.Contracts) == 0 || ctx.declIndex == nil {
+		return nil
+	}
+	terminalAPI := strings.TrimSpace(asset.Metadata["api"])
+	builderType := receiverType(terminalAPI)
+	if builderType == "" {
+		return nil
+	}
+	returnType := ctx.contractReturnType(terminalAPI)
+
+	var out []callGraphSupportingCall
+	seen := make(map[string]struct{})
+	for _, group := range ctx.kb.Contracts {
+		for i := range group {
+			c := group[i]
+			if c.Role == "" {
+				continue
+			}
+			recv := receiverType(c.Method)
+			isFactory := c.Return.Type == builderType          // produces the builder/checker
+			isConfig := recv == builderType                    // mutates the builder/checker
+			isOutput := returnType != "" && recv == returnType // reads the terminal's product
+			if !isFactory && !isConfig && !isOutput {
+				continue
+			}
+			if _, dup := seen[c.Method]; dup {
+				continue
+			}
+			decl := ctx.declIndex[c.Method]
+			if decl == nil {
+				continue // not defined in scanned source
+			}
+			seen[c.Method] = struct{}{}
+			out = append(out, buildContractSupportingCall(ctx, c, decl))
+		}
+	}
+	return out
+}
+
+// buildContractSupportingCall renders a contract-role method definition as a
+// supporting-call entry for a synthesized terminal.
+func buildContractSupportingCall(ctx *exportBuildContext, c contracts.Contract, decl *callgraph.FunctionDecl) callGraphSupportingCall {
+	sourcePath := normalizeExportPath(ctx, decl.FilePath).FilePath
+	meta := buildExportFunctionMetadata(ctx.graph, decl.ID, decl)
+	return callGraphSupportingCall{
+		SupportingID:       supportingIDFromParts(sourcePath, decl.StartLine, decl.ID.String()),
+		FunctionKey:        decl.ID.String(),
+		FunctionName:       meta.FunctionName,
+		CanonicalSignature: meta.CanonicalSignature,
+		DisplaySymbol:      meta.DisplaySymbol,
+		Aliases:            cloneStringSlice(meta.Aliases),
+		Category:           c.Role,
+		FilePath:           sourcePath,
+		StartLine:          decl.StartLine,
+		EndLine:            decl.StartLine,
+		MatchedOperation: &callGraphMatchedOperation{
+			Kind:   "type_usage",
+			Symbol: c.Method,
+			Line:   decl.StartLine,
+		},
+		SupportingCall: &callGraphCalledFunction{FunctionName: c.Method},
+	}
 }
 
 // supportingCallIDsOf returns the sorted, de-duplicated supporting-call ids of a

--- a/internal/scanner/opengrep/scanner.go
+++ b/internal/scanner/opengrep/scanner.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -41,6 +40,13 @@ const ScannerName = "opengrep"
 
 // MinimumVersion is the minimum required version of OpenGrep.
 const MinimumVersion = "1.12.1"
+
+// noSemgrepignoreFilename is a sentinel basename passed to opengrep's
+// --semgrepignore-filename so it looks for an ignore file that never exists,
+// effectively disabling default .semgrepignore handling. It must be a bare
+// basename: opengrep (>=1.12.1) rejects an absolute path like os.DevNull with
+// "invalid segment" because the leading slash is not a valid path segment.
+const noSemgrepignoreFilename = ".crypto-finder-no-semgrepignore"
 
 // Package-level variables for testing (can be overridden in tests).
 var (
@@ -259,14 +265,14 @@ func (s *Scanner) semgrepignoreControlArgs() []string {
 	}
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to detect opengrep ignore-file flags; using documented fallback")
-		return []string{"--experimental", "--semgrepignore-filename", os.DevNull}
+		return []string{"--experimental", "--semgrepignore-filename", noSemgrepignoreFilename}
 	}
 
 	helpText := string(help)
 	if strings.Contains(helpText, "--x-ignore-semgrepignore-files") {
 		return []string{"--x-ignore-semgrepignore-files"}
 	}
-	return []string{"--experimental", "--semgrepignore-filename", os.DevNull}
+	return []string{"--experimental", "--semgrepignore-filename", noSemgrepignoreFilename}
 }
 
 // execute runs the opengrep command and captures stdout/stderr.

--- a/internal/scanner/opengrep/scanner.go
+++ b/internal/scanner/opengrep/scanner.go
@@ -229,6 +229,14 @@ func (s *Scanner) buildCommand(target string, rulePaths []string) []string {
 	args := []string{
 		"--json",            // JSON output format
 		"--taint-intrafile", // Enable taint analysis
+		// crypto-finder owns file selection: it walks the tree and passes its
+		// authoritative skip set below via --exclude (defaults, scanoss.json,
+		// --include-tests, --no-default-exclusions, --exclude). OpenGrep would
+		// otherwise apply its own built-in default .semgrepignore (which skips
+		// test/ paths) as a second, conflicting filter, silently dropping test
+		// sources even when --include-tests is set. Disable it so crypto-finder's
+		// skip logic is the single source of truth.
+		"--x-ignore-semgrepignore-files",
 	}
 
 	for _, rulePath := range rulePaths {

--- a/internal/scanner/opengrep/scanner.go
+++ b/internal/scanner/opengrep/scanner.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -229,15 +230,8 @@ func (s *Scanner) buildCommand(target string, rulePaths []string) []string {
 	args := []string{
 		"--json",            // JSON output format
 		"--taint-intrafile", // Enable taint analysis
-		// crypto-finder owns file selection: it walks the tree and passes its
-		// authoritative skip set below via --exclude (defaults, scanoss.json,
-		// --include-tests, --no-default-exclusions, --exclude). OpenGrep would
-		// otherwise apply its own built-in default .semgrepignore (which skips
-		// test/ paths) as a second, conflicting filter, silently dropping test
-		// sources even when --include-tests is set. Disable it so crypto-finder's
-		// skip logic is the single source of truth.
-		"--x-ignore-semgrepignore-files",
 	}
+	args = append(args, s.semgrepignoreControlArgs()...)
 
 	for _, rulePath := range rulePaths {
 		args = append(args, "--config", rulePath)
@@ -254,6 +248,25 @@ func (s *Scanner) buildCommand(target string, rulePaths []string) []string {
 	args = append(args, target)
 
 	return args
+}
+
+// semgrepignoreControlArgs disables OpenGrep's built-in default ignore file
+// handling so crypto-finder's own skip logic remains the single source of truth.
+func (s *Scanner) semgrepignoreControlArgs() []string {
+	help, err := commandOutput(s.executablePath, "scan", "--help")
+	if err != nil {
+		help, err = commandOutput(s.executablePath, "--help")
+	}
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to detect opengrep ignore-file flags; using documented fallback")
+		return []string{"--experimental", "--semgrepignore-filename", os.DevNull}
+	}
+
+	helpText := string(help)
+	if strings.Contains(helpText, "--x-ignore-semgrepignore-files") {
+		return []string{"--x-ignore-semgrepignore-files"}
+	}
+	return []string{"--experimental", "--semgrepignore-filename", os.DevNull}
 }
 
 // execute runs the opengrep command and captures stdout/stderr.

--- a/internal/scanner/opengrep/scanner_test.go
+++ b/internal/scanner/opengrep/scanner_test.go
@@ -68,16 +68,17 @@ func TestBuildCommand(t *testing.T) {
 
 	// Verify required arguments
 	expectedArgs := map[string]bool{
-		"--json":             false,
-		"--taint-intrafile":  false,
-		"--config":           false,
-		"/rules/crypto.yaml": false,
-		"/rules/hash.yaml":   false,
-		"--exclude":          false,
-		"*.test":             false,
-		"vendor/*":           false,
-		"--debug":            false,
-		"/tmp/target":        false,
+		"--json":                         false,
+		"--taint-intrafile":              false,
+		"--x-ignore-semgrepignore-files": false,
+		"--config":                       false,
+		"/rules/crypto.yaml":             false,
+		"/rules/hash.yaml":               false,
+		"--exclude":                      false,
+		"*.test":                         false,
+		"vendor/*":                       false,
+		"--debug":                        false,
+		"/tmp/target":                    false,
 	}
 
 	for _, arg := range args {

--- a/internal/scanner/opengrep/scanner_test.go
+++ b/internal/scanner/opengrep/scanner_test.go
@@ -18,6 +18,7 @@ package opengrep
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -57,6 +58,17 @@ func TestGetInfo(t *testing.T) {
 }
 
 func TestBuildCommand(t *testing.T) {
+	originalCommandOutput := commandOutput
+	defer func() {
+		commandOutput = originalCommandOutput
+	}()
+	commandOutput = func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[0] == "scan" && args[1] == "--help" {
+			return []byte("--x-ignore-semgrepignore-files"), nil
+		}
+		return nil, nil
+	}
+
 	s := NewScanner()
 	s.skipPatterns = []string{"*.test", "vendor/*"}
 	s.extraArgs = []string{"--debug"}
@@ -109,6 +121,37 @@ func TestBuildCommand(t *testing.T) {
 	// Verify target is the last argument
 	if args[len(args)-1] != target {
 		t.Errorf("Expected target '%s' to be last argument, got '%s'", target, args[len(args)-1])
+	}
+}
+
+func TestBuildCommand_FallsBackWhenExperimentalIgnoreFlagUnsupported(t *testing.T) {
+	originalCommandOutput := commandOutput
+	defer func() {
+		commandOutput = originalCommandOutput
+	}()
+	commandOutput = func(_ string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[0] == "scan" && args[1] == "--help" {
+			return []byte("--semgrepignore-filename"), nil
+		}
+		return nil, nil
+	}
+
+	s := NewScanner()
+	args := s.buildCommand("/tmp/target", []string{"/rules/crypto.yaml"})
+
+	for _, arg := range args {
+		if arg == "--x-ignore-semgrepignore-files" {
+			t.Fatal("experimental ignore flag should not be used when help output does not advertise it")
+		}
+	}
+	if !containsArg(args, "--semgrepignore-filename") {
+		t.Fatal("expected documented semgrepignore filename fallback")
+	}
+	if !containsArg(args, "--experimental") {
+		t.Fatal("expected experimental gate for semgrepignore filename fallback")
+	}
+	if !containsArg(args, os.DevNull) {
+		t.Fatalf("expected fallback semgrepignore file %q", os.DevNull)
 	}
 }
 
@@ -303,6 +346,15 @@ func splitOnce(s, sep string) []string {
 		parts = append(parts, s)
 	}
 	return parts
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
 }
 
 // Helper function to find first occurrence of substring.

--- a/internal/scanner/opengrep/scanner_test.go
+++ b/internal/scanner/opengrep/scanner_test.go
@@ -18,7 +18,6 @@ package opengrep
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -150,8 +149,8 @@ func TestBuildCommand_FallsBackWhenExperimentalIgnoreFlagUnsupported(t *testing.
 	if !containsArg(args, "--experimental") {
 		t.Fatal("expected experimental gate for semgrepignore filename fallback")
 	}
-	if !containsArg(args, os.DevNull) {
-		t.Fatalf("expected fallback semgrepignore file %q", os.DevNull)
+	if !containsArg(args, noSemgrepignoreFilename) {
+		t.Fatalf("expected fallback semgrepignore file %q", noSemgrepignoreFilename)
 	}
 }
 

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -55,6 +55,7 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		// bounded on high-fan-in libraries (BouncyCastle, 18k functions) where the
 		// old all-simple-paths forward DFS hangs.
 		traceBackward(adjacency, opsByNode, supportingByNode, fragments, roots, &out)
+		attachAnnotationSupportingCalls(closure, fragments, &out)
 		return &out, nil
 	}
 
@@ -66,7 +67,65 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 	for _, start := range roots {
 		trace(start, adjacency, opsByNode, supportingByNode, fragments, nil, nil, map[graphNode]bool{}, &out)
 	}
+	attachAnnotationSupportingCalls(closure, fragments, &out)
 	return &out, nil
+}
+
+// attachAnnotationSupportingCalls resolves each surviving finding's
+// supporting_call_ids (the per-finding FK the fragment's crypto annotation
+// declares) against the closure's supporting-call pool, adding any the chain
+// traversal did not already emit.
+//
+// flushSupportingCalls only emits supporting calls for nodes that appear on a
+// backward chain to a crypto op. Contract/lifecycle supporting calls — e.g.
+// Password4J's Password.hash / addRandomSalt / Hash.getResult, attached to a
+// synthesized terminal by deriveContractSupportingCalls at export time — are
+// upstream public-API callers that are NOT on any backward chain from the
+// terminal (the terminal has in-degree 0), so traversal alone silently drops
+// them and their supporting_call_ids dangle against an empty pool. Honoring the
+// fragment's pre-computed FK here is what makes the served callgraph match a
+// live --export-callgraph (which carries them in supporting_calls).
+func attachAnnotationSupportingCalls(closure []ComponentKey, fragments map[ComponentKey]Fragment, out *Result) {
+	byID := make(map[string]SupportingCall)
+	for _, key := range closure {
+		fragment := fragments[key]
+		for i := range fragment.SupportingCalls {
+			sc := fragment.SupportingCalls[i]
+			if sc.SupportingID == "" {
+				continue
+			}
+			if _, ok := byID[sc.SupportingID]; !ok {
+				byID[sc.SupportingID] = sc
+			}
+		}
+	}
+	if len(byID) == 0 {
+		return
+	}
+
+	seen := make(map[string]bool, len(out.SupportingCalls))
+	for i := range out.SupportingCalls {
+		if id := out.SupportingCalls[i].SupportingID; id != "" {
+			seen[id] = true
+		}
+	}
+	for i := range out.Chains {
+		op := out.Chains[i].CryptoOp
+		if op == nil {
+			continue
+		}
+		for _, id := range op.SupportingCallIDs {
+			if id == "" || seen[id] {
+				continue
+			}
+			sc, ok := byID[id]
+			if !ok {
+				continue
+			}
+			seen[id] = true
+			out.SupportingCalls = append(out.SupportingCalls, sc)
+		}
+	}
 }
 
 // rootNodes selects the set of root-fragment functions to start traces from.


### PR DESCRIPTION
## What
Adds `internal/callgraph/contracts/java/tink.yaml` — inferred-types KB for Google Tink so the callgraph resolves Tink's fluent chain and reachability can reach the terminal crypto op:

```
KeyTemplates.get("AES256_GCM")
  -> KeysetHandle.generateNew(template)   : KeysetHandle
  -> handle.getPrimitive(Aead.class)      : Aead   (argument-conditional)
  -> aead.encrypt(plaintext, aad)         : byte[] (terminal)
```

`getPrimitive` contracts are argument-conditional on the requested primitive class literal (`Aead`/`Mac`/`PublicKeySign`/`PublicKeyVerify`), covering both the classic arity-1 form and the newer `getPrimitive(Configuration, Class)` arity-2 form.

## Why
Tink hides primitives behind `KeysetHandle.getPrimitive(<P>.class)`; without these contracts the callgraph can't link the keyset to the crypto operation. The crypto_rules semgrep rules (crypto_rules#85) detect Tink usage; this contract lets **reachability** trace it. conscrypt/ACCP need no contract — they route through standard JCA (covered by `jdk-crypto`).

## Tests
`go test ./internal/callgraph/contracts/...` passes (YAML loads + validates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Synthesizes library-level crypto entry points from rules and surfaces them in scan reports.
  * Uses contract knowledge to infer and include contract-derived supporting crypto calls in findings.
  * Ensures annotation-linked supporting calls are preserved in exported fragments.

* **Chores**
  * Added Java contracts for Google Tink, BouncyCastle and password4j to improve API recognition.
  * Scanner now disables external semgrepignore handling to honor the tool's skip rules.
  * Updated .gitignore for local runtime state.

* **Refactor**
  * Removed an unused parser parameter.

* **Tests**
  * Added unit tests validating entry-point synthesis and scanner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->