### PR TITLE
fix(callgraph): resolve abstract-class dispatch and deterministic function attribution

### DIFF
--- a/docs/DEPENDENCY_SCANNING.md
+++ b/docs/DEPENDENCY_SCANNING.md
@@ -1276,7 +1276,7 @@ The bytecode resolution bottleneck has largely been removed. Remaining performan
 - **Gradle source archives are best-effort** — Gradle dependency resolution provides binary artifact paths deterministically, but source archive availability still depends on what upstream repositories publish.
 - **Missing source JARs** — Dependencies without sources are skipped for source scanning, but they can still contribute Java bytecode types if the compiled JAR is present locally. They cannot produce source-level findings until sources are available.
 - **Wildcard import resolution** — When multiple wildcard imports could match a class name, resolution is best-effort.
-- **No inheritance/polymorphism** — Variable types are tracked syntactically; interface implementations and subclass overrides are not resolved.
+- **Limited inheritance/polymorphism** — Variable types are tracked syntactically, but interface method call sites and abstract-class method call sites are fanned out to same-name/arity concrete implementations and subclass overrides within the same namespace root (see `expandInterfaceDispatch`/`expandAbstractClassDispatch` in `internal/callgraph/builder.go`). This is a name+arity heuristic, not full type resolution, so it can over-match unrelated overloads across sibling implementations.
 - **Multi-module Maven partial resolution** — Multi-module Maven projects are supported via a three-tier fallback strategy. Tier 3 (`mvn install -DskipTests`) requires compilation and may fail if the project needs specific JDK versions or build tools not available in the scan environment.
 
 ### Python-specific

--- a/internal/callgraph/abstract_dispatch_test.go
+++ b/internal/callgraph/abstract_dispatch_test.go
@@ -1,0 +1,246 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+
+package callgraph
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestBuilder_ExpandsAbstractClassDispatchToSubclassOverrides reproduces the
+// exact shape of the password4j "shallow call chain" bug: HashBuilder.with
+// invokes HashingFunction.hash#3 through the interface, but the interface's
+// only concrete body lives on an ABSTRACT intermediate class
+// (AbstractHashingFunction), which itself calls unqualified this.hash(...)
+// overloads that are only implemented in leaf subclasses (PBKDF2Function).
+//
+// Two virtual-dispatch hops must both resolve for the backward chain trace
+// from PBKDF2Function.internalHash to ever reach HashBuilder.with:
+//
+//  1. interface -> abstract class: HashBuilder.with calls
+//     HashingFunction.hash#3; the concrete body is on AbstractHashingFunction
+//     (a class, not a leaf). expandInterfaceDispatch must fan this out
+//     regardless of whether the concrete owner is abstract or leaf.
+//  2. abstract class -> subclass override: AbstractHashingFunction.hash#3
+//     calls hash#1/hash#2 on itself (unqualified this-calls), but
+//     AbstractHashingFunction never defines hash#1/hash#2 bodies -- only
+//     PBKDF2Function does. The dispatch-expansion must also fan out FROM a
+//     class-owned (non-interface) call site to same-name+arity overrides
+//     declared on other classes in the same namespace root, not only from
+//     interface-owned call sites.
+func TestBuilder_ExpandsAbstractClassDispatchToSubclassOverrides(t *testing.T) {
+	root := t.TempDir()
+
+	// interface HashingFunction { hash(a); hash(a,b); hash(a,b,c); }
+	ifaceHash1 := FunctionDecl{
+		ID:         FunctionID{Package: "com.password4j", Type: "HashingFunction", Name: "hash#1"},
+		FilePath:   filepath.Join(root, "HashingFunction.java"),
+		StartLine:  1,
+		EndLine:    2,
+		OwnerType:  "interface",
+		OwnerName:  "HashingFunction",
+		Parameters: []FunctionParameter{{Type: "byte[]"}},
+	}
+	ifaceHash2 := FunctionDecl{
+		ID:         FunctionID{Package: "com.password4j", Type: "HashingFunction", Name: "hash#2"},
+		FilePath:   filepath.Join(root, "HashingFunction.java"),
+		StartLine:  3,
+		EndLine:    4,
+		OwnerType:  "interface",
+		OwnerName:  "HashingFunction",
+		Parameters: []FunctionParameter{{Type: "byte[]"}, {Type: "byte[]"}},
+	}
+	ifaceHash3 := FunctionDecl{
+		ID:         FunctionID{Package: "com.password4j", Type: "HashingFunction", Name: "hash#3"},
+		FilePath:   filepath.Join(root, "HashingFunction.java"),
+		StartLine:  5,
+		EndLine:    6,
+		OwnerType:  "interface",
+		OwnerName:  "HashingFunction",
+		Parameters: []FunctionParameter{{Type: "byte[]"}, {Type: "byte[]"}, {Type: "byte[]"}},
+	}
+
+	// abstract class AbstractHashingFunction implements HashingFunction {
+	//   public Hash hash(byte[] plain, byte[] salt, byte[] pepper) {
+	//     byte[] peppered = ...;
+	//     if (salt == null) { result = hash(peppered); }        // hop 2 -> hash#1
+	//     else { result = hash(peppered, salt); }                // hop 2 -> hash#2
+	//   }
+	// }
+	// hash#1/hash#2 are NOT implemented here -- only declared abstractly. Both
+	// unqualified this-calls live in the SAME hash#3 method body, mirroring the
+	// real AbstractHashingFunction.hash(byte[], byte[], CharSequence) shape.
+	abstractHash3 := FunctionDecl{
+		ID:        FunctionID{Package: "com.password4j", Type: "AbstractHashingFunction", Name: "hash#3"},
+		FilePath:  filepath.Join(root, "AbstractHashingFunction.java"),
+		StartLine: 81,
+		EndLine:   97,
+		OwnerType: "class",
+		OwnerName: "AbstractHashingFunction",
+		Parameters: []FunctionParameter{
+			{Type: "byte[]"}, {Type: "byte[]"}, {Type: "byte[]"},
+		},
+		Calls: []FunctionCall{
+			{
+				Callee:    FunctionID{Package: "com.password4j", Type: "AbstractHashingFunction", Name: "hash#1"},
+				Raw:       "this.hash",
+				FilePath:  filepath.Join(root, "AbstractHashingFunction.java"),
+				Line:      88,
+				Arguments: []string{"peppered"},
+			},
+			{
+				Callee:    FunctionID{Package: "com.password4j", Type: "AbstractHashingFunction", Name: "hash#2"},
+				Raw:       "this.hash",
+				FilePath:  filepath.Join(root, "AbstractHashingFunction.java"),
+				Line:      92,
+				Arguments: []string{"peppered", "salt"},
+			},
+		},
+	}
+
+	// class PBKDF2Function extends AbstractHashingFunction {
+	//   public Hash hash(byte[] plain) { return internalHash(...); }        // hash#1
+	//   public Hash hash(byte[] plain, byte[] salt) { return internalHash(...); } // hash#2
+	// }
+	pbkdf2Hash1 := FunctionDecl{
+		ID:         FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "hash#1"},
+		FilePath:   filepath.Join(root, "PBKDF2Function.java"),
+		StartLine:  145,
+		EndLine:    150,
+		OwnerType:  "class",
+		OwnerName:  "PBKDF2Function",
+		Parameters: []FunctionParameter{{Type: "byte[]"}},
+		Calls: []FunctionCall{
+			{
+				Callee:    FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "internalHash#2"},
+				Raw:       "internalHash",
+				FilePath:  filepath.Join(root, "PBKDF2Function.java"),
+				Line:      147,
+				Arguments: []string{"plain", "salt"},
+			},
+		},
+	}
+	pbkdf2Hash2 := FunctionDecl{
+		ID:        FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "hash#2"},
+		FilePath:  filepath.Join(root, "PBKDF2Function.java"),
+		StartLine: 159,
+		EndLine:   167,
+		OwnerType: "class",
+		OwnerName: "PBKDF2Function",
+		Parameters: []FunctionParameter{
+			{Type: "byte[]"}, {Type: "byte[]"},
+		},
+		Calls: []FunctionCall{
+			{
+				Callee:    FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "internalHash#2"},
+				Raw:       "internalHash",
+				FilePath:  filepath.Join(root, "PBKDF2Function.java"),
+				Line:      165,
+				Arguments: []string{"plain", "salt"},
+			},
+		},
+	}
+	internalHash := FunctionDecl{
+		ID:         FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "internalHash#2"},
+		FilePath:   filepath.Join(root, "PBKDF2Function.java"),
+		StartLine:  130,
+		EndLine:    140,
+		OwnerType:  "class",
+		OwnerName:  "PBKDF2Function",
+		Parameters: []FunctionParameter{{Type: "byte[]"}, {Type: "byte[]"}},
+	}
+
+	// class HashBuilder {
+	//   public Hash with(HashingFunction hashingFunction) {
+	//     return hashingFunction.hash(plainTextPassword, salt, pepper); // hop 1
+	//   }
+	// }
+	hashBuilderWith := FunctionDecl{
+		ID:        FunctionID{Package: "com.password4j", Type: "HashBuilder", Name: "with#1"},
+		FilePath:  filepath.Join(root, "HashBuilder.java"),
+		StartLine: 160,
+		EndLine:   165,
+		OwnerType: "class",
+		OwnerName: "HashBuilder",
+		Parameters: []FunctionParameter{
+			{Type: "HashingFunction"},
+		},
+		Calls: []FunctionCall{
+			{
+				Callee:    FunctionID{Package: "com.password4j", Type: "HashingFunction", Name: "hash#3"},
+				Raw:       "hashingFunction.hash",
+				FilePath:  filepath.Join(root, "HashBuilder.java"),
+				Line:      162,
+				Arguments: []string{"plainTextPassword", "salt", "pepper"},
+			},
+		},
+	}
+
+	parser := &stubParser{
+		sep: ".",
+		analyses: map[string][]*FileAnalysis{
+			root: {
+				{
+					Functions: []FunctionDecl{
+						ifaceHash1, ifaceHash2, ifaceHash3,
+						abstractHash3,
+						pbkdf2Hash1, pbkdf2Hash2, internalHash,
+						hashBuilderWith,
+					},
+				},
+			},
+		},
+	}
+
+	graph, err := NewBuilder(parser).BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "com.password4j"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	hashBuilderWithKey := hashBuilderWith.ID.String()
+	abstractHash3Key := abstractHash3.ID.String()
+	pbkdf2Hash1Key := pbkdf2Hash1.ID.String()
+	pbkdf2Hash2Key := pbkdf2Hash2.ID.String()
+
+	// Hop 1: interface fan-out must reach the ABSTRACT class's concrete body,
+	// not just leaf concrete classes.
+	t.Run("hop1_interface_fans_out_to_abstract_class_body", func(t *testing.T) {
+		callers := graph.Callers[abstractHash3Key]
+		if !sliceContainsAbstractDispatchKey(callers, hashBuilderWithKey) {
+			t.Fatalf("Callers[%s] = %v, want to include %s (interface fan-out to abstract class)",
+				abstractHash3Key, callers, hashBuilderWithKey)
+		}
+	})
+
+	// Hop 2: abstract class's unqualified this-calls must fan out to the
+	// concrete subclass overrides that actually implement them.
+	t.Run("hop2_abstract_this_call_fans_out_to_subclass_override_hash1", func(t *testing.T) {
+		callers := graph.Callers[pbkdf2Hash1Key]
+		if !sliceContainsAbstractDispatchKey(callers, abstractHash3Key) {
+			t.Fatalf("Callers[%s] = %v, want to include %s (abstract-to-subclass dispatch)",
+				pbkdf2Hash1Key, callers, abstractHash3Key)
+		}
+	})
+
+	t.Run("hop2_abstract_this_call_fans_out_to_subclass_override_hash2", func(t *testing.T) {
+		callers := graph.Callers[pbkdf2Hash2Key]
+		if !sliceContainsAbstractDispatchKey(callers, abstractHash3Key) {
+			t.Fatalf("Callers[%s] = %v, want to include %s (abstract-to-subclass dispatch)",
+				pbkdf2Hash2Key, callers, abstractHash3Key)
+		}
+	})
+}
+
+func sliceContainsAbstractDispatchKey(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -282,42 +282,67 @@ func pythonModuleFileStem(path string) string {
 
 // buildCallerIndex builds the reverse index: for each callee, which functions call it.
 func (b *Builder) buildCallerIndex(graph *CallGraph) {
-	methodsByName := indexMethodsByName(graph)
-	methodsByQualifiedArity := indexMethodsByQualifiedArity(graph)
-	subclassByTypeName := indexSubclassByTypeName(graph)
+	idx := dispatchIndexes{
+		methodsByName:           indexMethodsByName(graph),
+		methodsByQualifiedArity: indexMethodsByQualifiedArity(graph),
+		subclassByTypeName:      indexSubclassByTypeName(graph),
+		knownClassTypes:         indexKnownClassTypes(graph),
+	}
 
 	for callerKey, fn := range graph.Functions {
 		for i := range fn.Calls {
-			call := fn.Calls[i]
-			calleeKey := call.Callee.String()
-			addCaller(graph.Callers, calleeKey, callerKey)
-			recordEdgeResolution(graph, callerKey, calleeKey, EdgeKindExact, "", call.Line)
-
-			overloadTargets := b.expandOverloadCandidates(call.Callee, methodsByQualifiedArity)
-			resolvedTargets := make([]string, 1, 1+len(overloadTargets))
-			resolvedTargets[0] = calleeKey
-			for _, target := range overloadTargets {
-				addCaller(graph.Callers, target, callerKey)
-				recordEdgeResolution(graph, callerKey, target, EdgeKindExact, "", call.Line)
-				resolvedTargets = append(resolvedTargets, target)
-			}
-
-			for _, target := range resolvedTargets {
-				for _, alias := range b.expandInterfaceDispatch(target, graph, methodsByName) {
-					addCaller(graph.Callers, alias.CalleeKey, callerKey)
-					recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
-				}
-				for _, alias := range b.expandPythonSubclassDispatch(target, graph, subclassByTypeName) {
-					addCaller(graph.Callers, alias.CalleeKey, callerKey)
-					recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindPythonSubclassDispatch, alias.DeclaredType, call.Line)
-				}
-			}
-
-			for _, alias := range b.expandFluentFallback(call, graph, methodsByName) {
-				addCaller(graph.Callers, alias, callerKey)
-				recordEdgeResolution(graph, callerKey, alias, EdgeKindNameOnly, "", call.Line)
-			}
+			b.indexCallDispatch(graph, callerKey, fn.Calls[i], idx)
 		}
+	}
+}
+
+// dispatchIndexes bundles the lookup tables buildCallerIndex needs to expand
+// one call site into all of its dispatch aliases (overloads, interface/abstract
+// virtual dispatch, Python subclass dispatch, fluent fallback).
+type dispatchIndexes struct {
+	methodsByName           map[string][]*FunctionDecl
+	methodsByQualifiedArity map[string][]string
+	subclassByTypeName      map[string][]*FunctionDecl
+	knownClassTypes         map[string]bool
+}
+
+// indexCallDispatch records the direct edge for one call site plus every
+// synthesized dispatch alias (overloads, interface/abstract virtual dispatch,
+// Python subclass dispatch, fluent fallback), each with its own edge
+// classification.
+func (b *Builder) indexCallDispatch(graph *CallGraph, callerKey string, call FunctionCall, idx dispatchIndexes) {
+	calleeKey := call.Callee.String()
+	addCaller(graph.Callers, calleeKey, callerKey)
+	recordEdgeResolution(graph, callerKey, calleeKey, EdgeKindExact, "", call.Line)
+
+	overloadTargets := b.expandOverloadCandidates(call.Callee, idx.methodsByQualifiedArity)
+	resolvedTargets := make([]string, 1, 1+len(overloadTargets))
+	resolvedTargets[0] = calleeKey
+	for _, target := range overloadTargets {
+		addCaller(graph.Callers, target, callerKey)
+		recordEdgeResolution(graph, callerKey, target, EdgeKindExact, "", call.Line)
+		resolvedTargets = append(resolvedTargets, target)
+	}
+
+	for _, target := range resolvedTargets {
+		for _, alias := range b.expandInterfaceDispatch(target, graph, idx.methodsByName) {
+			addCaller(graph.Callers, alias.CalleeKey, callerKey)
+			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
+		}
+		for _, alias := range b.expandPythonSubclassDispatch(target, graph, idx.subclassByTypeName) {
+			addCaller(graph.Callers, alias.CalleeKey, callerKey)
+			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindPythonSubclassDispatch, alias.DeclaredType, call.Line)
+		}
+	}
+
+	for _, alias := range b.expandAbstractClassDispatch(call.Callee, graph, idx.methodsByName, idx.knownClassTypes) {
+		addCaller(graph.Callers, alias.CalleeKey, callerKey)
+		recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
+	}
+
+	for _, alias := range b.expandFluentFallback(call, graph, idx.methodsByName) {
+		addCaller(graph.Callers, alias, callerKey)
+		recordEdgeResolution(graph, callerKey, alias, EdgeKindNameOnly, "", call.Line)
 	}
 }
 
@@ -372,6 +397,23 @@ func indexMethodsByQualifiedArity(graph *CallGraph) map[string][]string {
 			index[qualifiedMethodArityKey(fn.ID.Package, fn.ID.Type, fn.ID.Name)],
 			key,
 		)
+	}
+	return index
+}
+
+// indexKnownClassTypes builds the set of "Package|Type" pairs for every
+// class-owned declaration in the graph. Used by expandAbstractClassDispatch to
+// tell apart "this Type is a real parsed class, just missing a body for this
+// particular method+arity" (an abstract method left undefined on an
+// intermediate class) from "this Type is unknown to the graph entirely"
+// (an unresolved/external callee, where no dispatch inference is safe).
+func indexKnownClassTypes(graph *CallGraph) map[string]bool {
+	index := make(map[string]bool)
+	for _, fn := range graph.Functions {
+		if fn.OwnerType != ownerTypeClass || fn.ID.Type == "" {
+			continue
+		}
+		index[fn.ID.Package+"|"+fn.ID.Type] = true
 	}
 	return index
 }
@@ -567,6 +609,71 @@ func interfaceDeclaredType(id FunctionID) string {
 		return id.Type
 	}
 	return id.Package + "." + id.Type
+}
+
+// expandAbstractClassDispatch links a call site to concrete overrides when the
+// resolved callee is an unqualified/this-call to a method that its own class
+// never defines a body for — the Java shape of an abstract intermediate class
+// declaring (but not implementing) a method that only its concrete subclasses
+// override. Mirrors expandInterfaceDispatch's policy (same-name+arity, same
+// namespace root) but keys off "callee class is known yet the exact method
+// has no declaration" rather than "callee owner is an interface", so it also
+// covers the case where the interface's only concrete body sits on an
+// abstract class that itself calls other not-yet-overridden interface methods
+// via `this`.
+//
+// It intentionally does NOT fire when the callee's Type is unknown to the
+// graph at all (e.g. an external/unresolved receiver) — knownClassTypes gates
+// that, so this stays a narrow "missing override" inference instead of a
+// generic name+arity fallback.
+func (b *Builder) expandAbstractClassDispatch(
+	callee FunctionID,
+	graph *CallGraph,
+	methodsByName map[string][]*FunctionDecl,
+	knownClassTypes map[string]bool,
+) []interfaceDispatchAlias {
+	if callee.Type == "" {
+		return nil
+	}
+	calleeKey := callee.String()
+	if _, declared := graph.Functions[calleeKey]; declared {
+		return nil
+	}
+	if !knownClassTypes[callee.Package+"|"+callee.Type] {
+		return nil
+	}
+
+	targets := methodsByName[methodLookupName(callee.Name)]
+	if len(targets) == 0 {
+		return nil
+	}
+
+	declaredType := interfaceDeclaredType(callee)
+	baseRoot := namespaceRoot(callee.Package)
+	calleeArity := functionArity(callee.Name)
+	keys := make([]string, 0, len(targets))
+	for _, candidate := range targets {
+		if candidate.OwnerType != ownerTypeClass {
+			continue
+		}
+		if candidate.ID.Type == callee.Type && candidate.ID.Package == callee.Package {
+			continue
+		}
+		if functionArity(candidate.ID.Name) != calleeArity {
+			continue
+		}
+		if namespaceRoot(candidate.ID.Package) != baseRoot {
+			continue
+		}
+		keys = append(keys, candidate.ID.String())
+	}
+
+	sort.Strings(keys)
+	results := make([]interfaceDispatchAlias, 0, len(keys))
+	for _, k := range keys {
+		results = append(results, interfaceDispatchAlias{CalleeKey: k, DeclaredType: declaredType})
+	}
+	return results
 }
 
 // expandFluentFallback links unresolved fluent-chain calls (foo().bar().baz()) to

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -2693,18 +2693,41 @@ func (ctx *exportBuildContext) findContainingFunctionByFinding(findingPath strin
 		return nil
 	}
 
+	// graph.Functions is an unordered map and spans can nest (a synthetic
+	// <clinit> may cover the whole class around the real method), so pick the
+	// tightest enclosing span instead of the first match; tie-break on the
+	// function key for full determinism.
+	var best *callgraph.FunctionDecl
 	for _, fn := range ctx.graph.Functions {
 		fnPath := filepath.ToSlash(fn.FilePath)
 		if !strings.HasSuffix(fnPath, normalizedFindingPath) {
 			continue
 		}
-		if line >= fn.StartLine && line <= fn.EndLine {
-			ctx.containingFunctionCache[cacheKey] = cachedContainingFunction{fn: fn, found: true}
-			return fn
+		if line < fn.StartLine || line > fn.EndLine {
+			continue
 		}
+		if best == nil || tighterSpan(fn, best) {
+			best = fn
+		}
+	}
+	if best != nil {
+		ctx.containingFunctionCache[cacheKey] = cachedContainingFunction{fn: best, found: true}
+		return best
 	}
 	ctx.containingFunctionCache[cacheKey] = cachedContainingFunction{found: false}
 	return nil
+}
+
+// tighterSpan reports whether a encloses fewer lines than b (or, on equal
+// spans, sorts first by function key) so the containing-function choice is
+// stable across map iteration orders.
+func tighterSpan(a, b *callgraph.FunctionDecl) bool {
+	spanA := a.EndLine - a.StartLine
+	spanB := b.EndLine - b.StartLine
+	if spanA != spanB {
+		return spanA < spanB
+	}
+	return a.ID.String() < b.ID.String()
 }
 
 func dependencyRelativePath(path string) string {

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -489,3 +489,42 @@ func TestDeriveSupportingCallsForFinding_CombinesContractRolesForDirectAssets(t 
 		t.Fatalf("structural function = %q, want pkg.Svc.run", got[1].FunctionName)
 	}
 }
+
+// TestFindContainingFunctionByFinding_PicksTightestSpan guards against map-order
+// nondeterminism: graph.Functions is an unordered map, and a wide-span decl
+// (e.g. a synthetic <clinit> covering the whole class) can enclose the same
+// line as the real method. The lookup must deterministically return the
+// tightest enclosing span, not whichever match iterates first. The cache is
+// cleared between iterations so every lookup re-runs the selection.
+func TestFindContainingFunctionByFinding_PicksTightestSpan(t *testing.T) {
+	wide := &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "<clinit>#0"},
+		FilePath:  "com/password4j/PBKDF2Function.java",
+		StartLine: 1,
+		EndLine:   300,
+	}
+	tight := &callgraph.FunctionDecl{
+		ID:        callgraph.FunctionID{Package: "com.password4j", Type: "PBKDF2Function", Name: "internalHash#5"},
+		FilePath:  "com/password4j/PBKDF2Function.java",
+		StartLine: 126,
+		EndLine:   139,
+	}
+	ctx := &exportBuildContext{
+		graph: &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+			wide.ID.String():  wide,
+			tight.ID.String(): tight,
+		}},
+		containingFunctionCache: make(map[string]cachedContainingFunction),
+	}
+
+	for i := 0; i < 50; i++ {
+		ctx.containingFunctionCache = make(map[string]cachedContainingFunction)
+		got := ctx.findContainingFunctionByFinding("com/password4j/PBKDF2Function.java", 130)
+		if got == nil {
+			t.Fatalf("iteration %d: got nil, want internalHash", i)
+		}
+		if got.ID.Name != "internalHash#5" {
+			t.Fatalf("iteration %d: got %s, want internalHash#5 (tightest span)", i, got.ID.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes the IBM password4j "shallow call chain" discrepancy. Two work-unit commits:

**1. Abstract-class dispatch fan-out** (`expandAbstractClassDispatch`). Interface call sites already fan out to concrete implementations, but an unqualified `this`-call inside an abstract class whose target overload only exists in subclasses produced no edges. password4j's public-API chain broke exactly there. With the fix, mining password4j 1.8.4 exposes the full chain IBM expects:

```
HashBuilder.withPBKDF2 → HashBuilder.with → AbstractHashingFunction.hash
  → PBKDF2Function.hash → PBKDF2Function.internalHash   (PBEKeySpec / JCA terminal)
```

and the `withPBKDF2` crypto entry point reaches the PBKDF2 terminal at `chain_depth: 5` (was: only its own synthetic finding at depth 1).

**2. Deterministic containing-function attribution.** `findContainingFunctionByFinding` returned the first line-range match from an unordered map; when a wide synthetic `<clinit>` span enclosed the same line as the real method, ~40% of runs attributed the finding to `<clinit>`, failed the crypto-call join and silently lost every chain for that finding. Now picks the tightest span, tie-broken by function key. (This flakiness pre-dates this branch — verified identical on the v0.13.0 binary.)

## Validation

- New tests: password4j-shaped fixture asserting both dispatch hops (`abstract_dispatch_test.go`) and a 50-iteration determinism test for tightest-span selection.
- Full suite green except pre-existing Docker/testcontainers postgres tests (no local daemon, same on main). Lint: only the 3 known pre-existing `prealloc` false positives on untouched lines.
- E2E on password4j 1.8.4 source: **5/5 consecutive runs** produce `reachable_findings` depths `[1, 5]` for `withPBKDF2` — deterministic.
- Fan-out noise on password4j (441 functions): edges 1066 → 1580 (+48%), finding-graph chains 17 → 35. Proportionate to the 7 `HashingFunction` implementations; measured, not suppressed.
- `docs/DEPENDENCY_SCANNING.md` polymorphism note updated to reflect actual behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependency scanning now provides more precise handling for Java interface and abstract method dispatch, improving call resolution in supported projects.
  * Findings are now matched to the tightest enclosing function span, making scan attribution more accurate and consistent.

* **Bug Fixes**
  * Reduced false matches in call graph expansion by only applying abstract dispatch logic when the receiver type is known.
  * Improved determinism when multiple functions overlap on the same line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->