### PR TITLE
fix(rules): stop ruleset filter cache from nesting into itself

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -36,6 +36,14 @@ const (
 
 	// RulesetsDirName is the rulesets cache directory name.
 	RulesetsDirName = "rulesets"
+
+	// FilteredRulesDirName is the directory, created inside a ruleset version
+	// root, where the language-filtered working copy of the rules is
+	// materialized for the scanner. It MUST be excluded from every rule-tree
+	// walk: it lives inside the same tree the loaders read from, so walking
+	// into it re-ingests previous runs' copies and the cache grows
+	// geometrically (a "copying a directory into itself" bug).
+	FilteredRulesDirName = ".crypto-finder-filtered"
 )
 
 // GetRootDir returns the path to the SCANOSS root directory (~/.scanoss)

--- a/internal/engine/rule_filter.go
+++ b/internal/engine/rule_filter.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"go.yaml.in/yaml/v3"
@@ -147,10 +148,17 @@ func materializeRuleFiles(ruleFiles []string) ([]string, func(), error) {
 	baseDir := commonRuleBaseDir(ruleFiles)
 	tempParent := ""
 	if rulesetRoot := rulesetVersionRoot(baseDir); rulesetRoot != "" {
-		tempParent = filepath.Join(rulesetRoot, ".crypto-finder-filtered")
+		tempParent = filepath.Join(rulesetRoot, config.FilteredRulesDirName)
 		if err := os.MkdirAll(tempParent, 0o750); err != nil {
 			return nil, nil, fmt.Errorf("create filtered rules temp parent: %w", err)
 		}
+		// Reap orphaned run-* dirs from prior jobs. The deferred cleanup
+		// below removes this run's dir on exit, but the mining worker
+		// SIGKILLs the whole process group on timeout, so killed jobs never
+		// run it and leak their run-* dir into the shared HOME cache. Prune
+		// only dirs older than the longest possible job so an in-flight
+		// concurrent run is never touched.
+		pruneStaleFilteredRuns(tempParent)
 	}
 
 	tempRoot, err := os.MkdirTemp(tempParent, "run-*")
@@ -185,6 +193,41 @@ func materializeRuleFiles(ruleFiles []string) ([]string, func(), error) {
 	return []string{targetRoot}, func() {
 		removeMaterializedRules(tempRoot)
 	}, nil
+}
+
+// filteredRunTTL is how old a run-* dir under .crypto-finder-filtered must be
+// before pruneStaleFilteredRuns reclaims it. It must comfortably exceed the
+// longest scan a concurrent process could still be running against its own
+// run-* dir, so we never delete a live one. Scans are bounded by the caller's
+// --timeout (the mining worker uses 30m); 2h leaves a wide safety margin while
+// still reclaiming disk from SIGKILLed jobs within the same day.
+const filteredRunTTL = 2 * time.Hour
+
+// pruneStaleFilteredRuns removes orphaned run-* directories left under
+// tempParent by jobs that never ran their cleanup (e.g. SIGKILLed on timeout
+// by the mining worker's process-group kill). Best-effort: only dirs whose
+// mtime is older than filteredRunTTL are removed, so an in-flight concurrent
+// run is never touched. All errors are swallowed — this is opportunistic
+// housekeeping, not part of the scan's correctness.
+func pruneStaleFilteredRuns(tempParent string) {
+	entries, err := os.ReadDir(tempParent)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-filteredRunTTL)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "run-") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		stale := filepath.Join(tempParent, entry.Name())
+		if rmErr := os.RemoveAll(stale); rmErr != nil {
+			log.Debug().Err(rmErr).Str("path", stale).Msg("Failed to prune stale filtered rules dir")
+		}
+	}
 }
 
 // removeMaterializedRules deletes a materialized rules directory, logging a
@@ -330,6 +373,12 @@ func collectRuleFiles(root string) []string {
 			return err
 		}
 		if d.IsDir() {
+			// Never descend into the materialized-rules dir: it lives inside
+			// the ruleset tree we're walking, so ingesting it would re-copy
+			// prior runs' output and the cache would grow geometrically.
+			if d.Name() == config.FilteredRulesDirName {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		ext := strings.ToLower(filepath.Ext(path))

--- a/internal/engine/rule_filter_test.go
+++ b/internal/engine/rule_filter_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/scanoss/crypto-finder/internal/config"
 )
 
 func writeRuleFile(t *testing.T, dir, name, content string) string {
@@ -152,6 +155,119 @@ func TestPrepareRulePathsForScanner_MaterializesFilteredFiles(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(paths[0], "nested", "go-extra.yaml")); err != nil {
 		t.Fatalf("expected copied nested go rule: %v", err)
+	}
+}
+
+// TestCollectRuleFiles_SkipsFilteredDir is the regression guard for the
+// self-nesting cache bug: collectRuleFiles must never descend into the
+// materialized .crypto-finder-filtered dir, otherwise each scan re-ingests the
+// previous run's copies and the ruleset cache grows geometrically.
+func TestCollectRuleFiles_SkipsFilteredDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	_ = writeRuleFile(t, root, "real.yaml", `rules:
+  - id: real
+    languages: [go]
+`)
+
+	// Simulate a prior run's materialized output living inside the tree.
+	filteredRun := filepath.Join(root, config.FilteredRulesDirName, "run-123", "latest")
+	if err := os.MkdirAll(filteredRun, 0o755); err != nil {
+		t.Fatalf("mkdir filtered run: %v", err)
+	}
+	_ = writeRuleFile(t, filteredRun, "copy.yaml", `rules:
+  - id: copy
+    languages: [go]
+`)
+
+	files := collectRuleFiles(root)
+	if len(files) != 1 {
+		t.Fatalf("collectRuleFiles len = %d, want 1 (must skip %s); got %v",
+			len(files), config.FilteredRulesDirName, files)
+	}
+	if filepath.Base(files[0]) != "real.yaml" {
+		t.Fatalf("collectRuleFiles returned %v, want only real.yaml", files)
+	}
+}
+
+// TestMaterializeRuleFiles_NoGeometricGrowth proves that materializing rules
+// inside the ruleset tree does not cause the next rule-tree walk to re-ingest
+// the materialized copy. Without the SkipDir guard, the second walk would see
+// the originals PLUS run-*'s copies and the count would balloon every scan.
+func TestMaterializeRuleFiles_NoGeometricGrowth(t *testing.T) {
+	// Cannot be parallel: overrides HOME so GetRulesetsDir resolves under temp,
+	// which is required for materializeRuleFiles to write inside the tree.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rulesetsDir, err := config.GetRulesetsDir()
+	if err != nil {
+		t.Fatalf("GetRulesetsDir: %v", err)
+	}
+	versionRoot := filepath.Join(rulesetsDir, "dca", "latest")
+	if err := os.MkdirAll(versionRoot, 0o755); err != nil {
+		t.Fatalf("mkdir version root: %v", err)
+	}
+	a := writeRuleFile(t, versionRoot, "a.yaml", `rules:
+  - id: a
+    languages: [go]
+`)
+	b := writeRuleFile(t, versionRoot, "b.yaml", `rules:
+  - id: b
+    languages: [go]
+`)
+
+	before := len(collectRuleFiles(versionRoot))
+	if before != 2 {
+		t.Fatalf("setup: collectRuleFiles before = %d, want 2", before)
+	}
+
+	// Materialize once, leaving the run-* dir in place (simulating a SIGKILLed
+	// job that never ran its cleanup).
+	_, _, err = optimizeRulePathsForScanner([]string{a, b})
+	if err != nil {
+		t.Fatalf("optimizeRulePathsForScanner: %v", err)
+	}
+
+	// The filtered dir must now exist inside the tree...
+	if _, err := os.Stat(filepath.Join(versionRoot, config.FilteredRulesDirName)); err != nil {
+		t.Fatalf("expected materialized dir inside version root: %v", err)
+	}
+	// ...but the next walk must still see only the two originals.
+	after := len(collectRuleFiles(versionRoot))
+	if after != before {
+		t.Fatalf("collectRuleFiles after materialize = %d, want %d (cache is re-ingesting itself)", after, before)
+	}
+}
+
+func TestPruneStaleFilteredRuns(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	stale := filepath.Join(parent, "run-stale")
+	fresh := filepath.Join(parent, "run-fresh")
+	keep := filepath.Join(parent, "not-a-run")
+	for _, d := range []string{stale, fresh, keep} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	old := time.Now().Add(-3 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	pruneStaleFilteredRuns(parent)
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("expected stale run-* pruned, err=%v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("expected fresh run-* kept: %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("expected non-run dir untouched: %v", err)
 	}
 }
 

--- a/internal/rules/source_local.go
+++ b/internal/rules/source_local.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/scanoss/crypto-finder/internal/config"
 	"github.com/scanoss/crypto-finder/internal/entities"
 )
 
@@ -181,6 +182,13 @@ func (l *LocalRuleSource) loadRulesFromDirectory(dirPath string) ([]string, erro
 
 		// Skip directories
 		if info.IsDir() {
+			// Never descend into the materialized filtered-rules dir: it is
+			// written inside the ruleset tree we read from, so ingesting it
+			// re-copies previous runs' output and the cache grows
+			// geometrically (a "copying a directory into itself" bug).
+			if info.Name() == config.FilteredRulesDirName {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where previously processed rules could be re-ingested, causing cache and directory growth
  * Added automatic cleanup of stale temporary rule files with a 2-hour retention policy to prevent disk bloat

* **Tests**
  * Added comprehensive test coverage for rule filtering and materialization behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->