### PR TITLE
feat(scan): attach inherited lifecycle methods via hierarchy-aware roles

### DIFF
--- a/internal/callgraph/contracts/java/bouncycastle.yaml
+++ b/internal/callgraph/contracts/java/bouncycastle.yaml
@@ -89,6 +89,13 @@ contracts:
     arity: 3
     return: { type: void, confidence: high }
     role: config
+  # GeneralDigest is the abstract base of the SHA-1/SHA-2 family; update() is
+  # inherited (not overridden) by SHA256Digest et al. The inheritance-aware
+  # role attachment surfaces it on those subtype constructor terminals.
+  - method: org.bouncycastle.crypto.digests.GeneralDigest.update
+    arity: 3
+    return: { type: void, confidence: high }
+    role: config
 
   # The EC named-curve lookup terminal: declaring its return type lets the
   # X9ECParameters getters below attach as role: output (receiver == return type).
@@ -137,5 +144,15 @@ hierarchy:
   org.bouncycastle.math.ec.ECPoint:
     - java.lang.Object
   java.math.BigInteger:
+    - java.lang.Object
+  # Digest inheritance so base-class lifecycle methods (GeneralDigest.update,
+  # KeccakDigest.update/getDigestSize) attach to subtype constructor terminals.
+  org.bouncycastle.crypto.digests.SHA256Digest:
+    - org.bouncycastle.crypto.digests.GeneralDigest
+  org.bouncycastle.crypto.digests.GeneralDigest:
+    - java.lang.Object
+  org.bouncycastle.crypto.digests.SHA3Digest:
+    - org.bouncycastle.crypto.digests.KeccakDigest
+  org.bouncycastle.crypto.digests.KeccakDigest:
     - java.lang.Object
   java.lang.Object: []

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -76,13 +76,25 @@ func SynthesizeRuleCryptoEntryPoints(report *entities.InterimReport, graph *call
 		return 0
 	}
 
-	// Index method definitions present in the scanned source by their base FQN
-	// (arity/overload decoration like "#0" or "#1$String" stripped), since the
-	// rule's metadata.crypto.api is the undecorated package.Type.method symbol.
-	// Index method definitions by base FQN, and separately by owning class FQN
-	// (package.Type). The class index lets a constructor api resolve even when
-	// the class declares no explicit constructor (the compiler-generated default
-	// has no <init> in the source AST, so it is absent from declsByFQN).
+	declsByFQN, declsByClass := indexGraphDeclarations(graph)
+	fileIdx := indexReportFiles(report)
+	added := synthesizeRuleCryptoAssets(report, fileIdx, apiCrypto, declsByFQN, declsByClass)
+
+	if added > 0 {
+		log.Info().
+			Int("count", added).
+			Msg("Surfaced library public crypto API methods as entry points (from rule metadata.crypto)")
+	}
+	return added
+}
+
+// indexGraphDeclarations indexes method definitions present in the scanned
+// source by their base FQN and by owning class FQN. The class index lets a
+// constructor api resolve even when the class declares no explicit constructor
+// (the compiler-generated default has no <init> in the source AST).
+func indexGraphDeclarations(
+	graph *callgraph.CallGraph,
+) (map[string][]*callgraph.FunctionDecl, map[string][]*callgraph.FunctionDecl) {
 	declsByFQN := make(map[string][]*callgraph.FunctionDecl)
 	declsByClass := make(map[string][]*callgraph.FunctionDecl)
 	for _, fn := range graph.Functions {
@@ -93,44 +105,92 @@ func SynthesizeRuleCryptoEntryPoints(report *entities.InterimReport, graph *call
 			declsByClass[class] = append(declsByClass[class], fn)
 		}
 	}
+	return declsByFQN, declsByClass
+}
 
+func indexReportFiles(report *entities.InterimReport) map[string]int {
 	fileIdx := make(map[string]int, len(report.Findings))
 	for i := range report.Findings {
 		fileIdx[report.Findings[i].FilePath] = i
 	}
+	return fileIdx
+}
 
+func synthesizeRuleCryptoAssets(
+	report *entities.InterimReport,
+	fileIdx map[string]int,
+	apiCrypto map[string]map[string]string,
+	declsByFQN map[string][]*callgraph.FunctionDecl,
+	declsByClass map[string][]*callgraph.FunctionDecl,
+) int {
 	added := 0
 	for api, meta := range apiCrypto {
-		decls := declsByFQN[api]
-		if len(decls) == 0 {
-			// No source-declared method matches the api. A constructor api may
-			// still belong to a scanned class with only an implicit default
-			// constructor — surface it once at a representative class location.
-			if rep := implicitCtorRep(api, declsByClass); rep != nil {
-				asset := buildSyntheticAssetFromRule(api, meta, rep)
-				if appendSyntheticAsset(report, fileIdx, rep.FilePath, languageForPath(rep.FilePath), asset) {
-					added++
-				}
-			}
-			continue // otherwise: api not defined in scanned source → not the owning library
-		}
-		for _, fn := range decls {
-			if functionBodyHasFinding(report, fn) {
-				continue // Type 1: primitive already detected inside the method
-			}
-			asset := buildSyntheticAssetFromRule(api, meta, fn)
-			if appendSyntheticAsset(report, fileIdx, fn.FilePath, languageForPath(fn.FilePath), asset) {
-				added++
-			}
-		}
-	}
-
-	if added > 0 {
-		log.Info().
-			Int("count", added).
-			Msg("Surfaced library public crypto API methods as entry points (from rule metadata.crypto)")
+		added += synthesizeAPIAssets(report, fileIdx, api, meta, declsByFQN[api], declsByClass)
 	}
 	return added
+}
+
+func synthesizeAPIAssets(
+	report *entities.InterimReport,
+	fileIdx map[string]int,
+	api string,
+	meta map[string]string,
+	decls []*callgraph.FunctionDecl,
+	declsByClass map[string][]*callgraph.FunctionDecl,
+) int {
+	if len(decls) == 0 {
+		return synthesizeImplicitCtorAsset(report, fileIdx, api, meta, declsByClass)
+	}
+	return synthesizeDeclaredAPIAssets(report, fileIdx, api, meta, decls)
+}
+
+func synthesizeImplicitCtorAsset(
+	report *entities.InterimReport,
+	fileIdx map[string]int,
+	api string,
+	meta map[string]string,
+	declsByClass map[string][]*callgraph.FunctionDecl,
+) int {
+	// No source-declared method matches the api. A constructor api may still
+	// belong to a scanned class with only an implicit default constructor.
+	rep := implicitCtorRep(api, declsByClass)
+	if rep == nil {
+		return 0
+	}
+	if appendSyntheticRuleAsset(report, fileIdx, api, meta, rep) {
+		return 1
+	}
+	return 0
+}
+
+func synthesizeDeclaredAPIAssets(
+	report *entities.InterimReport,
+	fileIdx map[string]int,
+	api string,
+	meta map[string]string,
+	decls []*callgraph.FunctionDecl,
+) int {
+	added := 0
+	for _, fn := range decls {
+		if functionBodyHasFinding(report, fn) {
+			continue // Type 1: primitive already detected inside the method.
+		}
+		if appendSyntheticRuleAsset(report, fileIdx, api, meta, fn) {
+			added++
+		}
+	}
+	return added
+}
+
+func appendSyntheticRuleAsset(
+	report *entities.InterimReport,
+	fileIdx map[string]int,
+	api string,
+	meta map[string]string,
+	fn *callgraph.FunctionDecl,
+) bool {
+	asset := buildSyntheticAssetFromRule(api, meta, fn)
+	return appendSyntheticAsset(report, fileIdx, fn.FilePath, languageForPath(fn.FilePath), asset)
 }
 
 // functionFQN renders a FunctionID as the dotted fully-qualified name used in a

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -897,6 +897,37 @@ func (ctx *exportBuildContext) contractReturnType(method string) string {
 	return ""
 }
 
+// typeOrAncestor reports whether candidate is typ itself or a transitive
+// supertype of typ in the contract hierarchy. It lets a role-tagged method
+// declared on a base class attach to a terminal of a subtype that inherits it
+// (e.g. GeneralDigest.update -> a SHA256Digest constructor terminal).
+func (ctx *exportBuildContext) typeOrAncestor(candidate, typ string) bool {
+	if candidate == "" || typ == "" {
+		return false
+	}
+	if candidate == typ {
+		return true
+	}
+	if ctx.kb == nil {
+		return false
+	}
+	seen := map[string]bool{typ: true}
+	queue := append([]string(nil), ctx.kb.Hierarchy[typ]...)
+	for len(queue) > 0 {
+		p := queue[0]
+		queue = queue[1:]
+		if p == candidate {
+			return true
+		}
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		queue = append(queue, ctx.kb.Hierarchy[p]...)
+	}
+	return false
+}
+
 // deriveContractSupportingCalls returns the fluent lifecycle methods of a
 // synthesized terminal as supporting calls, by contract type lineage. For
 // HashBuilder.withBcrypt (builder=HashBuilder, return=Hash): factory methods that
@@ -924,9 +955,12 @@ func deriveContractSupportingCalls(ctx *exportBuildContext, asset entities.Crypt
 				continue
 			}
 			recv := receiverType(c.Method)
-			isFactory := c.Return.Type == builderType          // produces the builder/checker
-			isConfig := recv == builderType                    // mutates the builder/checker
-			isOutput := returnType != "" && recv == returnType // reads the terminal's product
+			isFactory := c.Return.Type == builderType // produces the builder/checker
+			// config/output are inheritance-aware: a role method declared on a base
+			// class (e.g. GeneralDigest.update) attaches to a terminal of a subtype
+			// that inherits it (e.g. SHA256Digest), via the contract hierarchy.
+			isConfig := ctx.typeOrAncestor(recv, builderType)                    // invoked on the builder or a supertype
+			isOutput := returnType != "" && ctx.typeOrAncestor(recv, returnType) // reads the terminal's product or a supertype
 			if !isFactory && !isConfig && !isOutput {
 				continue
 			}

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -86,6 +86,15 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 // fragment's pre-computed FK here is what makes the served callgraph match a
 // live --export-callgraph (which carries them in supporting_calls).
 func attachAnnotationSupportingCalls(closure []ComponentKey, fragments map[ComponentKey]Fragment, out *Result) {
+	byID := indexAnnotationSupportingCalls(closure, fragments)
+	if len(byID) == 0 {
+		return
+	}
+	seen := indexResultSupportingCalls(out)
+	attachMissingAnnotationSupportingCalls(byID, seen, out)
+}
+
+func indexAnnotationSupportingCalls(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[string]SupportingCall {
 	byID := make(map[string]SupportingCall)
 	for _, key := range closure {
 		fragment := fragments[key]
@@ -99,32 +108,49 @@ func attachAnnotationSupportingCalls(closure []ComponentKey, fragments map[Compo
 			}
 		}
 	}
-	if len(byID) == 0 {
-		return
-	}
+	return byID
+}
 
+func indexResultSupportingCalls(out *Result) map[string]bool {
 	seen := make(map[string]bool, len(out.SupportingCalls))
 	for i := range out.SupportingCalls {
 		if id := out.SupportingCalls[i].SupportingID; id != "" {
 			seen[id] = true
 		}
 	}
+	return seen
+}
+
+func attachMissingAnnotationSupportingCalls(
+	byID map[string]SupportingCall,
+	seen map[string]bool,
+	out *Result,
+) {
 	for i := range out.Chains {
 		op := out.Chains[i].CryptoOp
 		if op == nil {
 			continue
 		}
-		for _, id := range op.SupportingCallIDs {
-			if id == "" || seen[id] {
-				continue
-			}
-			sc, ok := byID[id]
-			if !ok {
-				continue
-			}
-			seen[id] = true
-			out.SupportingCalls = append(out.SupportingCalls, sc)
+		appendMissingSupportingCalls(op.SupportingCallIDs, byID, seen, out)
+	}
+}
+
+func appendMissingSupportingCalls(
+	ids []string,
+	byID map[string]SupportingCall,
+	seen map[string]bool,
+	out *Result,
+) {
+	for _, id := range ids {
+		if id == "" || seen[id] {
+			continue
 		}
+		sc, ok := byID[id]
+		if !ok {
+			continue
+		}
+		seen[id] = true
+		out.SupportingCalls = append(out.SupportingCalls, sc)
 	}
 }
 


### PR DESCRIPTION
deriveContractSupportingCalls matched a role-tagged method to a synthesized
terminal only when its receiver equalled the terminal type exactly, so methods
declared on a base class (e.g. GeneralDigest.update, inherited by SHA256Digest)
never attached. Make config/output lineage walk the contract hierarchy: a method
attaches when its receiver is the terminal type OR a transitive supertype of it.

Add the GeneralDigest.update role:config contract and the digest inheritance
edges (SHA256Digest->GeneralDigest, SHA3Digest->KeccakDigest) so the SHA-1/SHA-2
and SHA-3 families surface their inherited update()/getDigestSize() as supporting
calls on their constructor terminals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced inheritance-aware contract matching for call graph analysis, enabling more accurate detection of method roles across derived type implementations.
  * Improved handling of cryptographic library inheritance relationships for better contract applicability tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->