### PR TITLE
feat(graphfrag): receiver-provenance disambiguation for multi-implementor dispatch

### DIFF
--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -157,6 +157,17 @@ func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) 
 	// imports. resolveFluentChainsByReturnType (above) only propagates in-graph
 	// return types and runs before the KB is available.
 	resolveFluentChainCalleesByContract(graph, kb)
+
+	// Resolve single-argument pass-through dispatch: a call site whose
+	// interface-typed parameter is used, unmodified, as the sole receiver of an
+	// otherwise-ambiguous interface-dispatch call inside the callee's body.
+	// When a caller of that callee passes a statically concrete argument (a
+	// constructor call, or a call whose declared/inferred return type is
+	// concrete), the ambiguity is resolvable FOR THAT CALLER even though the
+	// dispatch call site itself is shared by every caller of the callee. Runs
+	// after inference so both declared and KB-inferred return types are
+	// available. See resolveParameterPassthroughDispatch for the full contract.
+	resolveParameterPassthroughDispatch(graph)
 	inferenceDuration := time.Since(inferenceStart)
 
 	log.Info().
@@ -994,6 +1005,565 @@ func unconditionalContractReturn(ctrs []contracts.Contract) string {
 		}
 	}
 	return ""
+}
+
+// dispatchAmbiguousGroupKey groups EdgeResolutions the same way the stitcher's
+// dispatchGroupKey does: one interface-dispatch call site (caller + call site +
+// method + arity), independent of which of the N candidate targets a given
+// EdgeResolution entry names.
+type dispatchAmbiguousGroupKey struct {
+	Caller     string
+	CallSite   int
+	MethodName string
+	Arity      int
+}
+
+// resolveParameterPassthroughDispatch resolves a narrow, sound special case the
+// generic count-of-candidates ambiguity check cannot: a callee function whose
+// interface-typed parameter is used, directly and exclusively, as the receiver
+// of the ONE ambiguous interface-dispatch call in its body (a "pass-through"
+// receiver, e.g. password4j's `with(HashingFunction h) { return h.hash(...); }`).
+// That call site is genuinely ambiguous when judged in isolation — `with`'s
+// several callers each pass a DIFFERENT concrete HashingFunction implementation
+// (withPBKDF2 passes PBKDF2Function, withBcrypt passes BcryptFunction, ...) — so
+// stamping a single resolved type on the shared edge would be unsound: correct
+// for one caller, wrong for the rest.
+//
+// Instead, for each caller of the pass-through callee whose argument at the
+// parameter's position resolves to ONE concrete type (constructor call, or a
+// call whose declared/inferred return type is concrete) that matches EXACTLY
+// ONE candidate in the dispatch group, a new direct edge is added from that
+// SPECIFIC caller straight to the concrete target — bypassing the shared
+// ambiguous node for that caller's reachability only. The original
+// caller->passthrough->[ambiguous group] edges are left untouched, so any
+// caller this pass cannot resolve keeps failing closed exactly as before.
+// passthroughMaxIterations caps the fixpoint loop in resolveParameterPassthroughDispatch.
+// Each iteration only adds NEW bypass edges (existing ones are never revisited
+// as new sources — addCaller/recordEdgeResolution are idempotent), and a real
+// password4j-shaped chain is at most a few hops deep, so this is a generous
+// safety valve rather than a realistic limit.
+const passthroughMaxIterations = 10
+
+// resolveParameterPassthroughDispatch resolves a narrow, sound special case the
+// generic count-of-candidates ambiguity check cannot: a callee function whose
+// interface-typed parameter (or, for the SAME-context case, its own implicit
+// "this" receiver) is used, directly and exclusively, as the receiver of the
+// ONE ambiguous interface-dispatch call in its body (a "pass-through"
+// receiver, e.g. password4j's `with(HashingFunction h) { return h.hash(...); }`,
+// or an inherited method's `this.hash(...)` self-call). That call site is
+// genuinely ambiguous when judged in isolation — `with`'s several callers each
+// pass a DIFFERENT concrete HashingFunction implementation (withPBKDF2 passes
+// PBKDF2Function, withBcrypt passes BcryptFunction, ...) — so stamping a single
+// resolved type on the shared edge would be unsound: correct for one caller,
+// wrong for the rest.
+//
+// Instead, for each caller of the pass-through callee whose argument (or, for
+// a "this" receiver, whose own already-resolved bypass context) resolves to
+// ONE concrete type that matches EXACTLY ONE candidate in the dispatch group,
+// a new direct edge is added from that SPECIFIC caller straight to the
+// concrete target — bypassing the shared ambiguous node for that caller's
+// reachability only. The original caller->passthrough->[ambiguous group] edges
+// are left untouched, so any caller this pass cannot resolve keeps failing
+// closed exactly as before.
+//
+// Runs to a fixpoint (bounded by passthroughMaxIterations) because resolving
+// one hop (e.g. withPBKDF2 -> AbstractHashingFunction.hash#3, in a
+// PBKDF2Function context) can unlock the NEXT hop inside that same target's
+// body (hash#3's own "this.hash(...)" self-call, which the first pass alone
+// cannot see since it has no explicit receiver argument to resolve).
+func resolveParameterPassthroughDispatch(graph *CallGraph) {
+	totalResolved := 0
+	for iter := 0; iter < passthroughMaxIterations; iter++ {
+		groups := groupAmbiguousDispatchEdges(graph)
+		resolved := 0
+		for _, gk := range sortedAmbiguousGroupKeys(groups) {
+			resolved += resolvePassthroughGroup(graph, gk, groups[gk])
+		}
+		totalResolved += resolved
+		if resolved == 0 {
+			break
+		}
+	}
+	if totalResolved > 0 {
+		log.Info().Int("resolved", totalResolved).Msg("Resolved parameter pass-through interface dispatch")
+	}
+}
+
+// groupAmbiguousDispatchEdges collects every recorded interface_dispatch
+// EdgeResolution keyed by call site, mirroring the stitcher's dispatch-group
+// identity so a group here has >1 entries exactly when the stitcher would judge
+// that call site ambiguous.
+func groupAmbiguousDispatchEdges(graph *CallGraph) map[dispatchAmbiguousGroupKey][]edgeResolutionEntry {
+	groups := make(map[dispatchAmbiguousGroupKey][]edgeResolutionEntry)
+	for key, res := range graph.EdgeResolutions {
+		if res.Kind != EdgeKindInterfaceDispatch {
+			continue
+		}
+		callerKey, calleeKey, ok := splitEdgeResolutionKey(key)
+		if !ok {
+			continue
+		}
+		gk := dispatchAmbiguousGroupKey{Caller: callerKey, CallSite: res.CallSite, MethodName: res.MethodName, Arity: res.Arity}
+		groups[gk] = append(groups[gk], edgeResolutionEntry{calleeKey: calleeKey, resolution: res})
+	}
+	for gk, entries := range groups {
+		if len(entries) < 2 {
+			delete(groups, gk)
+		}
+	}
+	return groups
+}
+
+// edgeResolutionEntry pairs one EdgeResolutions map entry with its parsed
+// callee key so grouping code does not re-split the composite key.
+type edgeResolutionEntry struct {
+	calleeKey  string
+	resolution EdgeResolution
+}
+
+// splitEdgeResolutionKey recovers the callerKey/calleeKey from an
+// EdgeResolutionKey string. EdgeResolutionKeyPrefix builds the key as
+// "<callerKey>\x00<calleeKey>\x00<callSite>\x00<declaredType>\x00<method>\x00<arity>";
+// callerKey and calleeKey are FunctionID.String() values, which never contain
+// \x00, so the first two \x00-delimited fields are exactly callerKey and
+// calleeKey. Returns ok=false if the key has fewer than 2 fields (defensive;
+// should not happen for well-formed keys produced by EdgeResolutionKey).
+func splitEdgeResolutionKey(key string) (callerKey, calleeKey string, ok bool) {
+	parts := strings.SplitN(key, "\x00", 3)
+	if len(parts) < 3 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func sortedAmbiguousGroupKeys(groups map[dispatchAmbiguousGroupKey][]edgeResolutionEntry) []dispatchAmbiguousGroupKey {
+	keys := make([]dispatchAmbiguousGroupKey, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.Caller != b.Caller {
+			return a.Caller < b.Caller
+		}
+		if a.CallSite != b.CallSite {
+			return a.CallSite < b.CallSite
+		}
+		if a.MethodName != b.MethodName {
+			return a.MethodName < b.MethodName
+		}
+		return a.Arity < b.Arity
+	})
+	return keys
+}
+
+// resolvePassthroughGroup evaluates one ambiguous dispatch group (gk.Caller is
+// the function whose body issues the ambiguous call — the "pass-through
+// candidate") and, if it qualifies, resolves the ambiguity per-caller. Returns
+// the number of caller-specific bypass edges added.
+//
+// Qualification (conservative by design — every condition narrows toward
+// "do nothing" on doubt, matching the fail-closed default), delegated to
+// passthroughParameterIndex:
+//  1. The ambiguous call site must be uniquely identifiable in gk.Caller's
+//     body by (line, method, arity) — see findCallAtSite.
+//  2. Its receiver is either (a) one of gk.Caller's OWN parameters
+//     (positionally matched via FunctionParameter.Name) — a pass-through of an
+//     argument — in which case gk.Caller must have EXACTLY ONE call in its
+//     body (a parameter could otherwise be reassigned or escape into a branch
+//     this pass cannot see); or (b) gk.Caller's own implicit "this" — in which
+//     case a multi-call, branching body is tolerated (this's type is fixed for
+//     the whole method regardless of branch).
+//  3. Each entry in the group names a distinct candidate; each candidate's
+//     owner type is derived from its FunctionID.Type (simple name).
+func resolvePassthroughGroup(graph *CallGraph, gk dispatchAmbiguousGroupKey, entries []edgeResolutionEntry) int {
+	calleeFn, ambiguousCall, paramIdx, ok := passthroughParameterIndex(graph, gk)
+	if !ok {
+		return 0
+	}
+
+	candidateOwners := resolveOverloadPerOwner(graph, ambiguousCall, candidateOwnersByType(entries))
+	if len(candidateOwners) == 0 {
+		return 0
+	}
+
+	resolved := 0
+	for _, callerKey := range append([]string(nil), graph.Callers[gk.Caller]...) {
+		outerFn := graph.Functions[callerKey]
+		if outerFn == nil {
+			continue
+		}
+		resolved += resolvePassthroughForCaller(graph, outerFn, callerKey, calleeFn, gk, paramIdx, candidateOwners)
+	}
+	return resolved
+}
+
+// resolveOverloadPerOwner collapses candidateOwnersByType's owner->[]calleeKey
+// map to owner->calleeKey by picking the best-scoring overload for each owner
+// with more than one candidate, using the ambiguous call's OWN argument types
+// (call is the pass-through function's single internal call, e.g.
+// `hashingFunction.hash(plainTextPassword, salt, pepper)` — its argument types
+// are fixed regardless of which outer caller reaches it, since they come from
+// the pass-through function's own fields/locals, not the outer caller). Reuses
+// scoreOverloadCandidate, the same scoring inferJavaArgumentType-based overload
+// resolution uses elsewhere in this file. An owner whose best score is 0 (no
+// argument matched any parameter) is dropped rather than guessed.
+func resolveOverloadPerOwner(graph *CallGraph, call FunctionCall, ownerCandidates map[string][]string) map[string]string {
+	resolved := make(map[string]string, len(ownerCandidates))
+	for owner, keys := range ownerCandidates {
+		if len(keys) == 1 {
+			resolved[owner] = keys[0]
+			continue
+		}
+		best, bestScore := "", -1
+		for _, key := range keys {
+			fn := graph.Functions[key]
+			if fn == nil {
+				continue
+			}
+			if score := scoreOverloadCandidate(fn, &call); score > bestScore {
+				best, bestScore = key, score
+			}
+		}
+		if best != "" && bestScore > 0 {
+			resolved[owner] = best
+		}
+	}
+	return resolved
+}
+
+// thisReceiverParamIndex is the sentinel passthroughParameterIndex returns
+// when the ambiguous call's receiver is the function's own implicit "this"
+// (ReceiverVar == "") rather than a named parameter — e.g.
+// AbstractHashingFunction.hash#3's own `hash(peppered, salt)` self-call. In
+// that case resolvePassthroughForCaller resolves the concrete type from the
+// OUTER caller's own already-resolved bypass context (ResolvedReceiverType on
+// the edge that reached gk.Caller) instead of from an argument.
+const thisReceiverParamIndex = -1
+
+// passthroughParameterIndex locates the ambiguous call site inside
+// gk.Caller's body and classifies its receiver as either a pass-through of one
+// of the function's own parameters (returns that parameter's index) or the
+// function's own implicit "this" (returns thisReceiverParamIndex). Also
+// returns the specific matching FunctionCall (there may be several calls in
+// the body; only the one at gk.CallSite/method/arity is relevant). ok=false
+// disqualifies the whole group (see resolvePassthroughGroup).
+//
+// The "this" case tolerates a multi-call, branching body (e.g.
+// `if (salt == null) { hash(x) } else { hash(x, salt) }`): this's concrete
+// type is fixed for the whole method regardless of which branch runs, so extra
+// calls/branches around it do not introduce the ambiguity the parameter case
+// guards against. The named-parameter case keeps the stricter "exactly one
+// call total" gate: a parameter COULD be reassigned or escape into a branch
+// this pass cannot see, so it stays conservative.
+func passthroughParameterIndex(graph *CallGraph, gk dispatchAmbiguousGroupKey) (*FunctionDecl, FunctionCall, int, bool) {
+	fn := graph.Functions[gk.Caller]
+	if fn == nil {
+		return nil, FunctionCall{}, 0, false
+	}
+	call, ok := findCallAtSite(fn, gk)
+	if !ok {
+		return nil, FunctionCall{}, 0, false
+	}
+	if call.ReceiverVar == "" {
+		return fn, call, thisReceiverParamIndex, true
+	}
+	if len(fn.Calls) != 1 {
+		return nil, FunctionCall{}, 0, false
+	}
+	for i := range fn.Parameters {
+		if fn.Parameters[i].Name != "" && fn.Parameters[i].Name == call.ReceiverVar {
+			return fn, call, i, true
+		}
+	}
+	return nil, FunctionCall{}, 0, false
+}
+
+// findCallAtSite finds the single call in fn matching gk's call site identity
+// (line, method name, arity). Returns ok=false if zero or more than one call
+// matches (an unexpected shape this pass should not guess about).
+func findCallAtSite(fn *FunctionDecl, gk dispatchAmbiguousGroupKey) (FunctionCall, bool) {
+	var found *FunctionCall
+	for i := range fn.Calls {
+		c := &fn.Calls[i]
+		if c.Line != gk.CallSite {
+			continue
+		}
+		method, arity := methodBaseArity(c.Callee.Name)
+		if method != gk.MethodName || arity != gk.Arity {
+			continue
+		}
+		if found != nil {
+			return FunctionCall{}, false
+		}
+		found = c
+	}
+	if found == nil {
+		return FunctionCall{}, false
+	}
+	return *found, true
+}
+
+// candidateOwnersByType maps each candidate's declaring type SIMPLE name
+// (FunctionID.Type, e.g. "AbstractHashingFunction") to its callee key(s), for
+// candidates with a non-empty owner type. The simple name — not the
+// fully-qualified one — is used because resolveArgumentConcreteType's sources
+// (FunctionDecl.ReturnType, InferredReturn.Type, and constructor DeclaredType)
+// are erased/simple names throughout this codebase (see erasedTypeName), so
+// matching on simple name is what actually lines up; a real cross-package name
+// collision would require qualifying by package too, which this pass does not
+// attempt (out of scope: erased-name provenance does not carry package here).
+//
+// An owner can map to more than one candidate when the dispatch group's
+// method+arity covers multiple overloads declared on the SAME type (e.g.
+// AbstractHashingFunction.hash(CharSequence,String,CharSequence) and
+// .hash(byte[],byte[],CharSequence) are both arity-3 "hash" methods) — that
+// ambiguity is resolved by resolveOverloadPerOwner using the ambiguous call's
+// own argument types (the same signal scoreOverloadCandidate uses elsewhere).
+func candidateOwnersByType(entries []edgeResolutionEntry) map[string][]string {
+	owners := make(map[string][]string, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		id, err := ParseFunctionID(e.calleeKey)
+		if err != nil || id.Type == "" || seen[e.calleeKey] {
+			continue
+		}
+		seen[e.calleeKey] = true
+		owners[id.Type] = append(owners[id.Type], e.calleeKey)
+	}
+	return owners
+}
+
+// resolvePassthroughForCaller resolves ONE outer caller's context to a
+// concrete receiver type and, if it matches exactly one candidate owner, adds
+// a direct bypass edge from callerKey straight to that candidate. Returns 1 if
+// an edge was added, else 0.
+//
+// Two receiver shapes (see passthroughParameterIndex):
+//   - paramIdx >= 0: the ambiguous call's receiver is calleeFn's own paramIdx-th
+//     parameter. The concrete type comes from resolving outerFn's OWN call to
+//     calleeFn at that argument position (a constructor call, or a call whose
+//     declared/inferred return type is concrete).
+//   - paramIdx == thisReceiverParamIndex: the ambiguous call's receiver is
+//     calleeFn's own implicit "this" (calleeFn.ID IS gk.Caller). The concrete
+//     type comes from the ResolvedReceiverType this pass already stamped on
+//     the edge callerKey->gk.Caller in an earlier iteration — i.e. this
+//     extends an existing resolved bypass one hop further into the target's
+//     own body, rather than resolving a fresh argument.
+func resolvePassthroughForCaller(
+	graph *CallGraph,
+	outerFn *FunctionDecl,
+	callerKey string,
+	calleeFn *FunctionDecl,
+	gk dispatchAmbiguousGroupKey,
+	paramIdx int,
+	candidateOwners map[string]string,
+) int {
+	if paramIdx == thisReceiverParamIndex {
+		return resolvePassthroughForThisReceiver(graph, callerKey, gk, candidateOwners)
+	}
+
+	call := findCallToCallee(outerFn, calleeFn.ID, len(calleeFn.Parameters))
+	if call == nil || paramIdx >= len(call.Arguments) {
+		return 0
+	}
+	argType := resolveArgumentConcreteType(graph, call, paramIdx)
+	if argType == "" {
+		return 0
+	}
+	targetKey, ok := resolveCandidateOwner(graph, argType, candidateOwners)
+	if !ok {
+		return 0
+	}
+	addCaller(graph.Callers, targetKey, callerKey)
+	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", call.Line)
+	stampResolvedReceiverType(graph, callerKey, targetKey, call.Line, argType)
+	return 1
+}
+
+// resolvePassthroughForThisReceiver extends an already-resolved bypass edge
+// callerKey->gk.Caller (which carries a ResolvedReceiverType stamped by an
+// earlier resolveParameterPassthroughDispatch iteration) one hop further: if
+// gk.Caller's own ambiguous "this" call resolves, via that SAME concrete type,
+// to exactly one candidate, a new bypass edge callerKey->candidate is added.
+// Returns 1 if an edge was added, else 0.
+func resolvePassthroughForThisReceiver(
+	graph *CallGraph,
+	callerKey string,
+	gk dispatchAmbiguousGroupKey,
+	candidateOwners map[string]string,
+) int {
+	resolvedType, line, ok := lookupResolvedReceiverType(graph, callerKey, gk.Caller)
+	if !ok {
+		return 0
+	}
+	targetKey, ok := resolveCandidateOwner(graph, resolvedType, candidateOwners)
+	if !ok {
+		return 0
+	}
+	addCaller(graph.Callers, targetKey, callerKey)
+	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", line)
+	stampResolvedReceiverType(graph, callerKey, targetKey, line, resolvedType)
+	return 1
+}
+
+// lookupResolvedReceiverType scans callerKey's recorded EdgeResolutions for an
+// entry targeting calleeKey that carries a non-empty ResolvedReceiverType
+// (stamped by a previous resolveParameterPassthroughDispatch iteration).
+// Returns the resolved type and the call-site line to attribute the extended
+// bypass edge to.
+func lookupResolvedReceiverType(graph *CallGraph, callerKey, calleeKey string) (resolvedType string, line int, ok bool) {
+	prefix := EdgeResolutionKeyPrefix(callerKey, calleeKey)
+	for key, res := range graph.EdgeResolutions {
+		if res.ResolvedReceiverType == "" || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		return res.ResolvedReceiverType, res.CallSite, true
+	}
+	return "", 0, false
+}
+
+// resolveCandidateOwner matches a resolved concrete argument type against the
+// dispatch group's candidate owners (keyed by simple type name — see
+// candidateOwnersByType), first by exact match, then by walking the concrete
+// type's OwnerBases (populated for Java classes from their extends/implements
+// clauses) up to inheritanceMaxDepth levels — this is what lets password4j's
+// PBKDF2Function (which inherits hash#3 from AbstractHashingFunction without
+// overriding it) resolve to the AbstractHashingFunction candidate.
+//
+// argType may be a simple name (the common case: FunctionDecl.ReturnType /
+// InferredReturn.Type are erased/simple names) or occasionally
+// fully-qualified (a constructor's DeclaredType); simpleTypeName normalizes
+// either shape to its trailing segment before matching/walking.
+func resolveCandidateOwner(graph *CallGraph, argType string, candidateOwners map[string]string) (string, bool) {
+	simpleName := simpleTypeName(argType)
+	if targetKey, ok := candidateOwners[simpleName]; ok {
+		return targetKey, true
+	}
+
+	seen := map[string]bool{simpleName: true}
+	queue := []string{simpleName}
+	for depth := 0; depth < inheritanceMaxDepth && len(queue) > 0; depth++ {
+		next := queue[0]
+		queue = queue[1:]
+		decl := findClassDeclByType(graph, next)
+		if decl == nil {
+			continue
+		}
+		for _, base := range decl.OwnerBases {
+			base = simpleTypeName(strings.TrimSpace(base))
+			if base == "" || seen[base] {
+				continue
+			}
+			seen[base] = true
+			if targetKey, ok := candidateOwners[base]; ok {
+				return targetKey, true
+			}
+			queue = append(queue, base)
+		}
+	}
+	return "", false
+}
+
+// simpleTypeName returns the trailing, unqualified segment of a (possibly
+// fully-qualified) type name.
+func simpleTypeName(typeName string) string {
+	if idx := strings.LastIndex(typeName, "."); idx >= 0 {
+		return typeName[idx+1:]
+	}
+	return typeName
+}
+
+// inheritanceMaxDepth caps the OwnerBases ancestor walk in resolveCandidateOwner.
+// Java inheritance chains this pass needs to bridge are shallow in practice
+// (one or two hops); the cap is a safety valve against a malformed/cyclic
+// OwnerBases graph, not a realistic limit.
+const inheritanceMaxDepth = 8
+
+// findClassDeclByType finds any FunctionDecl declared on the given
+// simple-type-name class, used only to read its OwnerBases (every
+// method/constructor of a class carries the same OwnerBases, so the first hit
+// is sufficient). Matches by simple name only (see candidateOwnersByType).
+func findClassDeclByType(graph *CallGraph, typeName string) *FunctionDecl {
+	for _, fn := range graph.Functions {
+		if fn.OwnerType == ownerTypeClass && fn.ID.Type == typeName {
+			return fn
+		}
+	}
+	return nil
+}
+
+// findCallToCallee finds the first call in fn whose resolved callee matches id
+// and whose argument count equals wantArity (the pass-through function's own
+// parameter count, since the outer call must supply the same arity to reach it).
+func findCallToCallee(fn *FunctionDecl, id FunctionID, wantArity int) *FunctionCall {
+	for i := range fn.Calls {
+		c := &fn.Calls[i]
+		if c.Callee.String() == id.String() && len(c.Arguments) == wantArity {
+			return c
+		}
+	}
+	return nil
+}
+
+// resolveArgumentConcreteType resolves a call argument to a concrete
+// (non-interface, non-generic) type using its recorded SourceNodes: a
+// constructor call yields its constructed type; a CALL_RESULT yields the
+// target function's InferredReturn.Type when set, else its declared
+// ReturnType. Returns "" when no concrete type can be determined — the caller
+// then leaves the ambiguity exactly as before (fail-closed).
+func resolveArgumentConcreteType(graph *CallGraph, call *FunctionCall, argIdx int) string {
+	if argIdx >= len(call.ArgumentSources) {
+		return ""
+	}
+	for _, src := range call.ArgumentSources[argIdx] {
+		if typ := concreteTypeFromSourceNode(graph, src); typ != "" {
+			return typ
+		}
+	}
+	return ""
+}
+
+func concreteTypeFromSourceNode(graph *CallGraph, src SourceNode) string {
+	if src.Type != sourceNodeCallResult || src.CallTarget == nil {
+		return ""
+	}
+	target := src.CallTarget
+	if strings.Contains(target.Name, constructorMethodName) {
+		if src.DeclaredType != "" {
+			return src.DeclaredType
+		}
+		return qualifiedType(target.Package, target.Type)
+	}
+	callee := graph.Functions[target.String()]
+	if callee == nil {
+		return ""
+	}
+	if callee.InferredReturn != nil && callee.InferredReturn.Origin != OriginJoinFailed && callee.InferredReturn.Type != "" {
+		return callee.InferredReturn.Type
+	}
+	return callee.ReturnType
+}
+
+// stampResolvedReceiverType writes ResolvedReceiverType onto the just-recorded
+// exact EdgeResolution for callerKey->targetKey at line, so the fragment
+// exporter can carry it through as graph-fragment resolved_receiver_type.
+func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, line int, resolvedType string) {
+	// Mirror recordEdgeResolution's method/arity derivation exactly so the key
+	// matches the entry it just wrote (EdgeResolutionKey folds MethodName/Arity
+	// into the map key, so an approximate key would silently miss).
+	method, arity := "", 0
+	if calleeID, err := ParseFunctionID(targetKey); err == nil {
+		method = BaseFunctionName(calleeID.Name)
+		arity = functionArity(calleeID.Name)
+	}
+	key := EdgeResolutionKey(callerKey, targetKey, EdgeResolution{MethodName: method, Arity: arity, CallSite: line})
+	res, ok := graph.EdgeResolutions[key]
+	if !ok {
+		return
+	}
+	res.ResolvedReceiverType = resolvedType
+	graph.EdgeResolutions[key] = res
 }
 
 // buildTypePackageIndex maps simple type names to their packages.

--- a/internal/callgraph/java_parser.go
+++ b/internal/callgraph/java_parser.go
@@ -42,6 +42,10 @@ const (
 	javaFunctionTypeClassInit    = "class-init"
 	javaNodeStaticInitializer    = "static_initializer"
 	javaThisKeyword              = "this"
+	javaNodeSuperclass           = "superclass"
+	javaNodeSuperInterfaces      = "super_interfaces"
+	javaNodeTypeList             = "type_list"
+	javaNodeTypeIdentifier       = "type_identifier"
 )
 
 // NewJavaParser creates a new Java source parser backed by tree-sitter.
@@ -228,6 +232,9 @@ func (p *JavaParser) processClass(
 	fieldTypes := p.collectJavaFieldTypes(body, src)
 	fieldAssignments := p.collectClassFieldAssignments(body, src, filePath, fieldTypes)
 	methodDecls, constructorDecls := p.collectJavaClassDecls(body, src, filePath, analysis, fullClassName, ownerVisibility, fieldTypes, fieldAssignments)
+	bases := extractJavaClassBases(node, src)
+	stampOwnerBases(constructorDecls, bases)
+	stampOwnerBases(methodDecls, bases)
 	appendJavaDecls(analysis, constructorDecls)
 	appendJavaDecls(analysis, methodDecls)
 }
@@ -247,6 +254,55 @@ func parseJavaClass(node *sitter.Node, src []byte) (string, *sitter.Node) {
 	}
 
 	return className, body
+}
+
+// extractJavaClassBases reads a class_declaration's superclass (extends) and
+// super_interfaces (implements) clauses into a flat list of simple type names
+// (e.g. ["AbstractHashingFunction", "HashingFunction"]). Populates
+// FunctionDecl.OwnerBases for Java the same way the Python parser already does
+// for base classes — reusing the SAME field lets resolveParameterPassthroughDispatch
+// (and any future consumer) walk one level of inheritance without a
+// Java-specific type. Interfaces/generics are captured by simple name only
+// (erased), matching how OwnerBases is consumed elsewhere (string comparison
+// against FunctionID.Type).
+func extractJavaClassBases(node *sitter.Node, src []byte) []string {
+	var bases []string
+	for i := 0; i < int(node.ChildCount()); i++ {
+		child := node.Child(i)
+		switch child.Type() {
+		case javaNodeSuperclass:
+			bases = append(bases, javaTypeIdentifierNames(child, src)...)
+		case javaNodeSuperInterfaces:
+			bases = append(bases, javaTypeIdentifierNames(child, src)...)
+		}
+	}
+	return bases
+}
+
+// javaTypeIdentifierNames recursively collects every type_identifier leaf
+// under node (covers both a single superclass and a super_interfaces'
+// type_list of one-or-more implemented interfaces).
+func javaTypeIdentifierNames(node *sitter.Node, src []byte) []string {
+	var names []string
+	if node.Type() == javaNodeTypeIdentifier {
+		names = append(names, node.Content(src))
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		names = append(names, javaTypeIdentifierNames(node.Child(i), src)...)
+	}
+	return names
+}
+
+// stampOwnerBases copies bases onto every decl in decls. No-op when bases is
+// empty so a class with no extends/implements clause leaves OwnerBases nil,
+// exactly as before this field was populated for Java.
+func stampOwnerBases(decls []*FunctionDecl, bases []string) {
+	if len(bases) == 0 {
+		return
+	}
+	for _, decl := range decls {
+		decl.OwnerBases = bases
+	}
 }
 
 func javaNestedTypeName(outerType, typeName string) string {
@@ -1727,6 +1783,7 @@ func parseJavaParameterTypesFromList(listContent string) []FunctionParameter {
 		params = append(params, FunctionParameter{
 			Type:    erasedTypeName(spec.RawType, ref),
 			TypeRef: ref,
+			Name:    spec.Name,
 		})
 	}
 	return params

--- a/internal/callgraph/parameter_passthrough_dispatch_test.go
+++ b/internal/callgraph/parameter_passthrough_dispatch_test.go
@@ -1,0 +1,210 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveParameterPassthroughDispatch_ConstructorArgumentDisambiguates is
+// the minimal reproduction of the password4j withPBKDF2 shape: a factory
+// method (viaImplA) constructs a concrete SinkImplA and passes it, in one
+// statement, to with(Sink), whose ENTIRE body immediately dispatches on that
+// parameter (s.run()) — an interface call site that is genuinely ambiguous
+// judged in isolation (2 concrete Sink implementors in the graph), but
+// resolvable for viaImplA's specific call because it supplies a
+// constructor-known concrete type.
+//
+// Asserts: a new direct edge viaImplA -> SinkImplA.run is recorded as exact
+// and carries ResolvedReceiverType "SinkImplA" — the fragment exporter reads
+// this to stamp graph-fragment resolved_receiver_type (see
+// internal/scan/fragment_export_resolved_receiver_test.go), which the
+// stitcher then uses to disambiguate (see
+// pkg/graphfrag/stitch_receiver_provenance_test.go).
+func TestResolveParameterPassthroughDispatch_ConstructorArgumentDisambiguates(t *testing.T) {
+	root := t.TempDir()
+
+	sinkID := FunctionID{Package: "com.acme", Type: "Sink", Name: "run#0"}
+	implAID := FunctionID{Package: "com.acme", Type: "SinkImplA", Name: "run#0"}
+	implBID := FunctionID{Package: "com.acme", Type: "SinkImplB", Name: "run#0"}
+	withID := FunctionID{Package: "com.acme", Type: "Builder", Name: "with#1"}
+	viaAID := FunctionID{Package: "com.acme", Type: "Builder", Name: "viaImplA#0"}
+
+	sinkIface := FunctionDecl{
+		ID: sinkID, FilePath: filepath.Join(root, "Sink.java"), StartLine: 1, EndLine: 2,
+		OwnerType: ownerTypeInterface, OwnerName: "Sink", Parameters: []FunctionParameter{},
+	}
+	implA := FunctionDecl{
+		ID: implAID, FilePath: filepath.Join(root, "SinkImplA.java"), StartLine: 1, EndLine: 4,
+		OwnerType: ownerTypeClass, OwnerName: "SinkImplA", Parameters: []FunctionParameter{},
+	}
+	implB := FunctionDecl{
+		ID: implBID, FilePath: filepath.Join(root, "SinkImplB.java"), StartLine: 1, EndLine: 4,
+		OwnerType: ownerTypeClass, OwnerName: "SinkImplB", Parameters: []FunctionParameter{},
+	}
+	// with(Sink s) { s.run(); } — the pass-through candidate: a single call
+	// whose ReceiverVar ("s") names its own only parameter.
+	withFn := FunctionDecl{
+		ID: withID, FilePath: filepath.Join(root, "Builder.java"), StartLine: 10, EndLine: 12,
+		OwnerType: ownerTypeClass, OwnerName: "Builder",
+		Parameters: []FunctionParameter{{Type: "Sink", Name: "s"}},
+		Calls: []FunctionCall{
+			{Callee: sinkID, ReceiverVar: "s", FilePath: filepath.Join(root, "Builder.java"), Line: 11, Raw: "s.run()"},
+		},
+	}
+	// viaImplA() { with(new SinkImplA()); } — passes a constructor-known
+	// concrete type as the ambiguous call's ultimate receiver.
+	viaA := FunctionDecl{
+		ID: viaAID, FilePath: filepath.Join(root, "Builder.java"), StartLine: 20, EndLine: 22,
+		OwnerType: ownerTypeClass, OwnerName: "Builder",
+		Calls: []FunctionCall{
+			{
+				Callee:    withID,
+				Arguments: []string{"new SinkImplA()"},
+				ArgumentSources: [][]SourceNode{
+					{
+						{
+							Type:         sourceNodeCallResult,
+							CallTarget:   &FunctionID{Package: "com.acme", Type: "SinkImplA", Name: "<init>#0"},
+							DeclaredType: "SinkImplA",
+						},
+					},
+				},
+				FilePath: filepath.Join(root, "Builder.java"),
+				Line:     21,
+				Raw:      "with(new SinkImplA())",
+			},
+		},
+	}
+
+	parser := &stubParser{
+		sep: ".",
+		analyses: map[string][]*FileAnalysis{
+			root: {{Functions: []FunctionDecl{sinkIface, implA, implB, withFn, viaA}}},
+		},
+	}
+
+	graph, err := NewBuilder(parser).BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "com.acme"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	// Precondition: the with() call site is genuinely ambiguous in isolation —
+	// both SinkImplA.run and SinkImplB.run are candidates.
+	ambiguousKey := dispatchGroupKeyForTest(withID.String(), 11, "run", 0)
+	implARes, ok := graph.EdgeResolutions[EdgeResolutionKey(withID.String(), implAID.String(), EdgeResolution{
+		Kind: EdgeKindInterfaceDispatch, DeclaredType: "com.acme.Sink", MethodName: "run", Arity: 0, CallSite: 11,
+	})]
+	if !ok || implARes.Kind != EdgeKindInterfaceDispatch {
+		t.Fatalf("precondition failed: expected interface_dispatch edge with#1 -> SinkImplA.run, got %#v (key=%v)", implARes, ambiguousKey)
+	}
+
+	// The disambiguated bypass edge: viaImplA -> SinkImplA.run, exact, carrying
+	// ResolvedReceiverType "SinkImplA".
+	bypassKey := EdgeResolutionKey(viaAID.String(), implAID.String(), EdgeResolution{
+		Kind: EdgeKindExact, MethodName: "run", Arity: 0, CallSite: 21,
+	})
+	bypass, ok := graph.EdgeResolutions[bypassKey]
+	if !ok {
+		t.Fatalf("expected a resolved pass-through bypass edge viaImplA -> SinkImplA.run; EdgeResolutions=%#v", graph.EdgeResolutions)
+	}
+	if bypass.Kind != EdgeKindExact {
+		t.Fatalf("bypass edge kind = %q, want %q", bypass.Kind, EdgeKindExact)
+	}
+	if bypass.ResolvedReceiverType != "SinkImplA" {
+		t.Fatalf("bypass edge ResolvedReceiverType = %q, want %q", bypass.ResolvedReceiverType, "SinkImplA")
+	}
+
+	// No bypass edge should exist to the OTHER implementor — the pass must not
+	// guess when it has resolved the type.
+	wrongKey := EdgeResolutionKey(viaAID.String(), implBID.String(), EdgeResolution{
+		Kind: EdgeKindExact, MethodName: "run", Arity: 0, CallSite: 21,
+	})
+	if _, ok := graph.EdgeResolutions[wrongKey]; ok {
+		t.Fatalf("unexpected bypass edge viaImplA -> SinkImplB.run; the resolved type must only ever match SinkImplA")
+	}
+}
+
+// dispatchGroupKeyForTest is a tiny readability helper for failure messages;
+// it has no behavior of its own.
+func dispatchGroupKeyForTest(caller string, callSite int, method string, arity int) dispatchAmbiguousGroupKey {
+	return dispatchAmbiguousGroupKey{Caller: caller, CallSite: callSite, MethodName: method, Arity: arity}
+}
+
+// TestResolveParameterPassthroughDispatch_NoBypassWithoutConcreteArgument is
+// the regression guard: when NO caller of the pass-through candidate supplies
+// a staticaly concrete argument (e.g. the argument is itself another
+// interface-typed value with no constructor/declared-return-type anchor), no
+// bypass edge is added and the original ambiguous group is left exactly as
+// the pre-existing fail-closed policy would judge it.
+func TestResolveParameterPassthroughDispatch_NoBypassWithoutConcreteArgument(t *testing.T) {
+	root := t.TempDir()
+
+	sinkID := FunctionID{Package: "com.acme", Type: "Sink", Name: "run#0"}
+	implAID := FunctionID{Package: "com.acme", Type: "SinkImplA", Name: "run#0"}
+	implBID := FunctionID{Package: "com.acme", Type: "SinkImplB", Name: "run#0"}
+	withID := FunctionID{Package: "com.acme", Type: "Builder", Name: "with#1"}
+	viaUnknownID := FunctionID{Package: "com.acme", Type: "Builder", Name: "viaUnknown#1"}
+
+	sinkIface := FunctionDecl{
+		ID: sinkID, FilePath: filepath.Join(root, "Sink.java"), StartLine: 1, EndLine: 2,
+		OwnerType: ownerTypeInterface, OwnerName: "Sink", Parameters: []FunctionParameter{},
+	}
+	implA := FunctionDecl{
+		ID: implAID, FilePath: filepath.Join(root, "SinkImplA.java"), StartLine: 1, EndLine: 4,
+		OwnerType: ownerTypeClass, OwnerName: "SinkImplA", Parameters: []FunctionParameter{},
+	}
+	implB := FunctionDecl{
+		ID: implBID, FilePath: filepath.Join(root, "SinkImplB.java"), StartLine: 1, EndLine: 4,
+		OwnerType: ownerTypeClass, OwnerName: "SinkImplB", Parameters: []FunctionParameter{},
+	}
+	withFn := FunctionDecl{
+		ID: withID, FilePath: filepath.Join(root, "Builder.java"), StartLine: 10, EndLine: 12,
+		OwnerType: ownerTypeClass, OwnerName: "Builder",
+		Parameters: []FunctionParameter{{Type: "Sink", Name: "s"}},
+		Calls: []FunctionCall{
+			{Callee: sinkID, ReceiverVar: "s", FilePath: filepath.Join(root, "Builder.java"), Line: 11, Raw: "s.run()"},
+		},
+	}
+	// viaUnknown(Sink passthroughParam) { with(passthroughParam); } — the
+	// argument is itself just a parameter with no constructor/return-type
+	// anchor, so no concrete type can be resolved.
+	viaUnknown := FunctionDecl{
+		ID: viaUnknownID, FilePath: filepath.Join(root, "Builder.java"), StartLine: 30, EndLine: 32,
+		OwnerType:  ownerTypeClass,
+		OwnerName:  "Builder",
+		Parameters: []FunctionParameter{{Type: "Sink", Name: "passthroughParam"}},
+		Calls: []FunctionCall{
+			{
+				Callee:    withID,
+				Arguments: []string{"passthroughParam"},
+				FilePath:  filepath.Join(root, "Builder.java"),
+				Line:      31,
+				Raw:       "with(passthroughParam)",
+			},
+		},
+	}
+
+	parser := &stubParser{
+		sep: ".",
+		analyses: map[string][]*FileAnalysis{
+			root: {{Functions: []FunctionDecl{sinkIface, implA, implB, withFn, viaUnknown}}},
+		},
+	}
+
+	graph, err := NewBuilder(parser).BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "com.acme"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	for _, implKey := range []string{implAID.String(), implBID.String()} {
+		key := EdgeResolutionKey(viaUnknownID.String(), implKey, EdgeResolution{
+			Kind: EdgeKindExact, MethodName: "run", Arity: 0, CallSite: 31,
+		})
+		if _, ok := graph.EdgeResolutions[key]; ok {
+			t.Fatalf("unexpected bypass edge viaUnknown -> %s; no concrete argument type was available to resolve", implKey)
+		}
+	}
+}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -196,6 +196,12 @@ type FunctionDecl struct {
 type FunctionParameter struct {
 	Type    string
 	TypeRef TypeRef
+	// Name is the declared parameter name (e.g. "hashingFunction"), when the
+	// parser captures it (1.6+ / Java only as of introduction). Empty for
+	// ecosystems whose parser does not populate it — callers that key off Name
+	// (e.g. parameter pass-through dispatch resolution) simply find no match and
+	// degrade to the prior behavior.
+	Name string
 }
 
 // FunctionCall represents a call expression within a function body.
@@ -348,6 +354,16 @@ type EdgeResolution struct {
 	MethodName   string // base method name (no arity decoration)
 	Arity        int
 	CallSite     int // source line of the call expression
+
+	// ResolvedReceiverType is the concrete receiver type resolveParameterPassthroughDispatch
+	// determined for THIS specific dispatch edge, when the call site is a
+	// single-use pass-through parameter and the calling context supplied a
+	// statically concrete argument (e.g. password4j's
+	// `with(AlgorithmFinder.getPBKDF2Instance())` calling into
+	// `with(HashingFunction h) { h.hash(...) }`). Empty when no such resolution
+	// applies. Exported verbatim as graph-fragment resolved_receiver_type so the
+	// stitcher can disambiguate a dispatch group at serve time.
+	ResolvedReceiverType string
 }
 
 // EdgeResolutionKey is the stable map key for one resolved caller->callee

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -219,14 +219,15 @@ func buildFragmentInternalEdge(
 	res fragmentEdgeResolution,
 ) graphfrag.GraphFragmentEdge {
 	edge := graphfrag.GraphFragmentEdge{
-		CallerKey:    callerKey,
-		CalleeKey:    calleeKey,
-		Line:         line,
-		Resolution:   res.Resolution,
-		DeclaredType: res.DeclaredType,
-		MethodName:   res.MethodName,
-		Arity:        res.Arity,
-		EntryCall:    buildFragmentCallSiteEntryCall(ctx, call),
+		CallerKey:            callerKey,
+		CalleeKey:            calleeKey,
+		Line:                 line,
+		Resolution:           res.Resolution,
+		DeclaredType:         res.DeclaredType,
+		MethodName:           res.MethodName,
+		Arity:                res.Arity,
+		EntryCall:            buildFragmentCallSiteEntryCall(ctx, call),
+		ResolvedReceiverType: res.ResolvedReceiverType,
 	}
 	if call != nil {
 		edge.ReceiverVar = call.ReceiverVar
@@ -248,14 +249,15 @@ func buildFragmentExternalCall(
 	res fragmentEdgeResolution,
 ) graphfrag.GraphFragmentExternal {
 	external := graphfrag.GraphFragmentExternal{
-		CallerKey:    callerKey,
-		TargetKey:    calleeKey,
-		Line:         line,
-		Resolution:   res.Resolution,
-		DeclaredType: res.DeclaredType,
-		MethodName:   res.MethodName,
-		Arity:        res.Arity,
-		EntryCall:    buildFragmentCallSiteEntryCall(ctx, call),
+		CallerKey:            callerKey,
+		TargetKey:            calleeKey,
+		Line:                 line,
+		Resolution:           res.Resolution,
+		DeclaredType:         res.DeclaredType,
+		MethodName:           res.MethodName,
+		Arity:                res.Arity,
+		EntryCall:            buildFragmentCallSiteEntryCall(ctx, call),
+		ResolvedReceiverType: res.ResolvedReceiverType,
 	}
 	external.TargetFunctionName = fragmentTargetFunctionName(callerDecl, calleeKey, &external)
 	if call != nil {

--- a/internal/scan/fragment_export_resolved_receiver_test.go
+++ b/internal/scan/fragment_export_resolved_receiver_test.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scan
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+)
+
+// TestBuildGraphFragmentExport_CarriesResolvedReceiverType proves that an
+// interface-dispatch call site whose receiver the callgraph builder resolved
+// to a concrete type (EdgeResolution.ResolvedReceiverType, e.g. stamped by
+// resolveParameterPassthroughDispatch for a password4j-shaped pass-through
+// call) produces a fragment edge carrying resolved_receiver_type — the field
+// pkg/graphfrag's stitcher reads to disambiguate an otherwise-ambiguous
+// dispatch group (see pkg/graphfrag/stitch_receiver_provenance_test.go).
+func TestBuildGraphFragmentExport_CarriesResolvedReceiverType(t *testing.T) {
+	t.Parallel()
+
+	callerID := callgraph.FunctionID{Package: "com.acme", Type: "Builder", Name: "withPBKDF2#0"}
+	ifaceID := callgraph.FunctionID{Package: "com.acme", Type: "AbstractHashingFunction", Name: "hash#3"}
+
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			callerID.String(): {
+				ID:        callerID,
+				FilePath:  "Builder.java",
+				StartLine: 1,
+				EndLine:   5,
+				Calls: []callgraph.FunctionCall{
+					{Callee: ifaceID, FilePath: "Builder.java", Line: 3, Raw: "hasher.hash(...)"},
+				},
+			},
+			ifaceID.String(): {ID: ifaceID, FilePath: "AbstractHashingFunction.java", StartLine: 1, EndLine: 4},
+		},
+		Callers: map[string][]string{
+			ifaceID.String(): {callerID.String()},
+		},
+		EdgeResolutions: map[string]callgraph.EdgeResolution{},
+	}
+	res := callgraph.EdgeResolution{
+		Kind:                 callgraph.EdgeKindExact,
+		MethodName:           "hash",
+		Arity:                3,
+		CallSite:             3,
+		ResolvedReceiverType: "PBKDF2Function",
+	}
+	graph.EdgeResolutions[callgraph.EdgeResolutionKey(callerID.String(), ifaceID.String(), res)] = res
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
+
+	edge := findInternalEdge(&payload, callerID.String(), ifaceID.String())
+	if edge == nil {
+		t.Fatalf("internal edge %s -> %s not found in export", callerID.String(), ifaceID.String())
+	}
+	if edge.ResolvedReceiverType != "PBKDF2Function" {
+		t.Fatalf("ResolvedReceiverType = %q, want %q", edge.ResolvedReceiverType, "PBKDF2Function")
+	}
+}
+
+// TestBuildGraphFragmentExport_OmitsResolvedReceiverTypeWhenUnresolved proves
+// the field is empty (and therefore omitted on the wire via omitempty) for the
+// common case: an edge inference did not resolve a concrete receiver for.
+// This is the backward-compatibility contract — a v0.12.0 stitcher parsing a
+// v1.6 fragment sees the SAME shape it always has for these edges.
+func TestBuildGraphFragmentExport_OmitsResolvedReceiverTypeWhenUnresolved(t *testing.T) {
+	t.Parallel()
+
+	callerID := callgraph.FunctionID{Package: "com.acme", Type: "Builder", Name: "with#0"}
+	ifaceID := callgraph.FunctionID{Package: "com.acme", Type: "HashingFunction", Name: "hash#3"}
+
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			callerID.String(): {
+				ID:        callerID,
+				FilePath:  "Builder.java",
+				StartLine: 1,
+				EndLine:   5,
+				Calls: []callgraph.FunctionCall{
+					{Callee: ifaceID, FilePath: "Builder.java", Line: 3, Raw: "hasher.hash(...)"},
+				},
+			},
+			ifaceID.String(): {ID: ifaceID, FilePath: "HashingFunction.java", StartLine: 1, EndLine: 4},
+		},
+		Callers: map[string][]string{
+			ifaceID.String(): {callerID.String()},
+		},
+		EdgeResolutions: map[string]callgraph.EdgeResolution{},
+	}
+	res := callgraph.EdgeResolution{
+		Kind:         callgraph.EdgeKindInterfaceDispatch,
+		DeclaredType: "com.acme.HashingFunction",
+		MethodName:   "hash",
+		Arity:        3,
+		CallSite:     3,
+		// ResolvedReceiverType intentionally left empty: inference did not resolve it.
+	}
+	graph.EdgeResolutions[callgraph.EdgeResolutionKey(callerID.String(), ifaceID.String(), res)] = res
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
+
+	edge := findInternalEdge(&payload, callerID.String(), ifaceID.String())
+	if edge == nil {
+		t.Fatalf("internal edge %s -> %s not found in export", callerID.String(), ifaceID.String())
+	}
+	if edge.ResolvedReceiverType != "" {
+		t.Fatalf("ResolvedReceiverType = %q, want empty for an unresolved dispatch edge", edge.ResolvedReceiverType)
+	}
+}

--- a/internal/scan/fragment_reachability_test.go
+++ b/internal/scan/fragment_reachability_test.go
@@ -75,8 +75,8 @@ func TestBuildGraphFragmentExport13_DerivesSupportingCallsFromObjectLifecycle(t 
 		Ecosystem:  "java",
 	})
 
-	if payload.SchemaVersion != "graph-fragment-1.5" {
-		t.Fatalf("SchemaVersion = %q, want graph-fragment-1.5", payload.SchemaVersion)
+	if payload.SchemaVersion != "graph-fragment-1.6" {
+		t.Fatalf("SchemaVersion = %q, want graph-fragment-1.6", payload.SchemaVersion)
 	}
 
 	// The terminal finding is the only crypto annotation; the lifecycle calls are

--- a/internal/scan/password4j_dispatch_e2e_test.go
+++ b/internal/scan/password4j_dispatch_e2e_test.go
@@ -1,0 +1,154 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scan
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/pkg/graphfrag"
+)
+
+// password4jSourceDir points at a real, unmodified checkout of password4j
+// 1.8.4 (its src/main/java directory), supplied via env var so the test is
+// hermetic and self-skips on machines/CI without the checkout. To run:
+//
+//	curl -sL -o p4j.zip https://codeload.github.com/Password4j/password4j/zip/refs/tags/1.8.4
+//	unzip p4j.zip
+//	CRYPTO_FINDER_PASSWORD4J_SRC=$PWD/password4j-1.8.4/src/main/java \
+//	  go test ./internal/scan/ -run Password4j
+var password4jSourceDir = os.Getenv("CRYPTO_FINDER_PASSWORD4J_SRC")
+
+// TestStitch_RealParse_Password4j_PBKDF2ChainSurvivesDispatchDisambiguation is
+// the decisive E2E acceptance test for the stitch-dispatch-provenance change.
+//
+// password4j's HashBuilder.withPBKDF2() chain
+// (withPBKDF2 -> with -> HashingFunction.hash (interface dispatch, 7 concrete
+// implementors) -> PBKDF2Function.hash -> internalHash) crosses an interface
+// call site the mine-time callgraph builder can only resolve by
+// name+arity-expanding EVERY HashingFunction implementor (BcryptFunction,
+// Argon2Function, PBKDF2Function, ScryptFunction, MessageDigestFunction,
+// CompressedPBKDF2Function, BalloonHashingFunction). Before this change, the
+// serving-path stitcher (StitchWithOptions{EntryRootedOnly: true}, mirroring
+// scanoss.api's usage via pkg/reachability) fails this call site closed
+// (SuppressReasonAmbiguousDispatch) and the PBEKeySpec finding inside
+// internalHash never reaches withPBKDF2 in the served callgraph, even though
+// the finding is real and reachable.
+//
+// This test mines password4j 1.8.4 with the real Java parser/builder (the same
+// path `crypto-finder scan --export-graph-fragment` uses), builds the
+// graph-fragment export exactly as the mining service would, decodes it back
+// (round-tripping through the wire schema so resolved_receiver_type must
+// survive JSON), and stitches the single-component closure. It asserts the
+// PBEKeySpec finding is reached from HashBuilder.withPBKDF2 WITHOUT an
+// ambiguous_dispatch suppression on that path — proof the concrete-receiver
+// provenance disambiguation (pkg/graphfrag ResolvedReceiverType +
+// applyDispatchGroups) does its job end to end, on real mined fragments, not
+// just the hand-authored unit fixtures.
+func TestStitch_RealParse_Password4j_PBKDF2ChainSurvivesDispatchDisambiguation(t *testing.T) {
+	if password4jSourceDir == "" {
+		t.Skip("set CRYPTO_FINDER_PASSWORD4J_SRC to a password4j 1.8.4 src/main/java checkout to run this test")
+	}
+	if _, err := os.Stat(password4jSourceDir); err != nil {
+		t.Skipf("password4j fixture source not available at %s: %v", password4jSourceDir, err)
+	}
+
+	graph, err := callgraph.NewBuilderForEcosystem("java", callgraph.NewJavaParser()).
+		BuildFromDirectories([]callgraph.PackageDir{{Dir: password4jSourceDir, ImportPath: "com.password4j"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories(password4j): %v", err)
+	}
+
+	// Hand-author the PBEKeySpec finding the way a real crypto rule would
+	// report it: PBKDF2Function.internalHash constructs
+	// `new PBEKeySpec(plain, salt, iterations, length)` at line 130.
+	report := &entities.InterimReport{
+		Tool:  entities.ToolInfo{Name: "crypto-finder", Version: "dev"},
+		Rules: entities.RulesInfo{Version: "v-test"},
+		Findings: []entities.Finding{{
+			FilePath: "PBKDF2Function.java",
+			Language: "java",
+			CryptographicAssets: []entities.CryptographicAsset{{
+				StartLine: 130,
+				EndLine:   130,
+				Match:     "new PBEKeySpec(plain, salt, iterations, length)",
+				Rules:     []entities.RuleInfo{{ID: "java.jdk.pbekeyspec.construction"}},
+				Metadata:  map[string]string{"api": "javax.crypto.spec.PBEKeySpec.<init>", "assetType": "algorithm", "algorithmFamily": "PBKDF2"},
+			}},
+		}},
+	}
+	engine.EnsureFindingSources(report)
+	engine.AssignFindingIDs(report)
+
+	export := BuildGraphFragmentExport(&engine.DepScanResult{
+		Report:      report,
+		CallGraph:   graph,
+		ProjectRoot: password4jSourceDir,
+		RootModule:  "com.password4j:password4j",
+		Ecosystem:   "java",
+	})
+
+	// Round-trip through the wire schema (JSON) exactly like a real mine ->
+	// storage -> stitch cycle, so resolved_receiver_type must survive
+	// marshal/unmarshal, not just live in memory.
+	raw, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal graph fragment export: %v", err)
+	}
+	if !strings.Contains(string(raw), `"resolved_receiver_type"`) {
+		t.Fatalf("exported fragment JSON has no resolved_receiver_type field — export-time stamping did not fire")
+	}
+
+	component := graphfrag.ComponentKey{Purl: "pkg:maven/com.password4j/password4j", Version: "1.8.4"}
+	frag, err := graphfrag.DecodeFragment(component, raw)
+	if err != nil {
+		t.Fatalf("DecodeFragment(password4j): %v", err)
+	}
+
+	fragments := map[graphfrag.ComponentKey]graphfrag.Fragment{component: frag}
+	deps := graphfrag.DependencyGraph{component: nil}
+
+	res, err := graphfrag.StitchWithOptions(component, deps, fragments, graphfrag.StitchOptions{EntryRootedOnly: true})
+	if err != nil {
+		t.Fatalf("StitchWithOptions: %v", err)
+	}
+
+	assertPBKDF2ChainReachesFinding(t, res)
+}
+
+// assertPBKDF2ChainReachesFinding asserts at least one chain for the
+// PBEKeySpec finding has a frame rooted at (or passing through)
+// HashBuilder.withPBKDF2, proving the served callgraph threads the
+// interface-dispatch call site through to the finding.
+func assertPBKDF2ChainReachesFinding(t *testing.T, res *graphfrag.Result) {
+	t.Helper()
+	matched := make([]graphfrag.FindingChain, 0, len(res.Chains))
+	for _, ch := range res.Chains {
+		if ch.RuleID != "java.jdk.pbekeyspec.construction" {
+			continue
+		}
+		matched = append(matched, ch)
+	}
+	if len(matched) == 0 {
+		t.Fatalf("no chain found for java.jdk.pbekeyspec.construction; chains=%+v suppressed=%+v", res.Chains, res.Suppressed)
+	}
+
+	var hasWithPBKDF2Root bool
+	for i := range matched {
+		frames := matched[i].Frames
+		for j := range frames {
+			if strings.Contains(frames[j].Signature, "HashBuilder") && strings.Contains(frames[j].Signature, "withPBKDF2") {
+				hasWithPBKDF2Root = true
+			}
+		}
+	}
+	if !hasWithPBKDF2Root {
+		t.Fatalf("PBEKeySpec chain(s) found but none pass through HashBuilder.withPBKDF2: %+v", matched)
+	}
+}

--- a/pkg/graphfrag/encode.go
+++ b/pkg/graphfrag/encode.go
@@ -63,6 +63,8 @@ func EncodeFragment(frag Fragment) ([]byte, error) {
 			StartCol:     e.StartCol,
 			EndCol:       e.EndCol,
 			EntryCall:    fromCallSite(e.EntryCall),
+
+			ResolvedReceiverType: e.ResolvedReceiverType,
 		})
 	}
 	for i := range frag.ExternalCalls {
@@ -82,6 +84,8 @@ func EncodeFragment(frag Fragment) ([]byte, error) {
 			StartCol:     e.StartCol,
 			EndCol:       e.EndCol,
 			EntryCall:    fromCallSite(e.EntryCall),
+
+			ResolvedReceiverType: e.ResolvedReceiverType,
 		})
 	}
 

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -21,7 +21,15 @@ import "encoding/json"
 // 1.3 adds customer-facing reachability projections: crypto_entry_points,
 // supporting_calls, and display aliases for constructor symbols. Canonical
 // function keys still use the internal <init> identity for joins.
-const SchemaVersion = "graph-fragment-1.5"
+//
+// 1.6 adds resolved_receiver_type on internal_edges/external_calls: the
+// concrete receiver type the producer's KB-contract/return-type inference
+// resolved for an interface-dispatch call site, when available. The stitcher
+// uses it to disambiguate a dispatch group that has more than one candidate
+// target in closure, without changing the fail-closed default for call sites
+// inference did not resolve. Additive: a 1.5 fragment decodes with an empty
+// resolved_receiver_type, which the stitcher treats exactly as before.
+const SchemaVersion = "graph-fragment-1.6"
 
 // GraphAlgoVersion identifies the callgraph-CONSTRUCTION algorithm version. It
 // is independent of the binary version (cf_version) and the wire schema
@@ -204,6 +212,10 @@ type GraphFragmentEdge struct {
 	// EntryCall carries the call-site argument data-flow for this edge (1.2+).
 	// Nil on fragments exported with schema < 1.2.
 	EntryCall *GraphFragmentCallSite `json:"entry_call,omitempty"`
+	// ResolvedReceiverType is the concrete receiver type resolved by KB-contract
+	// or return-type inference for this call site (1.6+). Empty when inference
+	// did not resolve a concrete type, or on fragments exported with schema < 1.6.
+	ResolvedReceiverType string `json:"resolved_receiver_type,omitempty"`
 }
 
 // GraphFragmentExternal is one external (cross-component) call edge plus its
@@ -231,6 +243,10 @@ type GraphFragmentExternal struct {
 	// EntryCall carries the call-site argument data-flow for this edge (1.2+).
 	// Nil on fragments exported with schema < 1.2.
 	EntryCall *GraphFragmentCallSite `json:"entry_call,omitempty"`
+	// ResolvedReceiverType is the concrete receiver type resolved by KB-contract
+	// or return-type inference for this call site (1.6+). Empty when inference
+	// did not resolve a concrete type, or on fragments exported with schema < 1.6.
+	ResolvedReceiverType string `json:"resolved_receiver_type,omitempty"`
 }
 
 // GraphFragmentCryptoOp is one crypto finding annotation attached to a function

--- a/pkg/graphfrag/export_test.go
+++ b/pkg/graphfrag/export_test.go
@@ -187,12 +187,13 @@ func TestGraphFragmentCryptoOp_JSONRoundTrip(t *testing.T) {
 	}
 }
 
-// TestSchemaVersion_Is_1_5 verifies the schema version constant has been bumped.
-// 1.5 adds finding-anchored supporting_call_ids on crypto_annotations (the
-// precise finding->supporting foreign key) — additive over 1.4.
-func TestSchemaVersion_Is_1_5(t *testing.T) {
+// TestSchemaVersion_Is_1_6 verifies the schema version constant has been bumped.
+// 1.6 adds resolved_receiver_type on internal_edges/external_calls (the
+// concrete receiver type the producer's KB-contract/return-type inference
+// resolved for an interface-dispatch call site) — additive over 1.5.
+func TestSchemaVersion_Is_1_6(t *testing.T) {
 	t.Parallel()
-	if SchemaVersion != "graph-fragment-1.5" {
-		t.Errorf("SchemaVersion = %q, want graph-fragment-1.5", SchemaVersion)
+	if SchemaVersion != "graph-fragment-1.6" {
+		t.Errorf("SchemaVersion = %q, want graph-fragment-1.6", SchemaVersion)
 	}
 }

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -56,6 +56,8 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			StartCol:     ie.StartCol,
 			EndCol:       ie.EndCol,
 			EntryCall:    toCallSite(ie.EntryCall),
+
+			ResolvedReceiverType: ie.ResolvedReceiverType,
 		}
 		frag.InternalEdges = append(frag.InternalEdges, edge)
 	}
@@ -76,6 +78,8 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			StartCol:        ec.StartCol,
 			EndCol:          ec.EndCol,
 			EntryCall:       toCallSite(ec.EntryCall),
+
+			ResolvedReceiverType: ec.ResolvedReceiverType,
 		})
 	}
 	for i := range e.CryptoAnnotations {

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -239,6 +239,25 @@ type InternalEdge struct {
 	// EntryCall carries the call-site argument data-flow for this edge (1.2+).
 	// Nil on fragments exported with schema < 1.2.
 	EntryCall *CallSite
+
+	// ResolvedReceiverType is the concrete receiver type the producer's
+	// KB-contract/return-type inference resolved for THIS call site's receiver,
+	// when available (1.6+). It is populated on ResolutionInterfaceDispatch edges
+	// where inference narrowed the otherwise-interface-typed receiver to one
+	// concrete implementation type (e.g. "PBKDF2Function"), and on synthesized
+	// exact bypass edges the producer added specifically because it resolved such
+	// a receiver (see internal/callgraph resolveParameterPassthroughDispatch).
+	// Empty when inference did not resolve a concrete type, or on fragments
+	// exported with schema < 1.6 — the stitcher then falls back to the existing
+	// count-of-candidates ambiguity check.
+	//
+	// The stitcher uses this to disambiguate a dispatch group that has more than
+	// one candidate target in closure: if exactly one candidate's owner type
+	// matches ResolvedReceiverType, that edge survives and the rest are dropped
+	// (SuppressReasonAmbiguousDispatch is NOT recorded). This is a narrow,
+	// evidence-based disambiguation — it never changes the fail-closed default
+	// for call sites inference could not resolve.
+	ResolvedReceiverType string
 }
 
 // ResolutionKind classifies how confidently the producer resolved a call to its
@@ -324,6 +343,11 @@ type ExternalCall struct {
 	// EntryCall carries the call-site argument data-flow for this edge (1.2+).
 	// Nil on fragments exported with schema < 1.2.
 	EntryCall *CallSite
+
+	// ResolvedReceiverType is the concrete receiver type the producer's
+	// KB-contract/return-type inference resolved for THIS call site's receiver
+	// (1.6+). See InternalEdge.ResolvedReceiverType for the full contract.
+	ResolvedReceiverType string
 }
 
 // CryptoOperation is a crypto finding attached to a function.

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -3,7 +3,10 @@
 
 package graphfrag
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // StitchOptions tunes which root-fragment functions a stitch traces from. The
 // zero value reproduces the historical Stitch behavior (trace from every
@@ -261,14 +264,15 @@ type dispatchGroupKey struct {
 // call site whose implementations straddle the component boundary must be judged
 // as one group, not two.
 type callEdge struct {
-	caller     string
-	target     string
-	resolution ResolutionKind
-	method     string
-	arity      int
-	callSite   int
-	internal   bool
-	entryCall  *CallSite
+	caller               string
+	target               string
+	resolution           ResolutionKind
+	method               string
+	arity                int
+	callSite             int
+	internal             bool
+	entryCall            *CallSite
+	resolvedReceiverType string
 }
 
 // buildAdjacency composes the traversable call graph from the fragment closure
@@ -291,6 +295,7 @@ func buildAdjacency(
 ) (map[graphNode][]adjacencyEdge, []SuppressedEdge) {
 	out := make(map[graphNode][]adjacencyEdge)
 	var suppressed []SuppressedEdge
+	ownerTypes := indexOwnerTypes(closure, fragments)
 
 	for _, key := range closure {
 		fragment := fragments[key]
@@ -299,9 +304,42 @@ func buildAdjacency(
 		resolve := callEdgeResolver(key, componentSigs, componentSet(deps[key]), functionsBySignature)
 
 		dispatchGroups := applyImmediateEdgePolicy(key, edges, resolve, out, &suppressed)
-		applyDispatchGroups(key, dispatchGroups, resolve, out, &suppressed)
+		applyDispatchGroups(key, dispatchGroups, resolve, ownerTypes, out, &suppressed)
 	}
 	return out, suppressed
+}
+
+// indexOwnerTypes maps each node to the declaring type of its function, derived
+// from Function.FunctionName (the fully-qualified, dotted, customer-facing name
+// e.g. "com.password4j.PBKDF2Function.hash" -> "com.password4j.PBKDF2Function").
+// This is ecosystem-agnostic: every producer populates FunctionName in this
+// "<owner>.<method>" shape (see ConstructorDisplayFromSymbol for the same
+// convention used elsewhere in this package). Used only to disambiguate an
+// otherwise-ambiguous interface-dispatch group against a resolved receiver type
+// (see applyDispatchGroups); absent or malformed names simply never match.
+func indexOwnerTypes(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[graphNode]string {
+	out := make(map[graphNode]string)
+	for _, key := range closure {
+		fragment := fragments[key]
+		for i := range fragment.Functions {
+			fn := &fragment.Functions[i]
+			if owner := ownerTypeFromFunctionName(fn.FunctionName); owner != "" {
+				out[graphNode{Component: key, Function: fn.Signature}] = owner
+			}
+		}
+	}
+	return out
+}
+
+// ownerTypeFromFunctionName strips the trailing ".<method>" segment from a
+// fully-qualified function name, returning the declaring type. Returns "" when
+// name has no dot (no owner to derive).
+func ownerTypeFromFunctionName(name string) string {
+	dot := strings.LastIndex(name, ".")
+	if dot <= 0 {
+		return ""
+	}
+	return name[:dot]
 }
 
 func componentSet(closure []ComponentKey) map[ComponentKey]bool {
@@ -331,6 +369,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 		edges = append(edges, callEdge{
 			caller: e.Caller, target: e.Callee, resolution: e.Resolution,
 			method: e.MethodName, arity: e.Arity, callSite: e.CallSite, internal: true, entryCall: e.EntryCall,
+			resolvedReceiverType: e.ResolvedReceiverType,
 		})
 	}
 	for i := range fragment.ExternalCalls {
@@ -338,6 +377,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 		edges = append(edges, callEdge{
 			caller: c.Caller, target: c.TargetSignature, resolution: c.Resolution,
 			method: c.MethodName, arity: c.Arity, callSite: c.CallSite, internal: false, entryCall: c.EntryCall,
+			resolvedReceiverType: c.ResolvedReceiverType,
 		})
 	}
 	return edges
@@ -424,21 +464,90 @@ func applyDispatchGroups(
 	key ComponentKey,
 	groups map[dispatchGroupKey][]callEdge,
 	resolve edgeResolver,
+	ownerTypes map[graphNode]string,
 	adjacency map[graphNode][]adjacencyEdge,
 	suppressed *[]SuppressedEdge,
 ) {
 	for _, gk := range sortedDispatchKeys(groups) {
-		targets := distinctTargetEdges(groups[gk], resolve)
+		group := groups[gk]
+		targets := distinctTargetEdges(group, resolve)
 		caller := graphNode{Component: key, Function: gk.Caller}
 		switch {
 		case len(targets) == 1:
 			adjacency[caller] = append(adjacency[caller], targets[0])
 		case len(targets) > 1:
+			if resolved, ok := disambiguateByReceiverType(group, targets, ownerTypes); ok {
+				adjacency[caller] = append(adjacency[caller], resolved)
+				continue
+			}
 			*suppressed = append(*suppressed, ambiguousDispatchEdge(key, gk, candidateComponentsFromEdges(targets)))
 			// len(targets) == 0: no implementation in closure -> unreachable,
 			// nothing to traverse and nothing to record.
 		}
 	}
+}
+
+// disambiguateByReceiverType narrows an ambiguous dispatch group (>1 candidate
+// target) to a single edge when the call site carries resolved receiver-type
+// provenance (see InternalEdge.ResolvedReceiverType) that matches EXACTLY ONE
+// candidate's declaring type. This is the mine-time KB-contract/return-type
+// inference paying off at stitch time: an interface call site the producer
+// could not resolve structurally (name+arity expansion still finds every
+// sibling implementation) is disambiguated using the concrete type inference
+// already determined for that specific receiver.
+//
+// The match is by SIMPLE (unqualified) type name: ownerTypes indexes the full
+// "<package>.<Type>" (from Function.FunctionName), while ResolvedReceiverType
+// is typically the erased/simple name the producer's inference works with
+// (e.g. FunctionDecl.ReturnType) — mirroring the same simple-name convention
+// resolveParameterPassthroughDispatch already uses on the mine side.
+//
+// Returns ok=false — leaving the group to fail closed exactly as before — when:
+//   - no candidate edge carries receiver-type provenance, or
+//   - the resolved type matches zero candidates (stale/foreign type), or
+//   - the resolved type matches more than one candidate (should not happen for
+//     a well-formed KB, but never assumed).
+//
+// This never changes the fail-closed default for a call site inference did not
+// resolve: it only ever narrows an already-ambiguous group to at most one
+// survivor, never invents a candidate that resolve() did not already produce.
+func disambiguateByReceiverType(group []callEdge, targets []adjacencyEdge, ownerTypes map[graphNode]string) (adjacencyEdge, bool) {
+	resolvedType := simpleTypeName(firstResolvedReceiverType(group))
+	if resolvedType == "" {
+		return adjacencyEdge{}, false
+	}
+
+	var match adjacencyEdge
+	matches := 0
+	for _, t := range targets {
+		if simpleTypeName(ownerTypes[t.target]) == resolvedType {
+			match = t
+			matches++
+		}
+	}
+	if matches != 1 {
+		return adjacencyEdge{}, false
+	}
+	return match, true
+}
+
+// simpleTypeName returns the trailing, unqualified segment of a (possibly
+// fully-qualified) type name, e.g. "com.password4j.PBKDF2Function" ->
+// "PBKDF2Function". A name with no dot is returned unchanged.
+func simpleTypeName(typeName string) string {
+	if idx := strings.LastIndex(typeName, "."); idx >= 0 {
+		return typeName[idx+1:]
+	}
+	return typeName
+}
+
+func firstResolvedReceiverType(group []callEdge) string {
+	for _, e := range group {
+		if e.resolvedReceiverType != "" {
+			return e.resolvedReceiverType
+		}
+	}
+	return ""
 }
 
 func appendAdjacencyEdges(

--- a/pkg/graphfrag/stitch_receiver_provenance_test.go
+++ b/pkg/graphfrag/stitch_receiver_provenance_test.go
@@ -1,0 +1,204 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestStitch_AmbiguousDispatchWithProvenanceResolvesToMatch proves the core
+// disambiguation contract: a dispatch group with more than one candidate
+// target in closure, where the call site carries ResolvedReceiverType
+// provenance matching EXACTLY ONE candidate's declaring type, keeps that one
+// edge and drops the rest — WITHOUT recording SuppressReasonAmbiguousDispatch.
+// This is the mine-time KB-contract/return-type inference (see
+// internal/callgraph.resolveParameterPassthroughDispatch) paying off at
+// stitch time.
+func TestStitch_AmbiguousDispatchWithProvenanceResolvesToMatch(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:               "com.acme.app.AppEntry.entry(): void",
+					TargetSignature:      "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:           ResolutionInterfaceDispatch,
+					DeclaredType:         "net.crypto.Sink",
+					MethodName:           "encrypt",
+					Arity:                0,
+					CallSite:             10,
+					ResolvedReceiverType: "CryptoSink",
+				},
+				{
+					Caller:               "com.acme.app.AppEntry.entry(): void",
+					TargetSignature:      "net.crypto.BenignSink.encrypt(): void",
+					Resolution:           ResolutionInterfaceDispatch,
+					DeclaredType:         "net.crypto.Sink",
+					MethodName:           "encrypt",
+					Arity:                0,
+					CallSite:             10,
+					ResolvedReceiverType: "CryptoSink",
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void", FunctionName: "net.crypto.CryptoSink.encrypt"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "resolved-by-provenance"},
+			},
+		},
+		componentE: {
+			Component: componentE,
+			Functions: []Function{
+				{Signature: "net.crypto.BenignSink.encrypt(): void", FunctionName: "net.crypto.BenignSink.encrypt"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC, componentE}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 {
+		t.Fatalf("chains len = %d, want 1 (provenance must disambiguate): %#v", len(res.Chains), res.Chains)
+	}
+	if res.Chains[0].FindingID != "resolved-by-provenance" {
+		t.Fatalf("FindingID = %q, want resolved-by-provenance", res.Chains[0].FindingID)
+	}
+	if len(res.Suppressed) != 0 {
+		t.Fatalf("suppressed = %#v, want none — a resolved-by-provenance group must not be recorded as ambiguous", res.Suppressed)
+	}
+}
+
+// TestStitch_AmbiguousDispatchWithoutProvenanceStillFailsClosed is the
+// regression guard: a dispatch group with no ResolvedReceiverType on any
+// sibling behaves EXACTLY as before this change — fail closed, suppressed,
+// zero chains. Proves the disambiguation is strictly additive and never
+// changes the default policy for call sites inference did not resolve.
+func TestStitch_AmbiguousDispatchWithoutProvenanceStillFailsClosed(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+					// ResolvedReceiverType intentionally left empty.
+				},
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.BenignSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void", FunctionName: "net.crypto.CryptoSink.encrypt"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "should-not-appear"},
+			},
+		},
+		componentE: {
+			Component: componentE,
+			Functions: []Function{
+				{Signature: "net.crypto.BenignSink.encrypt(): void", FunctionName: "net.crypto.BenignSink.encrypt"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC, componentE}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (no provenance -> fail closed, regression): %#v", len(res.Chains), res.Chains)
+	}
+	if len(res.Suppressed) != 1 || res.Suppressed[0].Reason != SuppressReasonAmbiguousDispatch {
+		t.Fatalf("suppressed = %#v, want one ambiguous-dispatch entry", res.Suppressed)
+	}
+}
+
+// TestStitch_AmbiguousDispatchWithProvenanceMatchingNothingFailsClosed proves
+// a resolved receiver type that matches NEITHER candidate (stale/foreign type,
+// e.g. a producer bug or a type outside this dispatch group's candidate set)
+// is treated exactly like no provenance at all — fail closed, never a guess.
+func TestStitch_AmbiguousDispatchWithProvenanceMatchingNothingFailsClosed(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{
+				{Signature: "com.acme.app.AppEntry.entry(): void"},
+			},
+			ExternalCalls: []ExternalCall{
+				{
+					Caller:               "com.acme.app.AppEntry.entry(): void",
+					TargetSignature:      "net.crypto.CryptoSink.encrypt(): void",
+					Resolution:           ResolutionInterfaceDispatch,
+					DeclaredType:         "net.crypto.Sink",
+					MethodName:           "encrypt",
+					Arity:                0,
+					CallSite:             10,
+					ResolvedReceiverType: "SomeUnrelatedType",
+				},
+				{
+					Caller:          "com.acme.app.AppEntry.entry(): void",
+					TargetSignature: "net.crypto.BenignSink.encrypt(): void",
+					Resolution:      ResolutionInterfaceDispatch,
+					DeclaredType:    "net.crypto.Sink",
+					MethodName:      "encrypt",
+					Arity:           0,
+					CallSite:        10,
+				},
+			},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{
+				{Signature: "net.crypto.CryptoSink.encrypt(): void", FunctionName: "net.crypto.CryptoSink.encrypt"},
+			},
+			CryptoOperations: []CryptoOperation{
+				{Function: "net.crypto.CryptoSink.encrypt(): void", FindingID: "should-not-appear"},
+			},
+		},
+		componentE: {
+			Component: componentE,
+			Functions: []Function{
+				{Signature: "net.crypto.BenignSink.encrypt(): void", FunctionName: "net.crypto.BenignSink.encrypt"},
+			},
+		},
+	}
+	deps := DependencyGraph{componentA: {componentC, componentE}}
+
+	res, err := Stitch(componentA, deps, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Fatalf("chains len = %d, want 0 (provenance matching nothing -> fail closed): %#v", len(res.Chains), res.Chains)
+	}
+	if len(res.Suppressed) != 1 || res.Suppressed[0].Reason != SuppressReasonAmbiguousDispatch {
+		t.Fatalf("suppressed = %#v, want one ambiguous-dispatch entry", res.Suppressed)
+	}
+}


### PR DESCRIPTION
## Summary

Final piece of the IBM password4j "shallow call chain" fix. PR #57 made the miner produce the dispatch edges, but the **serving-path stitcher** (`StitchWithOptions{EntryRootedOnly: true}`, used by scanoss.api's `/dep-tree`) fail-closed suppresses any dispatch group with >1 candidate — password4j's 7 `HashingFunction` implementors meant the `withPBKDF2` chain never survived stitching (verified empirically before this change: `withPBKDF2_chain_depth5_survived: false`).

Two work-unit commits:

**1. `feat(callgraph)` — parameter pass-through dispatch resolution.** A shared call site like `HashBuilder.with(HashingFunction)` is legitimately ambiguous (7 callers pass 7 concrete types), so per-caller **bypass edges** are synthesized carrying the resolved concrete receiver (constructor / declared return / KB-contract inference), walking `OwnerBases` to bridge inherited-but-not-overridden methods, to a fixpoint. Shared ambiguous edges are never mutated.

**2. `feat(graphfrag)` — provenance-aware stitching.** Fragment schema `graph-fragment-1.5 → 1.6`: optional `resolved_receiver_type` on internal edges / external calls (additive `omitempty`, same convention as the 1.4→1.5 bump; old stitchers parse new fragments unaffected). `applyDispatchGroups` keeps a group's edge when provenance matches exactly one candidate; **everything else fails closed exactly as before** — this is scoped disambiguation, not a policy change.

## Evidence

E2E test mines real password4j 1.8.4 (parser → builder → fragment export → JSON round-trip → decode → stitch mirroring scanoss.api usage) and asserts the PBEKeySpec finding is reached from `HashBuilder.withPBKDF2` with no ambiguous-dispatch suppression on the path. Gated on `CRYPTO_FINDER_PASSWORD4J_SRC` (self-skips in CI).

Known trade-off: bypass edges skip the intermediate ambiguous frames, so the served chain is `withPBKDF2 → PBKDF2Function.hash → internalHash` (3 frames) rather than replaying `with`/`AbstractHashingFunction.hash` — the entry→terminal linkage and crypto metadata are complete; full context-sensitive frame reconstruction would be a separate feature.

## Validation

- Unit tests at all three layers (stitch disambiguation + fail-closed regressions, builder pass-through resolution, export field round-trip).
- `go test ./...` green (pre-existing Docker-dependent postgres suites excepted, same as main). Lint clean on touched packages. CodeRabbit review: 0 findings.

## Rollout

Needs: tag v0.13.3 + release → bump CMS (image + go.mod, mining side) and scanoss.api (go.mod v0.12.0 →, stitching side) → re-mine password4j so fragments carry provenance.