### PR TITLE
feat: synthesize multiple crypto functions per entry-point api

### DIFF
--- a/internal/converter/aggregator.go
+++ b/internal/converter/aggregator.go
@@ -37,6 +37,15 @@ type AggregatedAsset struct {
 	// Identities tracks all unique detection methods (rules) that found this asset
 	Identities []AssetIdentity
 
+	// CryptoFunctions collects the distinct raw cryptoFunction/operation values
+	// (e.g. "encrypt", "decrypt") seen across every asset grouped into this
+	// entry, in first-seen order. Two rules can legitimately share one algorithm
+	// identity while detecting different operations at the same declaration
+	// site (e.g. AESEngine.init synthesized once as encrypt and once as
+	// decrypt) -- this field preserves both instead of only the
+	// ReferenceAsset's single value.
+	CryptoFunctions []string
+
 	// ReferenceAsset holds one representative asset for extracting common metadata
 	ReferenceAsset *entities.CryptographicAsset
 
@@ -157,6 +166,9 @@ func (a *Aggregator) AggregateAssets(report *entities.InterimReport) ([]Aggregat
 
 			// Add identity if it's a new rule
 			a.addIdentityIfNew(aggregated, asset)
+
+			// Merge this asset's crypto function into the group (deduped).
+			a.addCryptoFunctionIfNew(aggregated, asset)
 		}
 	}
 
@@ -216,6 +228,22 @@ func (a *Aggregator) addIdentityIfNew(aggregated *AggregatedAsset, asset *entiti
 			aggregated.Identities = append(aggregated.Identities, identity)
 		}
 	}
+}
+
+// addCryptoFunctionIfNew appends asset's raw cryptoFunction/operation value to
+// aggregated.CryptoFunctions when it resolves to something non-empty and is
+// not already present, preserving first-seen order.
+func (a *Aggregator) addCryptoFunctionIfNew(aggregated *AggregatedAsset, asset *entities.CryptographicAsset) {
+	raw := resolveRawCryptoFunction(asset)
+	if raw == "" {
+		return
+	}
+	for _, existing := range aggregated.CryptoFunctions {
+		if existing == raw {
+			return
+		}
+	}
+	aggregated.CryptoFunctions = append(aggregated.CryptoFunctions, raw)
 }
 
 // SortAssets sorts aggregated assets alphabetically by Name for deterministic output.

--- a/internal/converter/aggregator_test.go
+++ b/internal/converter/aggregator_test.go
@@ -555,3 +555,114 @@ func TestAggregator_GetAssetKey(t *testing.T) {
 		})
 	}
 }
+
+// TestAggregator_CryptoFunctions_MergedAcrossSameIdentityAssets guards the DCA
+// case where two rules share one api with different operation/cryptoFunction
+// (e.g. AESEngine.init as both encrypt and decrypt, synthesized by rule-entrypoint
+// synthesis at the same declaration site). Both assets collapse into a single
+// AggregatedAsset by name (as they already do), but the crypto function signal
+// from BOTH assets must be preserved -- not just the first ReferenceAsset's.
+func TestAggregator_CryptoFunctions_MergedAcrossSameIdentityAssets(t *testing.T) {
+	aggregator := NewAggregator()
+
+	report := &entities.InterimReport{
+		Version: "1.0",
+		Tool:    entities.ToolInfo{Name: "test", Version: "1.0"},
+		Findings: []entities.Finding{
+			{
+				FilePath: "org/bouncycastle/crypto/engines/AESEngine.java",
+				Language: "java",
+				CryptographicAssets: []entities.CryptographicAsset{
+					{
+						StartLine: 70,
+						EndLine:   70,
+						Rules:     []entities.RuleInfo{{ID: "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", Severity: "INFO"}},
+						Metadata: map[string]string{
+							"assetType":          "algorithm",
+							"algorithmFamily":    "AES",
+							"algorithmPrimitive": "block-cipher",
+							"operation":          "encrypt",
+							"cryptoFunction":     "encrypt",
+							"api":                "org.bouncycastle.crypto.engines.AESEngine.init",
+						},
+					},
+					{
+						StartLine: 70,
+						EndLine:   70,
+						Rules:     []entities.RuleInfo{{ID: "java.bouncycastle.algorithm.block-cipher.aes-init-decrypt", Severity: "INFO"}},
+						Metadata: map[string]string{
+							"assetType":          "algorithm",
+							"algorithmFamily":    "AES",
+							"algorithmPrimitive": "block-cipher",
+							"operation":          "decrypt",
+							"cryptoFunction":     "decrypt",
+							"api":                "org.bouncycastle.crypto.engines.AESEngine.init",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	aggregated, err := aggregator.AggregateAssets(report)
+	if err != nil {
+		t.Fatalf("AggregateAssets() error = %v", err)
+	}
+	if len(aggregated) != 1 {
+		t.Fatalf("expected 1 aggregated asset (same algorithm name), got %d", len(aggregated))
+	}
+
+	asset := aggregated[0]
+	if len(asset.CryptoFunctions) != 2 {
+		t.Fatalf("expected 2 merged crypto functions, got %d: %v", len(asset.CryptoFunctions), asset.CryptoFunctions)
+	}
+
+	got := map[string]bool{}
+	for _, fn := range asset.CryptoFunctions {
+		got[fn] = true
+	}
+	if !got["encrypt"] || !got["decrypt"] {
+		t.Fatalf("expected both encrypt and decrypt merged, got %v", asset.CryptoFunctions)
+	}
+}
+
+// TestAggregator_CryptoFunctions_DedupedForRepeatedOperation guards that
+// repeated occurrences carrying the SAME cryptoFunction (e.g. the same
+// encrypt-only asset detected in two files) do not produce duplicate entries.
+func TestAggregator_CryptoFunctions_DedupedForRepeatedOperation(t *testing.T) {
+	aggregator := NewAggregator()
+
+	makeAsset := func(line int) entities.CryptographicAsset {
+		return entities.CryptographicAsset{
+			StartLine: line,
+			EndLine:   line,
+			Rules:     []entities.RuleInfo{{ID: "go-aes-encrypt", Severity: "INFO"}},
+			Metadata: map[string]string{
+				"assetType":          "algorithm",
+				"algorithmFamily":    "AES",
+				"algorithmPrimitive": "block-cipher",
+				"operation":          "encrypt",
+			},
+		}
+	}
+
+	report := &entities.InterimReport{
+		Version: "1.0",
+		Tool:    entities.ToolInfo{Name: "test", Version: "1.0"},
+		Findings: []entities.Finding{
+			{FilePath: "a.go", Language: "go", CryptographicAssets: []entities.CryptographicAsset{makeAsset(1)}},
+			{FilePath: "b.go", Language: "go", CryptographicAssets: []entities.CryptographicAsset{makeAsset(2)}},
+		},
+	}
+
+	aggregated, err := aggregator.AggregateAssets(report)
+	if err != nil {
+		t.Fatalf("AggregateAssets() error = %v", err)
+	}
+	if len(aggregated) != 1 {
+		t.Fatalf("expected 1 aggregated asset, got %d", len(aggregated))
+	}
+	if got := aggregated[0].CryptoFunctions; len(got) != 1 || got[0] != "encrypt" {
+		t.Fatalf("expected deduped CryptoFunctions = [encrypt], got %v", got)
+	}
+}

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -170,7 +170,67 @@ func (c *Converter) convertAggregatedAsset(aggregated *AggregatedAsset) (*cdx.Co
 	baseComponent.Name = aggregated.Name
 	baseComponent.Evidence = c.buildEvidence(aggregated)
 
+	if aggregated.AssetType == AssetTypeAlgorithm {
+		mergeCryptoFunctions(baseComponent, aggregated.CryptoFunctions)
+	}
+
 	return baseComponent, nil
+}
+
+// mergeCryptoFunctions overwrites the component's CycloneDX CryptoFunctions
+// array and scanoss:cryptoFunction property with the full set of raw function
+// values collected across every asset in the aggregated group, when that set
+// has more than one distinct value. The mapper already set both fields from a
+// single ReferenceAsset; when two rules share one algorithm identity but carry
+// different operations (e.g. AESEngine.init synthesized as both encrypt and
+// decrypt at the same declaration site), that single-value baseline is
+// replaced here so no signal is silently dropped by aggregation.
+func mergeCryptoFunctions(component *cdx.Component, rawFunctions []string) {
+	if len(rawFunctions) < 2 || component.CryptoProperties == nil {
+		return // Nothing to merge; the mapper's single-function baseline stands.
+	}
+	algProps := component.CryptoProperties.AlgorithmProperties
+	if algProps == nil {
+		return
+	}
+
+	// Distinct raw values can normalize to the same enum (e.g. "hash" and
+	// "digest" both map to digest), so dedup by the mapped value.
+	functions := make([]cdx.CryptoFunction, 0, len(rawFunctions))
+	seen := make(map[cdx.CryptoFunction]struct{}, len(rawFunctions))
+	for _, raw := range rawFunctions {
+		fn, ok := mapRawCryptoFunctionToCycloneDX(raw)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[fn]; dup {
+			continue
+		}
+		seen[fn] = struct{}{}
+		functions = append(functions, fn)
+	}
+	if len(functions) > 0 {
+		algProps.CryptoFunctions = &functions
+	}
+
+	setCryptoFunctionProperty(component, strings.Join(rawFunctions, ","))
+}
+
+// setCryptoFunctionProperty replaces the scanoss:cryptoFunction property value
+// in place (or adds it if absent for some reason) instead of appending a
+// duplicate alongside the single-value one the mapper already added.
+func setCryptoFunctionProperty(component *cdx.Component, value string) {
+	if component.Properties == nil {
+		addCustomProperty(component, scanossCryptoFunctionPropertyName, value)
+		return
+	}
+	for i := range *component.Properties {
+		if (*component.Properties)[i].Name == scanossCryptoFunctionPropertyName {
+			(*component.Properties)[i].Value = value
+			return
+		}
+	}
+	addCustomProperty(component, scanossCryptoFunctionPropertyName, value)
 }
 
 // buildEvidence constructs the evidence structure with occurrences and identities.

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -400,6 +400,106 @@ func TestConverter_MultipleRulesOnSameLine(t *testing.T) {
 	}
 }
 
+// TestConverter_MergesCryptoFunctionsForSharedAPIDifferentOperation guards the
+// DCA multi-crypto-function synthesis case: two synthesized assets at the same
+// declaration site (org.bouncycastle.crypto.engines.AESEngine.init) share one
+// algorithm identity but differ in cryptoFunction (encrypt vs decrypt). They
+// must collapse into ONE CDX component (as aggregation-by-name already does),
+// and that component's CryptoFunctions array must carry BOTH values instead of
+// only the first asset's.
+func TestConverter_MergesCryptoFunctionsForSharedAPIDifferentOperation(t *testing.T) {
+	converter := NewConverter()
+
+	report := &entities.InterimReport{
+		Version: "1.0",
+		Tool:    entities.ToolInfo{Name: "test", Version: "1.0"},
+		Findings: []entities.Finding{
+			{
+				FilePath: "org/bouncycastle/crypto/engines/AESEngine.java",
+				Language: "java",
+				CryptographicAssets: []entities.CryptographicAsset{
+					{
+						StartLine: 70,
+						EndLine:   70,
+						Rules:     []entities.RuleInfo{{ID: "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", Severity: "INFO"}},
+						Metadata: map[string]string{
+							"assetType":          "algorithm",
+							"algorithmFamily":    "AES",
+							"algorithmPrimitive": "block-cipher",
+							"operation":          "encrypt",
+							"cryptoFunction":     "encrypt",
+							"api":                "org.bouncycastle.crypto.engines.AESEngine.init",
+						},
+					},
+					{
+						StartLine: 70,
+						EndLine:   70,
+						Rules:     []entities.RuleInfo{{ID: "java.bouncycastle.algorithm.block-cipher.aes-init-decrypt", Severity: "INFO"}},
+						Metadata: map[string]string{
+							"assetType":          "algorithm",
+							"algorithmFamily":    "AES",
+							"algorithmPrimitive": "block-cipher",
+							"operation":          "decrypt",
+							"cryptoFunction":     "decrypt",
+							"api":                "org.bouncycastle.crypto.engines.AESEngine.init",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bom, err := converter.Convert(report)
+	if err != nil {
+		t.Fatalf("Convert() unexpected error: %v", err)
+	}
+	if bom.Components == nil {
+		t.Fatal("expected 1 merged component, got nil Components")
+	}
+	if len(*bom.Components) != 1 {
+		t.Fatalf("expected 1 merged component, got %d", len(*bom.Components))
+	}
+
+	component := (*bom.Components)[0]
+	if component.CryptoProperties == nil || component.CryptoProperties.AlgorithmProperties == nil {
+		t.Fatal("component missing AlgorithmProperties")
+	}
+	algProps := component.CryptoProperties.AlgorithmProperties
+	if algProps.CryptoFunctions == nil {
+		t.Fatal("CryptoFunctions is nil, want [encrypt decrypt]")
+	}
+	functions := *algProps.CryptoFunctions
+	if len(functions) != 2 {
+		t.Fatalf("CryptoFunctions count = %d, want 2 (%v)", len(functions), functions)
+	}
+	var hasEncrypt, hasDecrypt bool
+	for _, fn := range functions {
+		if fn == cdx.CryptoFunctionEncrypt {
+			hasEncrypt = true
+		}
+		if fn == cdx.CryptoFunctionDecrypt {
+			hasDecrypt = true
+		}
+	}
+	if !hasEncrypt || !hasDecrypt {
+		t.Fatalf("expected both encrypt and decrypt in CryptoFunctions, got %v", functions)
+	}
+
+	// The scanoss:cryptoFunction custom property must also carry both values.
+	if component.Properties == nil {
+		t.Fatal("component missing Properties")
+	}
+	var propValue string
+	for _, p := range *component.Properties {
+		if p.Name == scanossCryptoFunctionPropertyName {
+			propValue = p.Value
+		}
+	}
+	if !contains(propValue, "encrypt") || !contains(propValue, "decrypt") {
+		t.Fatalf("scanoss:cryptoFunction property = %q, want it to mention both encrypt and decrypt", propValue)
+	}
+}
+
 // Helper function to load test fixtures.
 func loadFixture(t *testing.T, filename string) *entities.InterimReport {
 	t.Helper()

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,18 +125,18 @@ func indexReportFiles(report *entities.InterimReport) map[string]int {
 func synthesizeRuleCryptoAssets(
 	report *entities.InterimReport,
 	fileIdx map[string]int,
-	apiCrypto map[string]map[string]string,
+	apiCrypto map[string][]map[string]string,
 	declsByFQN map[string][]*callgraph.FunctionDecl,
 	declsByClass map[string][]*callgraph.FunctionDecl,
 	ecosystem string,
 ) int {
 	added := 0
-	for api, meta := range apiCrypto {
+	for api, metas := range apiCrypto {
 		decls := declsByFQN[api]
 		if len(decls) == 0 && ecosystem == ecosystemPython {
 			decls = pythonModuleCollapsedDecls(api, declsByFQN)
 		}
-		added += synthesizeAPIAssets(report, fileIdx, api, meta, decls, declsByClass)
+		added += synthesizeAPIAssets(report, fileIdx, api, metas, decls, declsByClass)
 	}
 	return added
 }
@@ -177,21 +178,21 @@ func synthesizeAPIAssets(
 	report *entities.InterimReport,
 	fileIdx map[string]int,
 	api string,
-	meta map[string]string,
+	metas []map[string]string,
 	decls []*callgraph.FunctionDecl,
 	declsByClass map[string][]*callgraph.FunctionDecl,
 ) int {
 	if len(decls) == 0 {
-		return synthesizeImplicitCtorAsset(report, fileIdx, api, meta, declsByClass)
+		return synthesizeImplicitCtorAsset(report, fileIdx, api, metas, declsByClass)
 	}
-	return synthesizeDeclaredAPIAssets(report, fileIdx, api, meta, decls)
+	return synthesizeDeclaredAPIAssets(report, fileIdx, api, metas, decls)
 }
 
 func synthesizeImplicitCtorAsset(
 	report *entities.InterimReport,
 	fileIdx map[string]int,
 	api string,
-	meta map[string]string,
+	metas []map[string]string,
 	declsByClass map[string][]*callgraph.FunctionDecl,
 ) int {
 	// No source-declared method matches the api. A constructor api may still
@@ -200,17 +201,26 @@ func synthesizeImplicitCtorAsset(
 	if rep == nil {
 		return 0
 	}
-	if appendSyntheticRuleAsset(report, fileIdx, api, meta, rep) {
-		return 1
+	added := 0
+	for _, meta := range metas {
+		if appendSyntheticRuleAsset(report, fileIdx, api, meta, rep) {
+			added++
+		}
 	}
-	return 0
+	return added
 }
 
+// synthesizeDeclaredAPIAssets appends one synthetic asset per crypto block in
+// metas at each declaration in decls. The terminal-finding check is evaluated
+// ONCE per declaration, before any of that declaration's blocks are appended:
+// a later block (e.g. the decrypt half of a shared api) must be suppressed only
+// by a REAL pre-existing finding in the method body, never by a synthetic
+// sibling asset (e.g. the encrypt half) added moments earlier in this same loop.
 func synthesizeDeclaredAPIAssets(
 	report *entities.InterimReport,
 	fileIdx map[string]int,
 	api string,
-	meta map[string]string,
+	metas []map[string]string,
 	decls []*callgraph.FunctionDecl,
 ) int {
 	added := 0
@@ -218,8 +228,10 @@ func synthesizeDeclaredAPIAssets(
 		if functionBodyHasTerminalFinding(report, fn) {
 			continue // Type 1: primitive already detected inside the method.
 		}
-		if appendSyntheticRuleAsset(report, fileIdx, api, meta, fn) {
-			added++
+		for _, meta := range metas {
+			if appendSyntheticRuleAsset(report, fileIdx, api, meta, fn) {
+				added++
+			}
 		}
 	}
 	return added
@@ -336,6 +348,12 @@ func buildSyntheticAssetFromRule(api string, meta map[string]string, fn *callgra
 	if md["assetType"] == "" {
 		md["assetType"] = "algorithm"
 	}
+	// Metadata parity with call-site matches: the semgrep transformer backfills
+	// cryptoFunction from operation (extractCryptoMetadata), and DCA rules carry
+	// only `operation`. Mirror that here or mined entry points lack the field.
+	if md["cryptoFunction"] == "" && md["operation"] != "" {
+		md["cryptoFunction"] = md["operation"]
+	}
 
 	line := fn.StartLine
 	if line <= 0 {
@@ -357,7 +375,12 @@ func buildSyntheticAssetFromRule(api string, meta map[string]string, fn *callgra
 }
 
 // appendSyntheticAsset adds asset to the Finding for filePath (creating one if
-// needed), skipping exact duplicates. Returns true when an asset was added.
+// needed), skipping exact duplicates. Two assets are considered duplicates only
+// when they sit at the same line AND carry identical metadata in full (not just
+// the same api) -- this lets two rules sharing one api (e.g. AESEngine.init as
+// both encrypt and decrypt) coexist as distinct assets at the same declaration
+// site, while still deduping a truly identical block synthesized twice. Returns
+// true when an asset was added.
 func appendSyntheticAsset(
 	report *entities.InterimReport,
 	fileIdx map[string]int,
@@ -367,7 +390,7 @@ func appendSyntheticAsset(
 	if idx, ok := fileIdx[filePath]; ok {
 		for i := range report.Findings[idx].CryptographicAssets {
 			existing := &report.Findings[idx].CryptographicAssets[i]
-			if existing.StartLine == asset.StartLine && existing.Metadata["api"] == asset.Metadata["api"] {
+			if existing.StartLine == asset.StartLine && maps.Equal(existing.Metadata, asset.Metadata) {
 				return false
 			}
 		}
@@ -399,11 +422,15 @@ type ruleFileCryptoYAML struct {
 // looks like a fully-qualified method (the boundary-rule convention: a dotted
 // symbol). The ecosystem parameter is forwarded to the qualified-symbol gate so
 // Python's 1-dot module-level functions are accepted. The returned map carries
-// the crypto block stringified verbatim so the synthetic finding metadata is
-// identical to a call-site match. The rule remains the single source of truth
-// for the crypto semantics.
-func buildRuleCryptoByAPI(rulePaths []string, ecosystem string) map[string]map[string]string {
-	out := make(map[string]map[string]string)
+// each distinct crypto block stringified verbatim (in file-walk order) so the
+// synthetic finding metadata is identical to a call-site match. Multiple rules
+// legitimately share one api with different semantics (e.g. AESEngine.init as
+// both encrypt and decrypt) -- both blocks are kept, one per operation. An
+// identical block (full map equality) discovered again for the same api is
+// deduped, since that only means the same rule was found in multiple files. The
+// rule remains the single source of truth for the crypto semantics.
+func buildRuleCryptoByAPI(rulePaths []string, ecosystem string) map[string][]map[string]string {
+	out := make(map[string][]map[string]string)
 	for _, p := range rulePaths {
 		for _, file := range expandRuleFiles(p) {
 			addRuleCryptoFile(out, file, ecosystem)
@@ -412,7 +439,7 @@ func buildRuleCryptoByAPI(rulePaths []string, ecosystem string) map[string]map[s
 	return out
 }
 
-func addRuleCryptoFile(out map[string]map[string]string, file, ecosystem string) {
+func addRuleCryptoFile(out map[string][]map[string]string, file, ecosystem string) {
 	// Rule paths come from the trusted ruleset manager.
 	data, err := os.ReadFile(file)
 	if err != nil {
@@ -429,17 +456,19 @@ func addRuleCryptoFile(out map[string]map[string]string, file, ecosystem string)
 	}
 }
 
-func addRuleCrypto(out map[string]map[string]string, crypto map[string]any, ecosystem string) {
+func addRuleCrypto(out map[string][]map[string]string, crypto map[string]any, ecosystem string) {
 	api, ok := cryptoAPI(crypto, ecosystem)
 	if !ok {
 		return
 	}
-	if _, seen := out[api]; seen {
-		return // first declaration wins; deterministic enough for synthesis
-	}
 	meta := stringifyCryptoBlock(crypto)
 	removeUnresolvedMetadataVariables(meta)
-	out[api] = meta
+	for _, existing := range out[api] {
+		if maps.Equal(existing, meta) {
+			return // identical block already indexed for this api; skip.
+		}
+	}
+	out[api] = append(out[api], meta)
 }
 
 func cryptoAPI(crypto map[string]any, ecosystem string) (string, bool) {

--- a/internal/engine/rule_entrypoint_synthesis_test.go
+++ b/internal/engine/rule_entrypoint_synthesis_test.go
@@ -38,6 +38,35 @@ func writeRule(t *testing.T, dir, api, family string) string {
 	return p
 }
 
+// aesEngineInitAPI is the shared api FQN used by the multi-crypto-function
+// synthesis tests below, mirroring the real DCA rules
+// java.bouncycastle.algorithm.block-cipher.aes-init-encrypt/aes-init-decrypt,
+// which both carry api: org.bouncycastle.crypto.engines.AESEngine.init.
+const aesEngineInitAPI = "org.bouncycastle.crypto.engines.AESEngine.init"
+
+// writeRuleWithID writes an AES rule file for aesEngineInitAPI carrying one
+// metadata.crypto block with an explicit rule id and operation. Used to
+// construct multi-rule same-api scenarios (e.g. AESEngine.init shared by an
+// encrypt rule and a decrypt rule) where the caller passes the shared dir
+// (not the individual file path) to SynthesizeRuleCryptoEntryPoints.
+func writeRuleWithID(t *testing.T, dir, filename, ruleID, operation string) {
+	t.Helper()
+	body := "" +
+		"rules:\n" +
+		"  - id: " + ruleID + "\n" +
+		"    metadata:\n" +
+		"      crypto:\n" +
+		"        assetType: algorithm\n" +
+		"        algorithmPrimitive: block-cipher\n" +
+		"        algorithmFamily: AES\n" +
+		"        operation: " + operation + "\n" +
+		"        api: " + aesEngineInitAPI + "\n"
+	p := filepath.Join(dir, filename)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func graphWith(decl *callgraph.FunctionDecl) *callgraph.CallGraph {
 	g := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{}}
 	if decl != nil {
@@ -464,5 +493,148 @@ func TestSynthesize_UnresolvedAlgorithmNameFallsBackToFamily(t *testing.T) {
 	// still removed rather than left as a literal "$variant".
 	if v, ok := asset.Metadata["algorithmParameterSetIdentifier"]; ok {
 		t.Fatalf("expected unresolved algorithmParameterSetIdentifier to be removed, got %q", v)
+	}
+}
+
+// ── Multi-crypto-function synthesis (shared api, different operation) ──────
+
+// aesEngineInitDecl mimics org.bouncycastle.crypto.engines.AESEngine.init(...),
+// the shared declaration site for both the encrypt and decrypt boundary rules.
+func aesEngineInitDecl() *callgraph.FunctionDecl {
+	return &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "org.bouncycastle.crypto.engines", Type: "AESEngine", Name: "init"},
+		FilePath:  "org/bouncycastle/crypto/engines/AESEngine.java",
+		StartLine: 70,
+		EndLine:   90,
+	}
+}
+
+// TestSynthesize_SharedAPIDifferentOperation_ProducesTwoAssets guards the DCA
+// case where two rules (aes-init-encrypt / aes-init-decrypt) legitimately share
+// one api (AESEngine.init) but carry different operation/cryptoFunction. Both
+// must synthesize as separate assets at the same declaration site.
+func TestSynthesize_SharedAPIDifferentOperation_ProducesTwoAssets(t *testing.T) {
+	dir := t.TempDir()
+	const api = aesEngineInitAPI
+	writeRuleWithID(t, dir, "encrypt.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", "encrypt")
+	writeRuleWithID(t, dir, "decrypt.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-decrypt", "decrypt")
+
+	report := &entities.InterimReport{}
+	graph := graphWith(aesEngineInitDecl())
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{dir}, "")
+	if n != 2 {
+		t.Fatalf("expected 2 synthesized assets (encrypt + decrypt), got %d", n)
+	}
+	if len(report.Findings) != 1 {
+		t.Fatalf("expected 1 finding (same file), got %d", len(report.Findings))
+	}
+	assets := report.Findings[0].CryptographicAssets
+	if len(assets) != 2 {
+		t.Fatalf("expected 2 assets at the shared declaration site, got %d", len(assets))
+	}
+
+	ops := map[string]bool{}
+	for _, a := range assets {
+		if a.StartLine != 70 {
+			t.Errorf("asset StartLine = %d, want 70 (method decl line)", a.StartLine)
+		}
+		if a.Metadata["api"] != api {
+			t.Errorf("asset api = %q, want %q", a.Metadata["api"], api)
+		}
+		ops[a.Metadata["operation"]] = true
+	}
+	if !ops["encrypt"] || !ops["decrypt"] {
+		t.Fatalf("expected one encrypt and one decrypt asset, got operations: %v", ops)
+	}
+}
+
+// TestSynthesize_BackfillsCryptoFunctionFromOperation guards metadata parity
+// with call-site matches: the semgrep transformer backfills cryptoFunction
+// from operation (extractCryptoMetadata), and production DCA rules carry only
+// `operation`. A synthetic asset must expose the same cryptoFunction key a
+// real match of the same rule would have, or downstream consumers (dep-tree
+// metadata readers) see the field missing on mined entry points only.
+func TestSynthesize_BackfillsCryptoFunctionFromOperation(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleWithID(t, dir, "encrypt.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", "encrypt")
+
+	report := &entities.InterimReport{}
+	graph := graphWith(aesEngineInitDecl())
+
+	if n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{dir}, ""); n != 1 {
+		t.Fatalf("expected 1 synthesized asset, got %d", n)
+	}
+	md := report.Findings[0].CryptographicAssets[0].Metadata
+	if md["cryptoFunction"] != "encrypt" {
+		t.Fatalf("cryptoFunction = %q, want %q (backfilled from operation)", md["cryptoFunction"], "encrypt")
+	}
+}
+
+// TestSynthesize_DuplicateRuleCryptoBlock_DedupesToOneAsset guards the case
+// where the identical rule (same crypto block) is discovered twice (e.g. it
+// appears verbatim in two rule files walked during indexing). Only one asset
+// should synthesize — dedup keys off full metadata equality, not just api.
+func TestSynthesize_DuplicateRuleCryptoBlock_DedupesToOneAsset(t *testing.T) {
+	dir := t.TempDir()
+	// Same rule id, same operation, same everything -- written to two files.
+	writeRuleWithID(t, dir, "a.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", "encrypt")
+	writeRuleWithID(t, dir, "b.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", "encrypt")
+
+	report := &entities.InterimReport{}
+	graph := graphWith(aesEngineInitDecl())
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{dir}, "")
+	if n != 1 {
+		t.Fatalf("expected 1 synthesized asset (identical block deduped), got %d", n)
+	}
+}
+
+// TestSynthesize_SingleRuleAPI_Unchanged is a regression guard: a single rule
+// per api must keep producing exactly one asset (no accidental fan-out from the
+// map[string][]map[string]string refactor).
+func TestSynthesize_SingleRuleAPI_Unchanged(t *testing.T) {
+	dir := t.TempDir()
+	rule := writeRule(t, dir, "com.example.Builder.withBcrypt", "bcrypt")
+	report := &entities.InterimReport{}
+	graph := graphWith(builderWithBcrypt())
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{rule}, "")
+	if n != 1 {
+		t.Fatalf("expected 1 synthesized finding, got %d", n)
+	}
+}
+
+// TestSynthesize_TerminalFinding_SuppressesBothSharedAPIBlocks guards ordering:
+// when the method body already has a REAL detected primitive finding, BOTH
+// shared-api blocks (encrypt and decrypt) must be suppressed -- and critically,
+// the second block must be suppressed because of the REAL finding, not because
+// the first synthetic sibling (added moments earlier) looks like a terminal
+// finding to functionBodyHasTerminalFinding.
+func TestSynthesize_TerminalFinding_SuppressesBothSharedAPIBlocks(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleWithID(t, dir, "encrypt.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-encrypt", "encrypt")
+	writeRuleWithID(t, dir, "decrypt.yaml", "java.bouncycastle.algorithm.block-cipher.aes-init-decrypt", "decrypt")
+
+	decl := aesEngineInitDecl()
+	report := &entities.InterimReport{
+		Findings: []entities.Finding{{
+			FilePath: decl.FilePath,
+			Language: "java",
+			CryptographicAssets: []entities.CryptographicAsset{{
+				StartLine: 75, // inside [70,90]
+				Metadata:  map[string]string{"algorithmPrimitive": "block-cipher", "algorithmFamily": "AES"},
+			}},
+		}},
+	}
+	graph := graphWith(decl)
+
+	n := SynthesizeRuleCryptoEntryPoints(report, graph, []string{dir}, "")
+	if n != 0 {
+		t.Fatalf("expected 0 synthesized assets (method body already has a real finding), got %d", n)
+	}
+	// Only the original real finding should remain -- no synthetic siblings leaked in.
+	if got := len(report.Findings[0].CryptographicAssets); got != 1 {
+		t.Fatalf("expected exactly 1 asset (the original real finding), got %d", got)
 	}
 }


### PR DESCRIPTION
## Summary

Mined libraries now expose every rule-declared operation on a shared entry-point api, instead of keeping only the first rule.

The DCA ruleset now carries value-variant rules that legitimately share one `api` FQN — `aes-init-encrypt` / `aes-init-decrypt` both anchor on `org.bouncycastle.crypto.engines.AESEngine.init` (the boolean argument decides the operation). With the previous first-declaration-wins index, mining bcprov synthesized only the encrypt asset and silently dropped decrypt. This is the crypto-finder half of the IBM data-discrepancy fix (missing `cryptoFunction` on BouncyCastle AES assets).

## Changes

| Area | Change |
|------|--------|
| `internal/engine/rule_entrypoint_synthesis.go` | Index rule crypto blocks as a list per api (full-metadata dedup, file-walk order); dedup synthetic assets by line + full metadata so same-line assets differing in operation coexist; evaluate terminal-finding suppression once per declaration so a synthetic sibling cannot suppress the next block; backfill `cryptoFunction` from `operation` for metadata parity with call-site matches. |
| `internal/converter/aggregator.go` / `converter.go` | Collect distinct raw cryptoFunction values across an aggregated group; when ≥2, emit the full `cryptoFunctions` enum array (deduped post-normalization) and the joined raw set in `scanoss:cryptoFunction`. |

## Validation

- Unit tests at synthesis, aggregator, and converter level (shared-api fan-out, duplicate-block dedup, suppression ordering, backfill parity, CDX merge).
- E2E against a mini library fixture declaring `AESEngine.init`: `findings.json` carries two synthetic assets (operation+cryptoFunction encrypt / decrypt) plus the ctor asset; CBOM aggregates to one `AES` component with `cryptoFunctions: ["encrypt", "decrypt"]`.
- `golangci-lint run`: 0 issues on touched packages. Pre-existing Docker-dependent postgres cache tests are unaffected (fail locally without a daemon, same as main).

Note: entry-point synthesis fires on the mining path (`--export-callgraph`); consumer scans are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Better support for crypto findings now preserves multiple operations for the same algorithm grouping, such as both encrypt and decrypt.
  * Synthesized results can now retain richer crypto metadata when multiple rule definitions apply to the same API.

* **Bug Fixes**
  * Duplicate crypto operation values are now deduplicated while keeping distinct ones intact.
  * Results now avoid dropping valid crypto metadata when multiple matching findings are merged.

* **Tests**
  * Added coverage for merging, deduplication, and shared-API crypto scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->