### PR TITLE
feat(python): add contracts for bcrypt, argon2, passlib, pynacl

### DIFF
--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -57,11 +57,9 @@ type Contract struct {
 	When          *Condition // nil = unconditional contract
 	Return        ContractReturn
 	SourceLibrary string // populated by Load() from the v2 YAML library.name field
-	// Role is a reserved, currently-unconsumed classification of a method's part
-	// in a crypto object's lifecycle (e.g. "config", "lifecycle", "output").
-	// Supporting calls are derived structurally from the call graph today;
-	// populating Role is the planned extension point for semantic categorization
-	// of those calls without re-introducing per-finding rules.
+	// Role classifies a method's part in a crypto object's lifecycle (e.g.
+	// "factory", "config", "output") so exported supporting calls can carry
+	// semantic categories without duplicating crypto rule metadata.
 	Role string
 }
 

--- a/internal/callgraph/contracts/python/argon2-cffi.yaml
+++ b/internal/callgraph/contracts/python/argon2-cffi.yaml
@@ -1,0 +1,49 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: argon2-cffi
+  coordinates:
+    - argon2-cffi
+  version_range: ">=23.0"
+  description: "argon2-cffi high-level PasswordHasher and low-level Argon2 APIs"
+
+contracts:
+  - method: argon2.PasswordHasher.<init>
+    arity: 0
+    return: { type: argon2.PasswordHasher, confidence: high }
+    role: factory
+  - method: argon2.PasswordHasher.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: argon2.PasswordHasher.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: argon2.PasswordHasher.check_needs_rehash
+    arity: 1
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: argon2.low_level.hash_secret
+    arity: 7
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: argon2.low_level.hash_secret_raw
+    arity: 7
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: argon2.low_level.verify_secret
+    arity: 3
+    return: { type: builtins.bool, confidence: high }
+    role: output
+
+hierarchy:
+  argon2.PasswordHasher:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.bool:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/bcrypt.yaml
+++ b/internal/callgraph/contracts/python/bcrypt.yaml
@@ -1,0 +1,33 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: bcrypt
+  coordinates:
+    - bcrypt
+  version_range: ">=4.0"
+  description: "pyca/bcrypt password hashing APIs"
+
+contracts:
+  - method: bcrypt.gensalt
+    arity: 0
+    return: { type: builtins.bytes, confidence: high }
+    role: factory
+  - method: bcrypt.hashpw
+    arity: 2
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: bcrypt.checkpw
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: bcrypt.kdf
+    arity: 4
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+
+hierarchy:
+  builtins.bytes:
+    - builtins.object
+  builtins.bool:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/passlib.yaml
+++ b/internal/callgraph/contracts/python/passlib.yaml
@@ -1,0 +1,192 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: passlib
+  coordinates:
+    - passlib
+  version_range: ">=1.7,<2.0"
+  description: "Passlib public password hash APIs and CryptContext"
+
+contracts:
+  - method: passlib.context.CryptContext.<init>
+    arity: 0
+    return: { type: passlib.context.CryptContext, confidence: high }
+    role: factory
+  - method: passlib.context.CryptContext.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.context.CryptContext.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+
+  - method: passlib.hash.bcrypt.using
+    arity: 0
+    return: { type: passlib.hash.bcrypt, confidence: high }
+    role: factory
+  - method: passlib.hash.bcrypt.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.hash.bcrypt.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: passlib.handlers.bcrypt.bcrypt.using
+    arity: 0
+    return: { type: passlib.handlers.bcrypt.bcrypt, confidence: high }
+    role: factory
+  - method: passlib.handlers.bcrypt.bcrypt.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.handlers.bcrypt.bcrypt.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+
+  - method: passlib.hash.argon2.using
+    arity: 0
+    return: { type: passlib.hash.argon2, confidence: high }
+    role: factory
+  - method: passlib.hash.argon2.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.hash.argon2.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: passlib.handlers.argon2.argon2.using
+    arity: 0
+    return: { type: passlib.handlers.argon2.argon2, confidence: high }
+    role: factory
+  - method: passlib.handlers.argon2.argon2.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.handlers.argon2.argon2.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+
+  - method: passlib.hash.scrypt.using
+    arity: 0
+    return: { type: passlib.hash.scrypt, confidence: high }
+    role: factory
+  - method: passlib.hash.scrypt.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.hash.scrypt.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: passlib.handlers.scrypt.scrypt.using
+    arity: 0
+    return: { type: passlib.handlers.scrypt.scrypt, confidence: high }
+    role: factory
+  - method: passlib.handlers.scrypt.scrypt.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: output
+  - method: passlib.handlers.scrypt.scrypt.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+
+  # Concrete Passlib handler/backend methods used when mining Passlib's own source.
+  # These APIs are terminal crypto entry points; role-tagged sibling/base methods
+  # provide semantic supporting-call context for direct rule findings.
+  - method: passlib.handlers._BcryptBackend._calc_checksum
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+  - method: passlib.handlers._PyBcryptBackend._calc_checksum_raw
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+  - method: passlib.handlers._BuiltinBackend._calc_checksum
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+  - method: passlib.handlers._BcryptCommon._prepare_digest_args
+    arity: 1
+    return: { type: builtins.tuple, confidence: high }
+    role: config
+  - method: passlib.handlers._BcryptCommon._get_config
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+    role: config
+  - method: passlib.handlers._BcryptCommon._generate_salt
+    arity: 0
+    return: { type: builtins.str, confidence: high }
+    role: config
+
+  - method: passlib.handlers._CffiBackend.hash
+    arity: 1
+    return: { type: builtins.str, confidence: high }
+  - method: passlib.handlers._CffiBackend.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+  - method: passlib.handlers._PureBackend._calc_checksum
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+  - method: passlib.handlers._Argon2Common.using
+    arity: 0
+    return: { type: passlib.handlers._Argon2Common, confidence: high }
+    role: config
+  - method: passlib.handlers._Argon2Common._get_backend_type
+    arity: 1
+    return: { type: builtins.object, confidence: high }
+    role: config
+  - method: passlib.handlers.scrypt._calc_checksum
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+  - method: passlib.handlers.scrypt.using
+    arity: 0
+    return: { type: passlib.handlers.scrypt, confidence: high }
+    role: config
+  - method: passlib.handlers.scrypt._generate_salt
+    arity: 0
+    return: { type: builtins.bytes, confidence: high }
+    role: config
+
+hierarchy:
+  passlib.context.CryptContext:
+    - builtins.object
+  passlib.hash.bcrypt:
+    - builtins.object
+  passlib.hash.argon2:
+    - builtins.object
+  passlib.hash.scrypt:
+    - builtins.object
+  passlib.handlers.bcrypt.bcrypt:
+    - builtins.object
+  passlib.handlers.argon2.argon2:
+    - builtins.object
+  passlib.handlers.scrypt.scrypt:
+    - builtins.object
+  passlib.handlers._BcryptBackend:
+    - passlib.handlers._BcryptCommon
+  passlib.handlers._PyBcryptBackend:
+    - passlib.handlers._BcryptCommon
+  passlib.handlers._BuiltinBackend:
+    - passlib.handlers._BcryptCommon
+  passlib.handlers._BcryptCommon:
+    - builtins.object
+  passlib.handlers._CffiBackend:
+    - passlib.handlers._Argon2Common
+  passlib.handlers._PureBackend:
+    - passlib.handlers._Argon2Common
+  passlib.handlers._Argon2Common:
+    - builtins.object
+  passlib.handlers.scrypt:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.tuple:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.bool:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/pynacl.yaml
+++ b/internal/callgraph/contracts/python/pynacl.yaml
@@ -1,0 +1,133 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: pynacl
+  coordinates:
+    - PyNaCl
+  version_range: ">=1.5"
+  description: "PyNaCl high-level secret/public/signing/hash/pwhash APIs"
+
+contracts:
+  - method: nacl.secret.SecretBox.<init>
+    arity: 1
+    return: { type: nacl.secret.SecretBox, confidence: high }
+    role: factory
+  - method: nacl.secret.SecretBox.encrypt
+    arity: 1
+    return: { type: nacl.utils.EncryptedMessage, confidence: high }
+    role: output
+  - method: nacl.secret.SecretBox.decrypt
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.public.PrivateKey.<init>
+    arity: 1
+    return: { type: nacl.public.PrivateKey, confidence: high }
+    role: factory
+  - method: nacl.public.PrivateKey.generate
+    arity: 0
+    return: { type: nacl.public.PrivateKey, confidence: high }
+    role: factory
+  - method: nacl.public.Box.<init>
+    arity: 2
+    return: { type: nacl.public.Box, confidence: high }
+    role: factory
+  - method: nacl.public.Box.encrypt
+    arity: 1
+    return: { type: nacl.utils.EncryptedMessage, confidence: high }
+    role: output
+  - method: nacl.public.Box.decrypt
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.public.SealedBox.<init>
+    arity: 1
+    return: { type: nacl.public.SealedBox, confidence: high }
+    role: factory
+  - method: nacl.public.SealedBox.encrypt
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.public.SealedBox.decrypt
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.signing.SigningKey.<init>
+    arity: 1
+    return: { type: nacl.signing.SigningKey, confidence: high }
+    role: factory
+  - method: nacl.signing.SigningKey.generate
+    arity: 0
+    return: { type: nacl.signing.SigningKey, confidence: high }
+    role: factory
+  - method: nacl.signing.SigningKey.sign
+    arity: 1
+    return: { type: nacl.signing.SignedMessage, confidence: high }
+    role: output
+  - method: nacl.signing.VerifyKey.<init>
+    arity: 1
+    return: { type: nacl.signing.VerifyKey, confidence: high }
+    role: factory
+  - method: nacl.signing.VerifyKey.verify
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.argon2i.kdf
+    arity: 5
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.argon2i.str
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.argon2i.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: nacl.pwhash.argon2id.kdf
+    arity: 5
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.argon2id.str
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.argon2id.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+  - method: nacl.pwhash.scrypt.kdf
+    arity: 5
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.scrypt.str
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+  - method: nacl.pwhash.scrypt.verify
+    arity: 2
+    return: { type: builtins.bool, confidence: high }
+    role: output
+
+hierarchy:
+  nacl.secret.SecretBox:
+    - builtins.object
+  nacl.public.PrivateKey:
+    - builtins.object
+  nacl.public.Box:
+    - builtins.object
+  nacl.public.SealedBox:
+    - builtins.object
+  nacl.signing.SigningKey:
+    - builtins.object
+  nacl.signing.VerifyKey:
+    - builtins.object
+  nacl.utils.EncryptedMessage:
+    - builtins.bytes
+  nacl.signing.SignedMessage:
+    - builtins.bytes
+  builtins.bytes:
+    - builtins.object
+  builtins.bool:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -307,6 +307,51 @@ func TestLoadEmbedded_Python_CryptodomeAlias(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_Python_BenchmarkLibraries(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantLib    string
+	}{
+		{"bcrypt.hashpw", 2, "builtins.bytes", "bcrypt"},
+		{"bcrypt.checkpw", 2, "builtins.bool", "bcrypt"},
+		{"argon2.PasswordHasher.<init>", 0, "argon2.PasswordHasher", "argon2-cffi"},
+		{"argon2.PasswordHasher.hash", 1, "builtins.str", "argon2-cffi"},
+		{"passlib.context.CryptContext.hash", 1, "builtins.str", "passlib"},
+		{"passlib.hash.bcrypt.using", 0, "passlib.hash.bcrypt", "passlib"},
+		{"passlib.hash.argon2.hash", 1, "builtins.str", "passlib"},
+		{"passlib.hash.scrypt.verify", 2, "builtins.bool", "passlib"},
+		{"nacl.secret.SecretBox.<init>", 1, "nacl.secret.SecretBox", "pynacl"},
+		{"nacl.secret.SecretBox.encrypt", 1, "nacl.utils.EncryptedMessage", "pynacl"},
+		{"nacl.public.PrivateKey.generate", 0, "nacl.public.PrivateKey", "pynacl"},
+		{"nacl.signing.SigningKey.sign", 1, "nacl.signing.SignedMessage", "pynacl"},
+		{"nacl.pwhash.argon2id.kdf", 5, "builtins.bytes", "pynacl"},
+	}
+
+	for _, tt := range tests {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) == 0 {
+			t.Errorf("%s#%d: no contracts found", tt.method, tt.arity)
+			continue
+		}
+		c := got[0]
+		if c.Return.Type != tt.wantReturn {
+			t.Errorf("%s#%d return type = %q, want %q", tt.method, tt.arity, c.Return.Type, tt.wantReturn)
+		}
+		if c.SourceLibrary != tt.wantLib {
+			t.Errorf("%s#%d source library = %q, want %q", tt.method, tt.arity, c.SourceLibrary, tt.wantLib)
+		}
+		if c.Return.Confidence != "high" {
+			t.Errorf("%s#%d confidence = %q, want high", tt.method, tt.arity, c.Return.Confidence)
+		}
+	}
+}
+
 // TestLoadEmbedded_Python_AllLibrariesHaveValidReturnTypes asserts that every
 // contract in the merged Python KB has a non-empty return type and "high"
 // confidence (the only author-facing confidence level per crypto-kb-author skill).

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -215,7 +215,7 @@ func synthesizeDeclaredAPIAssets(
 ) int {
 	added := 0
 	for _, fn := range decls {
-		if functionBodyHasFinding(report, fn) {
+		if functionBodyHasTerminalFinding(report, fn) {
 			continue // Type 1: primitive already detected inside the method.
 		}
 		if appendSyntheticRuleAsset(report, fileIdx, api, meta, fn) {
@@ -298,10 +298,10 @@ func baseFQN(fqn string) string {
 	return fqn
 }
 
-// functionBodyHasFinding reports whether report already contains a crypto asset
-// located within fn's line range in fn's file — i.e. the method itself performs
-// a detectable crypto operation (Type 1) and is already a natural entry point.
-func functionBodyHasFinding(report *entities.InterimReport, fn *callgraph.FunctionDecl) bool {
+// functionBodyHasTerminalFinding reports whether report already contains a
+// non-supporting crypto asset inside fn. CSPRNG salt generation is supporting
+// evidence and must not suppress a synthesized KDF/hash API boundary.
+func functionBodyHasTerminalFinding(report *entities.InterimReport, fn *callgraph.FunctionDecl) bool {
 	fnPath := filepath.ToSlash(fn.FilePath)
 	for i := range report.Findings {
 		if !strings.HasSuffix(fnPath, filepath.ToSlash(report.Findings[i].FilePath)) &&
@@ -310,12 +310,16 @@ func functionBodyHasFinding(report *entities.InterimReport, fn *callgraph.Functi
 		}
 		for j := range report.Findings[i].CryptographicAssets {
 			a := &report.Findings[i].CryptographicAssets[j]
-			if a.StartLine >= fn.StartLine && a.StartLine <= fn.EndLine {
+			if a.StartLine >= fn.StartLine && a.StartLine <= fn.EndLine && syntheticSuppressingAsset(a) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func syntheticSuppressingAsset(a *entities.CryptographicAsset) bool {
+	return a.Metadata["algorithmPrimitive"] != "drbg"
 }
 
 // buildSyntheticAssetFromRule constructs a CryptographicAsset at the API method's
@@ -433,7 +437,9 @@ func addRuleCrypto(out map[string]map[string]string, crypto map[string]any, ecos
 	if _, seen := out[api]; seen {
 		return // first declaration wins; deterministic enough for synthesis
 	}
-	out[api] = stringifyCryptoBlock(crypto)
+	meta := stringifyCryptoBlock(crypto)
+	removeUnresolvedMetadataVariables(meta)
+	out[api] = meta
 }
 
 func cryptoAPI(crypto map[string]any, ecosystem string) (string, bool) {
@@ -484,6 +490,14 @@ func stringifyCryptoBlock(crypto map[string]any) map[string]string {
 		md[k] = fmt.Sprintf("%v", v)
 	}
 	return md
+}
+
+func removeUnresolvedMetadataVariables(meta map[string]string) {
+	for k, v := range meta {
+		if strings.Contains(v, "$") {
+			delete(meta, k)
+		}
+	}
 }
 
 // expandRuleFiles returns the YAML rule files for a path that may be a file or a

--- a/internal/engine/rule_entrypoint_synthesis_test.go
+++ b/internal/engine/rule_entrypoint_synthesis_test.go
@@ -391,3 +391,70 @@ func TestSynthesize_NoOpWhenBodyAlreadyDetected(t *testing.T) {
 		t.Fatalf("expected 0 synthesized findings when body already detected, got %d", n)
 	}
 }
+
+func TestSynthesize_DrbgFindingDoesNotSuppressBoundaryAsset(t *testing.T) {
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "argon2.PasswordHasher.hash", "Argon2")
+	decl := &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "argon2", Type: "PasswordHasher", Name: "hash"},
+		FilePath:  "argon2/_password_hasher.py",
+		StartLine: 190,
+		EndLine:   205,
+	}
+	report := &entities.InterimReport{
+		Findings: []entities.Finding{{
+			FilePath: decl.FilePath,
+			Language: "python",
+			CryptographicAssets: []entities.CryptographicAsset{{
+				StartLine: 201,
+				Metadata: map[string]string{
+					"algorithmPrimitive": "drbg",
+					"api":                "urandom",
+				},
+			}},
+		}},
+	}
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graphWith(decl), []string{rule}, "python"); n != 1 {
+		t.Fatalf("expected boundary asset despite supporting drbg finding, got %d", n)
+	}
+	if got := len(report.Findings[0].CryptographicAssets); got != 2 {
+		t.Fatalf("assets len = %d, want drbg + synthesized KDF", got)
+	}
+}
+
+func TestSynthesize_RemovesUnresolvedRuleMetadataVariables(t *testing.T) {
+	dir := t.TempDir()
+	rule := filepath.Join(dir, "rule.yaml")
+	if err := os.WriteFile(rule, []byte(""+
+		"rules:\n"+
+		"  - id: test.rule\n"+
+		"    metadata:\n"+
+		"      crypto:\n"+
+		"        assetType: algorithm\n"+
+		"        algorithmPrimitive: kdf\n"+
+		"        algorithmFamily: Argon2\n"+
+		"        algorithmName: Argon2$variant\n"+
+		"        operation: keyderive\n"+
+		"        api: argon2.low_level.hash_secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	decl := &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "argon2.low_level", Name: "hash_secret"},
+		FilePath:  "argon2/low_level.py",
+		StartLine: 52,
+		EndLine:   80,
+	}
+	report := &entities.InterimReport{}
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graphWith(decl), []string{rule}, "python"); n != 1 {
+		t.Fatalf("expected generic synthetic finding with unresolved fields removed, got %d", n)
+	}
+	asset := report.Findings[0].CryptographicAssets[0]
+	if asset.Metadata["algorithmName"] != "" {
+		t.Fatalf("expected unresolved algorithmName to be removed, got %q", asset.Metadata["algorithmName"])
+	}
+	if asset.Metadata["algorithmFamily"] != "Argon2" {
+		t.Fatalf("expected stable algorithmFamily to be preserved, got %q", asset.Metadata["algorithmFamily"])
+	}
+}

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -841,6 +841,9 @@ func deriveSupportingCallsForFinding(ctx *exportBuildContext, finding entities.F
 	if isSyntheticEntryPoint(asset) {
 		return deriveContractSupportingCalls(ctx, asset)
 	}
+	if contractCalls := deriveContractSupportingCalls(ctx, asset); len(contractCalls) > 0 {
+		return contractCalls
+	}
 	containingFn := ctx.findContainingFunctionByFinding(finding.FilePath, asset.StartLine)
 	if containingFn == nil {
 		return nil

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -841,9 +841,6 @@ func deriveSupportingCallsForFinding(ctx *exportBuildContext, finding entities.F
 	if isSyntheticEntryPoint(asset) {
 		return deriveContractSupportingCalls(ctx, asset)
 	}
-	if contractCalls := deriveContractSupportingCalls(ctx, asset); len(contractCalls) > 0 {
-		return contractCalls
-	}
 	containingFn := ctx.findContainingFunctionByFinding(finding.FilePath, asset.StartLine)
 	if containingFn == nil {
 		return nil
@@ -857,7 +854,9 @@ func deriveSupportingCallsForFinding(ctx *exportBuildContext, finding entities.F
 		return nil
 	}
 	lifecycle := deriveObjectLifecycleCalls(containingFn, terminal)
-	out := make([]callGraphSupportingCall, 0, len(lifecycle))
+	contractCalls := deriveContractSupportingCalls(ctx, asset)
+	out := make([]callGraphSupportingCall, 0, len(lifecycle)+len(contractCalls))
+	out = append(out, contractCalls...)
 	for _, c := range lifecycle {
 		out = append(out, buildDerivedSupportingCall(ctx, containingFn, c))
 	}

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -417,15 +417,40 @@ func findCryptoEntryPointByFunctionKey(points []callGraphCryptoEntryPoint, key s
 	return nil
 }
 
-func TestDeriveSupportingCallsForFinding_UsesContractRolesForDirectAssets(t *testing.T) {
+func TestDeriveSupportingCallsForFinding_CombinesContractRolesForDirectAssets(t *testing.T) {
 	t.Parallel()
 
-	decl := &callgraph.FunctionDecl{
+	owner := callgraph.FunctionID{Package: "pkg", Type: "Svc", Name: "run"}
+	structuralCall := callgraph.FunctionCall{
+		Callee:      callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "prepare"},
+		ReceiverVar: "builder",
+		Raw:         "builder.prepare()",
+		FilePath:    "lib.py",
+		Line:        11,
+	}
+	terminalCall := callgraph.FunctionCall{
+		Callee:      callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "terminal"},
+		ReceiverVar: "builder",
+		Raw:         "builder.terminal(secret)",
+		FilePath:    "lib.py",
+		Line:        12,
+	}
+	ownerDecl := &callgraph.FunctionDecl{
+		ID:        owner,
+		FilePath:  "lib.py",
+		StartLine: 10,
+		EndLine:   20,
+		Calls:     []callgraph.FunctionCall{structuralCall, terminalCall},
+	}
+	contractDecl := &callgraph.FunctionDecl{
 		ID:        callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "configure"},
 		FilePath:  "lib.py",
-		StartLine: 12,
+		StartLine: 8,
 	}
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{owner.String(): ownerDecl}}
 	ctx := &exportBuildContext{
+		graph:                   graph,
+		containingFunctionCache: make(map[string]cachedContainingFunction),
 		kb: &contracts.KnowledgeBase{
 			Contracts: map[string][]contracts.Contract{
 				"pkg.Builder.terminal#1": {{
@@ -442,21 +467,25 @@ func TestDeriveSupportingCallsForFinding_UsesContractRolesForDirectAssets(t *tes
 			},
 			Hierarchy: map[string][]string{"pkg.Builder": {"builtins.object"}},
 		},
-		declIndex: map[string]*callgraph.FunctionDecl{"pkg.Builder.configure": decl},
+		declIndex: map[string]*callgraph.FunctionDecl{"pkg.Builder.configure": contractDecl},
 	}
 	asset := entities.CryptographicAsset{
-		Metadata: map[string]string{"api": "pkg.Builder.terminal"},
-		Rules:    []entities.RuleInfo{{ID: "direct-rule"}},
+		StartLine: 12,
+		EndLine:   12,
+		Match:     "builder.terminal(secret)",
+		Metadata:  map[string]string{"api": "pkg.Builder.terminal"},
+		Rules:     []entities.RuleInfo{{ID: "direct-rule"}},
 	}
+	finding := entities.Finding{FilePath: "lib.py"}
 
-	got := deriveSupportingCallsForFinding(ctx, entities.Finding{}, asset)
-	if len(got) != 1 {
-		t.Fatalf("supporting calls = %d, want 1", len(got))
+	got := deriveSupportingCallsForFinding(ctx, finding, asset)
+	if len(got) != 2 {
+		t.Fatalf("supporting calls = %d, want contract + structural", len(got))
 	}
 	if got[0].Category != "config" {
-		t.Fatalf("category = %q, want config", got[0].Category)
+		t.Fatalf("contract category = %q, want config", got[0].Category)
 	}
-	if got[0].FunctionName != "pkg.Builder.configure" {
-		t.Fatalf("function = %q, want pkg.Builder.configure", got[0].FunctionName)
+	if got[1].FunctionName != "pkg.Svc.run" {
+		t.Fatalf("structural function = %q, want pkg.Svc.run", got[1].FunctionName)
 	}
 }

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 
@@ -414,4 +415,48 @@ func findCryptoEntryPointByFunctionKey(points []callGraphCryptoEntryPoint, key s
 		}
 	}
 	return nil
+}
+
+func TestDeriveSupportingCallsForFinding_UsesContractRolesForDirectAssets(t *testing.T) {
+	t.Parallel()
+
+	decl := &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "configure"},
+		FilePath:  "lib.py",
+		StartLine: 12,
+	}
+	ctx := &exportBuildContext{
+		kb: &contracts.KnowledgeBase{
+			Contracts: map[string][]contracts.Contract{
+				"pkg.Builder.terminal#1": {{
+					Method: "pkg.Builder.terminal",
+					Arity:  1,
+					Return: contracts.ContractReturn{Type: "pkg.Result", Confidence: "high"},
+				}},
+				"pkg.Builder.configure#0": {{
+					Method: "pkg.Builder.configure",
+					Arity:  0,
+					Return: contracts.ContractReturn{Type: "pkg.Builder", Confidence: "high"},
+					Role:   "config",
+				}},
+			},
+			Hierarchy: map[string][]string{"pkg.Builder": {"builtins.object"}},
+		},
+		declIndex: map[string]*callgraph.FunctionDecl{"pkg.Builder.configure": decl},
+	}
+	asset := entities.CryptographicAsset{
+		Metadata: map[string]string{"api": "pkg.Builder.terminal"},
+		Rules:    []entities.RuleInfo{{ID: "direct-rule"}},
+	}
+
+	got := deriveSupportingCallsForFinding(ctx, entities.Finding{}, asset)
+	if len(got) != 1 {
+		t.Fatalf("supporting calls = %d, want 1", len(got))
+	}
+	if got[0].Category != "config" {
+		t.Fatalf("category = %q, want config", got[0].Category)
+	}
+	if got[0].FunctionName != "pkg.Builder.configure" {
+		t.Fatalf("function = %q, want pkg.Builder.configure", got[0].FunctionName)
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cryptographic library support for Python's argon2-cffi, bcrypt, passlib, and PyNaCl, enabling detection and categorization of their crypto APIs.
  * Implemented contract-based supporting call derivation to classify cryptographic methods by their lifecycle role.

* **Bug Fixes**
  * Improved DRBG (deterministic random bit generator) handling to prevent unnecessary suppression of synthesized findings.
  * Fixed removal of unresolved metadata variables from synthesized crypto findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->