### PR TITLE
perf: fix mining-path hotspots exposed by dispatch fan-out on large libraries

### DIFF
--- a/internal/callgraph/bcprov_profile_test.go
+++ b/internal/callgraph/bcprov_profile_test.go
@@ -1,0 +1,162 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+
+package callgraph
+
+// bcprov_profile_test.go — a one-off profiling harness for the
+// perf/mdaloia/dispatch-expansion-hotpath investigation. Not a regression
+// test: gated on CRYPTO_FINDER_BCPROV_SRC so it never runs in CI. Point it at
+// an unpacked bcprov-jdk15on source tree and run with -cpuprofile to find the
+// hotspot in the dispatch-expansion machinery added by PR #57/#58.
+//
+// Example:
+//
+//	CRYPTO_FINDER_BCPROV_SRC=/path/to/bcprov/src go test \
+//	  -run TestProfileBcprov -cpuprofile cpu.out -timeout 15m ./internal/callgraph/
+//	go tool pprof -top -nodecount=20 cpu.out
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func bcprovSourceDir(t testing.TB) string {
+	t.Helper()
+	dir := os.Getenv("CRYPTO_FINDER_BCPROV_SRC")
+	if dir == "" {
+		t.Skip("set CRYPTO_FINDER_BCPROV_SRC to an unpacked bcprov-jdk15on src dir to run this profiling harness")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("bcprov fixture source not available at %s: %v", dir, err)
+	}
+	return dir
+}
+
+func password4jSourceDirForEquivalence(t testing.TB) string {
+	t.Helper()
+	dir := os.Getenv("CRYPTO_FINDER_PASSWORD4J_SRC")
+	if dir == "" {
+		t.Skip("set CRYPTO_FINDER_PASSWORD4J_SRC to a password4j src/main/java checkout to run this equivalence check")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("password4j fixture source not available at %s: %v", dir, err)
+	}
+	return dir
+}
+
+// TestProfileBcprov builds the call graph over the full bcprov source tree
+// once. Run under `go test -cpuprofile` to capture a CPU profile of the
+// build pipeline (parse + buildCallerIndex dispatch expansion +
+// resolveParameterPassthroughDispatch + inference).
+func TestProfileBcprov(t *testing.T) {
+	dir := bcprovSourceDir(t)
+
+	builder := NewBuilder(NewJavaParser())
+	graph, err := builder.BuildFromDirectories([]PackageDir{{Dir: dir, ImportPath: "org.bouncycastle"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories(bcprov): %v", err)
+	}
+
+	t.Logf("functions=%d callers=%d edgeResolutions=%d", len(graph.Functions), len(graph.Callers), len(graph.EdgeResolutions))
+}
+
+// canonicalGraphDump renders graph.Callers and graph.EdgeResolutions as a
+// fully sorted, deterministic text dump so two builds (e.g. before/after an
+// algorithmic change to the dispatch-expansion passes) can be compared byte
+// for byte. Any difference here means the change altered observable output,
+// not just performance.
+func canonicalGraphDump(graph *CallGraph) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "functions=%d\n", len(graph.Functions))
+
+	calleeKeys := make([]string, 0, len(graph.Callers))
+	for k := range graph.Callers {
+		calleeKeys = append(calleeKeys, k)
+	}
+	sort.Strings(calleeKeys)
+	fmt.Fprintf(&b, "callers_entries=%d\n", len(calleeKeys))
+	for _, calleeKey := range calleeKeys {
+		callers := append([]string(nil), graph.Callers[calleeKey]...)
+		sort.Strings(callers)
+		fmt.Fprintf(&b, "CALLERS %s <- %s\n", calleeKey, strings.Join(callers, ","))
+	}
+
+	edgeKeys := make([]string, 0, len(graph.EdgeResolutions))
+	for k := range graph.EdgeResolutions {
+		edgeKeys = append(edgeKeys, k)
+	}
+	sort.Strings(edgeKeys)
+	fmt.Fprintf(&b, "edge_resolutions=%d\n", len(edgeKeys))
+	for _, k := range edgeKeys {
+		res := graph.EdgeResolutions[k]
+		fmt.Fprintf(&b, "EDGE %s kind=%s declaredType=%s method=%s arity=%d callSite=%d resolvedReceiverType=%s\n",
+			k, res.Kind, res.DeclaredType, res.MethodName, res.Arity, res.CallSite, res.ResolvedReceiverType)
+	}
+
+	return b.String()
+}
+
+// dumpGraphEquivalence builds the call graph for dir and writes a canonical
+// sorted dump plus its sha256 to outPath, then logs the hash and top-level
+// counts. Used to diff builder.go's output before vs after an algorithmic
+// change — see perf/mdaloia/dispatch-expansion-hotpath.
+func dumpGraphEquivalence(t *testing.T, dir, importPath, outPath string) {
+	t.Helper()
+
+	builder := NewBuilder(NewJavaParser())
+	graph, err := builder.BuildFromDirectories([]PackageDir{{Dir: dir, ImportPath: importPath}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories(%s): %v", importPath, err)
+	}
+
+	dump := canonicalGraphDump(graph)
+	sum := sha256.Sum256([]byte(dump))
+	hash := hex.EncodeToString(sum[:])
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(outPath), err)
+	}
+	if err := os.WriteFile(outPath, []byte(dump), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", outPath, err)
+	}
+
+	t.Logf("functions=%d callers=%d edgeResolutions=%d sha256=%s dump=%s",
+		len(graph.Functions), len(graph.Callers), len(graph.EdgeResolutions), hash, outPath)
+}
+
+// TestEquivalenceDumpBcprov writes a canonical sorted dump of the bcprov call
+// graph's Callers/EdgeResolutions to CRYPTO_FINDER_EQUIV_OUT (or a default
+// scratch path) so it can be diffed against a dump taken on the other side of
+// an algorithmic change. Gated on CRYPTO_FINDER_BCPROV_SRC; not a CI test.
+func TestEquivalenceDumpBcprov(t *testing.T) {
+	dir := bcprovSourceDir(t)
+	out := os.Getenv("CRYPTO_FINDER_EQUIV_OUT")
+	if out == "" {
+		out = filepath.Join(os.TempDir(), "bcprov_equivalence_dump.txt")
+	}
+	dumpGraphEquivalence(t, dir, "org.bouncycastle", out)
+}
+
+// TestEquivalenceDumpPassword4j is TestEquivalenceDumpBcprov's counterpart
+// for the password4j fixture used by TestStitch_RealParse_Password4j in
+// internal/scan, giving a second, structurally different corpus for the
+// same before/after equivalence check.
+func TestEquivalenceDumpPassword4j(t *testing.T) {
+	dir := password4jSourceDirForEquivalence(t)
+	out := os.Getenv("CRYPTO_FINDER_EQUIV_OUT")
+	if out == "" {
+		out = filepath.Join(os.TempDir(), "password4j_equivalence_dump.txt")
+	}
+	dumpGraphEquivalence(t, dir, "com.password4j", out)
+}

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -1071,13 +1071,45 @@ const passthroughMaxIterations = 10
 // PBKDF2Function context) can unlock the NEXT hop inside that same target's
 // body (hash#3's own "this.hash(...)" self-call, which the first pass alone
 // cannot see since it has no explicit receiver argument to resolve).
-func resolveParameterPassthroughDispatch(graph *CallGraph) {
+func resolveParameterPassthroughDispatch(graph *CallGraph) int {
+	// receiverIdx mirrors every ResolvedReceiverType stamped onto
+	// graph.EdgeResolutions, keyed by "callerKey\x00calleeKey" so
+	// resolvePassthroughForThisReceiver can look up an already-resolved bypass
+	// edge in O(1) instead of linearly scanning the (potentially huge, after
+	// dispatch fan-out) EdgeResolutions map on every call — see
+	// lookupResolvedReceiverType's doc comment for the full contract this
+	// index mirrors. Built once and kept in sync by stampResolvedReceiverType
+	// for the lifetime of this pass (including across fixpoint iterations,
+	// since a later group can depend on an edge a same-iteration earlier group
+	// just stamped).
+	receiverIdx := newResolvedReceiverIndex(graph)
+
+	// The ambiguous-group membership (groupAmbiguousDispatchEdges) and each
+	// group's qualification (passthroughParameterIndex, candidateOwners) are
+	// invariant across fixpoint iterations: this pass only ever adds
+	// EdgeKindExact bypass edges targeting a CONCRETE candidate — never an
+	// EdgeKindInterfaceDispatch edge — so groupAmbiguousDispatchEdges's
+	// filtered set never changes. Computing that (and each group's
+	// qualification) once instead of on every iteration turns what used to be
+	// up to passthroughMaxIterations full rescans of graph.EdgeResolutions
+	// (millions of entries on large graphs such as bcprov) into a single
+	// rescan.
+	//
+	// graph.Callers[gk.Caller] is NOT invariant, though: gk.Caller can itself
+	// be a bypass TARGET for a different group (a multi-hop chain — e.g.
+	// password4j's HashBuilder.withBcrypt() -> BcryptFunction.hash, where
+	// BcryptFunction.hash's own inherited AbstractHashingFunction.hash body
+	// is a second, deeper ambiguous group). Resolving that outer group adds
+	// gk.Caller as a NEW caller of the inner group via addCaller, so the
+	// caller list must be re-read from graph.Callers every iteration — see
+	// resolveQualifiedPassthroughGroup.
+	qualified := qualifyPassthroughGroups(graph)
+
 	totalResolved := 0
 	for iter := 0; iter < passthroughMaxIterations; iter++ {
-		groups := groupAmbiguousDispatchEdges(graph)
 		resolved := 0
-		for _, gk := range sortedAmbiguousGroupKeys(groups) {
-			resolved += resolvePassthroughGroup(graph, gk, groups[gk])
+		for i := range qualified {
+			resolved += resolveQualifiedPassthroughGroup(graph, &qualified[i], receiverIdx)
 		}
 		totalResolved += resolved
 		if resolved == 0 {
@@ -1087,6 +1119,88 @@ func resolveParameterPassthroughDispatch(graph *CallGraph) {
 	if totalResolved > 0 {
 		log.Info().Int("resolved", totalResolved).Msg("Resolved parameter pass-through interface dispatch")
 	}
+	return totalResolved
+}
+
+// qualifiedPassthroughGroup caches one ambiguous dispatch group's
+// iteration-invariant qualification (see resolveParameterPassthroughDispatch's
+// doc comment): everything passthroughParameterIndex and
+// resolveOverloadPerOwner/candidateOwnersByType compute from gk and entries
+// alone, plus the group's outer caller list, none of which changes across
+// fixpoint iterations.
+type qualifiedPassthroughGroup struct {
+	gk              dispatchAmbiguousGroupKey
+	calleeFn        *FunctionDecl
+	paramIdx        int
+	candidateOwners map[string]string
+}
+
+// qualifyPassthroughGroups computes groupAmbiguousDispatchEdges once and
+// resolves each group's iteration-invariant qualification up front, so the
+// fixpoint loop in resolveParameterPassthroughDispatch only repeats the part
+// that can actually change between iterations: per-caller resolution.
+//
+// Qualification for one group (gk.Caller is the function whose body issues
+// the ambiguous call — the "pass-through candidate"; conservative by design —
+// every condition narrows toward "do nothing" on doubt, matching the
+// fail-closed default), delegated to passthroughParameterIndex:
+//  1. The ambiguous call site must be uniquely identifiable in gk.Caller's
+//     body by (line, method, arity) — see findCallAtSite.
+//  2. Its receiver is either (a) one of gk.Caller's OWN parameters
+//     (positionally matched via FunctionParameter.Name) — a pass-through of an
+//     argument — in which case gk.Caller must have EXACTLY ONE call in its
+//     body (a parameter could otherwise be reassigned or escape into a branch
+//     this pass cannot see); or (b) gk.Caller's own implicit "this" — in which
+//     case a multi-call, branching body is tolerated (this's type is fixed for
+//     the whole method regardless of branch).
+//  3. Each entry in the group names a distinct candidate; each candidate's
+//     owner type is derived from its FunctionID.Type (simple name).
+func qualifyPassthroughGroups(graph *CallGraph) []qualifiedPassthroughGroup {
+	groups := groupAmbiguousDispatchEdges(graph)
+	keys := sortedAmbiguousGroupKeys(groups)
+	qualified := make([]qualifiedPassthroughGroup, 0, len(keys))
+	for _, gk := range keys {
+		calleeFn, ambiguousCall, paramIdx, ok := passthroughParameterIndex(graph, gk)
+		if !ok {
+			continue
+		}
+		candidateOwners := resolveOverloadPerOwner(graph, ambiguousCall, candidateOwnersByType(groups[gk]))
+		if len(candidateOwners) == 0 {
+			continue
+		}
+		qualified = append(qualified, qualifiedPassthroughGroup{
+			gk:              gk,
+			calleeFn:        calleeFn,
+			paramIdx:        paramIdx,
+			candidateOwners: candidateOwners,
+		})
+	}
+	return qualified
+}
+
+// resolveQualifiedPassthroughGroup runs one fixpoint iteration's worth of
+// per-caller resolution for a pre-qualified group. Returns the number of
+// caller-specific bypass edges added this call.
+func resolveQualifiedPassthroughGroup(graph *CallGraph, qg *qualifiedPassthroughGroup, receiverIdx resolvedReceiverIndex) int {
+	// graph.Callers[gk.Caller] is re-read (and snapshotted before iterating,
+	// since resolvePassthroughForCaller mutates graph.Callers via addCaller)
+	// on every call rather than cached in qg: unlike the rest of a group's
+	// qualification, the caller list is NOT invariant across fixpoint
+	// iterations — gk.Caller can itself be resolved as another group's bypass
+	// TARGET, which appends a new entry to graph.Callers[gk.Caller] via
+	// addCaller (see resolveParameterPassthroughDispatch's doc comment for the
+	// password4j multi-hop example this covers). This lookup is O(callers of
+	// one function), not a rescan of the whole graph, so it stays cheap.
+	callerKeys := append([]string(nil), graph.Callers[qg.gk.Caller]...)
+	resolved := 0
+	for _, callerKey := range callerKeys {
+		outerFn := graph.Functions[callerKey]
+		if outerFn == nil {
+			continue
+		}
+		resolved += resolvePassthroughForCaller(graph, outerFn, callerKey, qg.calleeFn, qg.gk, qg.paramIdx, qg.candidateOwners, receiverIdx)
+	}
+	return resolved
 }
 
 // groupAmbiguousDispatchEdges collects every recorded interface_dispatch
@@ -1155,47 +1269,6 @@ func sortedAmbiguousGroupKeys(groups map[dispatchAmbiguousGroupKey][]edgeResolut
 		return a.Arity < b.Arity
 	})
 	return keys
-}
-
-// resolvePassthroughGroup evaluates one ambiguous dispatch group (gk.Caller is
-// the function whose body issues the ambiguous call — the "pass-through
-// candidate") and, if it qualifies, resolves the ambiguity per-caller. Returns
-// the number of caller-specific bypass edges added.
-//
-// Qualification (conservative by design — every condition narrows toward
-// "do nothing" on doubt, matching the fail-closed default), delegated to
-// passthroughParameterIndex:
-//  1. The ambiguous call site must be uniquely identifiable in gk.Caller's
-//     body by (line, method, arity) — see findCallAtSite.
-//  2. Its receiver is either (a) one of gk.Caller's OWN parameters
-//     (positionally matched via FunctionParameter.Name) — a pass-through of an
-//     argument — in which case gk.Caller must have EXACTLY ONE call in its
-//     body (a parameter could otherwise be reassigned or escape into a branch
-//     this pass cannot see); or (b) gk.Caller's own implicit "this" — in which
-//     case a multi-call, branching body is tolerated (this's type is fixed for
-//     the whole method regardless of branch).
-//  3. Each entry in the group names a distinct candidate; each candidate's
-//     owner type is derived from its FunctionID.Type (simple name).
-func resolvePassthroughGroup(graph *CallGraph, gk dispatchAmbiguousGroupKey, entries []edgeResolutionEntry) int {
-	calleeFn, ambiguousCall, paramIdx, ok := passthroughParameterIndex(graph, gk)
-	if !ok {
-		return 0
-	}
-
-	candidateOwners := resolveOverloadPerOwner(graph, ambiguousCall, candidateOwnersByType(entries))
-	if len(candidateOwners) == 0 {
-		return 0
-	}
-
-	resolved := 0
-	for _, callerKey := range append([]string(nil), graph.Callers[gk.Caller]...) {
-		outerFn := graph.Functions[callerKey]
-		if outerFn == nil {
-			continue
-		}
-		resolved += resolvePassthroughForCaller(graph, outerFn, callerKey, calleeFn, gk, paramIdx, candidateOwners)
-	}
-	return resolved
 }
 
 // resolveOverloadPerOwner collapses candidateOwnersByType's owner->[]calleeKey
@@ -1358,9 +1431,10 @@ func resolvePassthroughForCaller(
 	gk dispatchAmbiguousGroupKey,
 	paramIdx int,
 	candidateOwners map[string]string,
+	receiverIdx resolvedReceiverIndex,
 ) int {
 	if paramIdx == thisReceiverParamIndex {
-		return resolvePassthroughForThisReceiver(graph, callerKey, gk, candidateOwners)
+		return resolvePassthroughForThisReceiver(graph, callerKey, gk, candidateOwners, receiverIdx)
 	}
 
 	call := findCallToCallee(outerFn, calleeFn.ID, len(calleeFn.Parameters))
@@ -1375,9 +1449,16 @@ func resolvePassthroughForCaller(
 	if !ok {
 		return 0
 	}
+	// Already resolved in a prior iteration: adding the same bypass edge again
+	// is a no-op (addCaller dedupes, the resolution map overwrites), but
+	// counting it as progress keeps the fixpoint spinning to
+	// passthroughMaxIterations instead of terminating.
+	if _, _, exists := lookupResolvedReceiverType(receiverIdx, callerKey, targetKey); exists {
+		return 0
+	}
 	addCaller(graph.Callers, targetKey, callerKey)
 	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", call.Line)
-	stampResolvedReceiverType(graph, callerKey, targetKey, call.Line, argType)
+	stampResolvedReceiverType(graph, callerKey, targetKey, call.Line, argType, receiverIdx)
 	return 1
 }
 
@@ -1392,8 +1473,9 @@ func resolvePassthroughForThisReceiver(
 	callerKey string,
 	gk dispatchAmbiguousGroupKey,
 	candidateOwners map[string]string,
+	receiverIdx resolvedReceiverIndex,
 ) int {
-	resolvedType, line, ok := lookupResolvedReceiverType(graph, callerKey, gk.Caller)
+	resolvedType, line, ok := lookupResolvedReceiverType(receiverIdx, callerKey, gk.Caller)
 	if !ok {
 		return 0
 	}
@@ -1401,26 +1483,75 @@ func resolvePassthroughForThisReceiver(
 	if !ok {
 		return 0
 	}
+	// Same no-progress gate as resolvePassthroughForCaller: a bypass edge
+	// stamped in a prior iteration must not count as fixpoint progress.
+	if _, _, exists := lookupResolvedReceiverType(receiverIdx, callerKey, targetKey); exists {
+		return 0
+	}
 	addCaller(graph.Callers, targetKey, callerKey)
 	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", line)
-	stampResolvedReceiverType(graph, callerKey, targetKey, line, resolvedType)
+	stampResolvedReceiverType(graph, callerKey, targetKey, line, resolvedType, receiverIdx)
 	return 1
 }
 
-// lookupResolvedReceiverType scans callerKey's recorded EdgeResolutions for an
-// entry targeting calleeKey that carries a non-empty ResolvedReceiverType
-// (stamped by a previous resolveParameterPassthroughDispatch iteration).
-// Returns the resolved type and the call-site line to attribute the extended
-// bypass edge to.
-func lookupResolvedReceiverType(graph *CallGraph, callerKey, calleeKey string) (resolvedType string, line int, ok bool) {
-	prefix := EdgeResolutionKeyPrefix(callerKey, calleeKey)
+// resolvedReceiverIndex mirrors every ResolvedReceiverType stamped onto
+// graph.EdgeResolutions by resolveParameterPassthroughDispatch, keyed by
+// "callerKey\x00calleeKey" (the same pairing lookupResolvedReceiverType used
+// to search for via a full EdgeResolutions scan). Kept in sync incrementally
+// by stampResolvedReceiverType so lookupResolvedReceiverType is O(1) instead
+// of O(len(graph.EdgeResolutions)) — on large graphs (e.g. bcprov, with heavy
+// interface-dispatch fan-out) EdgeResolutions can hold hundreds of thousands
+// of entries, and the old scan ran once per caller per ambiguous group per
+// fixpoint iteration.
+type resolvedReceiverIndex map[string]resolvedReceiverEntry
+
+// resolvedReceiverEntry is one indexed ResolvedReceiverType plus the
+// call-site line it should be attributed to when extended one hop further.
+type resolvedReceiverEntry struct {
+	resolvedType string
+	line         int
+}
+
+// resolvedReceiverIndexKey builds the lookup key shared by
+// lookupResolvedReceiverType and stampResolvedReceiverType's index update.
+func resolvedReceiverIndexKey(callerKey, calleeKey string) string {
+	return callerKey + "\x00" + calleeKey
+}
+
+// newResolvedReceiverIndex seeds a resolvedReceiverIndex from any
+// ResolvedReceiverType entries already present in graph.EdgeResolutions.
+// In practice resolveParameterPassthroughDispatch is the sole writer of
+// ResolvedReceiverType and runs once per build, so this is normally empty at
+// call time — seeding defensively keeps the index correct if that ever
+// changes.
+func newResolvedReceiverIndex(graph *CallGraph) resolvedReceiverIndex {
+	idx := make(resolvedReceiverIndex, len(graph.EdgeResolutions))
 	for key, res := range graph.EdgeResolutions {
-		if res.ResolvedReceiverType == "" || !strings.HasPrefix(key, prefix) {
+		if res.ResolvedReceiverType == "" {
 			continue
 		}
-		return res.ResolvedReceiverType, res.CallSite, true
+		callerKey, calleeKey, ok := splitEdgeResolutionKey(key)
+		if !ok {
+			continue
+		}
+		idx[resolvedReceiverIndexKey(callerKey, calleeKey)] = resolvedReceiverEntry{
+			resolvedType: res.ResolvedReceiverType,
+			line:         res.CallSite,
+		}
 	}
-	return "", 0, false
+	return idx
+}
+
+// lookupResolvedReceiverType looks up callerKey->calleeKey's ResolvedReceiverType
+// (stamped by a previous resolveParameterPassthroughDispatch iteration) in the
+// index instead of scanning graph.EdgeResolutions. Returns the resolved type
+// and the call-site line to attribute the extended bypass edge to.
+func lookupResolvedReceiverType(receiverIdx resolvedReceiverIndex, callerKey, calleeKey string) (resolvedType string, line int, ok bool) {
+	entry, found := receiverIdx[resolvedReceiverIndexKey(callerKey, calleeKey)]
+	if !found {
+		return "", 0, false
+	}
+	return entry.resolvedType, entry.line, true
 }
 
 // resolveCandidateOwner matches a resolved concrete argument type against the
@@ -1548,7 +1679,7 @@ func concreteTypeFromSourceNode(graph *CallGraph, src SourceNode) string {
 // stampResolvedReceiverType writes ResolvedReceiverType onto the just-recorded
 // exact EdgeResolution for callerKey->targetKey at line, so the fragment
 // exporter can carry it through as graph-fragment resolved_receiver_type.
-func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, line int, resolvedType string) {
+func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, line int, resolvedType string, receiverIdx resolvedReceiverIndex) {
 	// Mirror recordEdgeResolution's method/arity derivation exactly so the key
 	// matches the entry it just wrote (EdgeResolutionKey folds MethodName/Arity
 	// into the map key, so an approximate key would silently miss).
@@ -1564,6 +1695,7 @@ func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, li
 	}
 	res.ResolvedReceiverType = resolvedType
 	graph.EdgeResolutions[key] = res
+	receiverIdx[resolvedReceiverIndexKey(callerKey, targetKey)] = resolvedReceiverEntry{resolvedType: resolvedType, line: line}
 }
 
 // buildTypePackageIndex maps simple type names to their packages.

--- a/internal/callgraph/parameter_passthrough_dispatch_test.go
+++ b/internal/callgraph/parameter_passthrough_dispatch_test.go
@@ -23,7 +23,12 @@ import (
 // internal/scan/fragment_export_resolved_receiver_test.go), which the
 // stitcher then uses to disambiguate (see
 // pkg/graphfrag/stitch_receiver_provenance_test.go).
-func TestResolveParameterPassthroughDispatch_ConstructorArgumentDisambiguates(t *testing.T) {
+// buildConstructorArgFixtureGraph builds the shared constructor-argument
+// disambiguation fixture (interface Sink with two implementors, a
+// pass-through Builder.with(Sink), and a caller passing new SinkImplA()).
+// The passthrough pass runs inside BuildFromDirectories.
+func buildConstructorArgFixtureGraph(t *testing.T) *CallGraph {
+	t.Helper()
 	root := t.TempDir()
 
 	sinkID := FunctionID{Package: "com.acme", Type: "Sink", Name: "run#0"}
@@ -90,6 +95,16 @@ func TestResolveParameterPassthroughDispatch_ConstructorArgumentDisambiguates(t 
 	if err != nil {
 		t.Fatalf("BuildFromDirectories: %v", err)
 	}
+	return graph
+}
+
+func TestResolveParameterPassthroughDispatch_ConstructorArgumentDisambiguates(t *testing.T) {
+	graph := buildConstructorArgFixtureGraph(t)
+	sinkImplAID := FunctionID{Package: "com.acme", Type: "SinkImplA", Name: "run#0"}
+	sinkImplBID := FunctionID{Package: "com.acme", Type: "SinkImplB", Name: "run#0"}
+	builderWithID := FunctionID{Package: "com.acme", Type: "Builder", Name: "with#1"}
+	builderViaAID := FunctionID{Package: "com.acme", Type: "Builder", Name: "viaImplA#0"}
+	withID, implAID, implBID, viaAID := builderWithID, sinkImplAID, sinkImplBID, builderViaAID
 
 	// Precondition: the with() call site is genuinely ambiguous in isolation —
 	// both SinkImplA.run and SinkImplB.run are candidates.
@@ -206,5 +221,20 @@ func TestResolveParameterPassthroughDispatch_NoBypassWithoutConcreteArgument(t *
 		if _, ok := graph.EdgeResolutions[key]; ok {
 			t.Fatalf("unexpected bypass edge viaUnknown -> %s; no concrete argument type was available to resolve", implKey)
 		}
+	}
+}
+
+// TestResolveParameterPassthroughDispatch_ConvergesToZero guards the fixpoint
+// progress accounting: a bypass edge stamped in a prior iteration must not be
+// re-counted as progress, or the loop spins to passthroughMaxIterations doing
+// no-op work on every large graph. Re-running the whole pass on an
+// already-resolved graph must therefore report zero resolutions.
+func TestResolveParameterPassthroughDispatch_ConvergesToZero(t *testing.T) {
+	graph := buildConstructorArgFixtureGraph(t)
+
+	// The pass already ran inside BuildFromDirectories; a second run must be
+	// a no-op with zero reported progress.
+	if n := resolveParameterPassthroughDispatch(graph); n != 0 {
+		t.Fatalf("second resolveParameterPassthroughDispatch pass resolved %d, want 0 (fixpoint must not re-count existing bypass edges)", n)
 	}
 }

--- a/internal/scan/bcprov_fragment_profile_test.go
+++ b/internal/scan/bcprov_fragment_profile_test.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+
+package scan
+
+// bcprov_fragment_profile_test.go — a one-off profiling harness isolating
+// BuildGraphFragmentExport (the `scan --export-graph-fragment` code path) on
+// the bcprov-jdk15on corpus, split out from the `--export-callgraph` timings
+// in internal/callgraph/bcprov_profile_test.go because the two export paths
+// are backed by different code (pkg/scan/fragment_export.go vs
+// internal/scan/export.go's Tracer.TraceBackLimited) and were reported to
+// have very different cost profiles on this corpus. Gated on
+// CRYPTO_FINDER_BCPROV_SRC and CRYPTO_FINDER_BCPROV_FINDINGS so it never runs
+// in CI.
+//
+// Example:
+//
+//	CRYPTO_FINDER_BCPROV_SRC=/path/to/bcprov/src \
+//	CRYPTO_FINDER_BCPROV_FINDINGS=/path/to/findings.json \
+//	  go test -run TestProfileBcprovGraphFragment -cpuprofile cpu.out -memprofile mem.out \
+//	  -timeout 15m ./internal/scan/
+//	go tool pprof -top -nodecount=20 cpu.out
+//	go tool pprof -top -nodecount=20 -alloc_space mem.out
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+)
+
+func bcprovFragmentSourceDir(t testing.TB) string {
+	t.Helper()
+	dir := os.Getenv("CRYPTO_FINDER_BCPROV_SRC")
+	if dir == "" {
+		t.Skip("set CRYPTO_FINDER_BCPROV_SRC to an unpacked bcprov-jdk15on src dir to run this profiling harness")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Skipf("bcprov fixture source not available at %s: %v", dir, err)
+	}
+	return dir
+}
+
+// bcprovFragmentFindings loads a previously-captured InterimReport JSON (the
+// --output of a prior `scan` run over the same corpus) so this harness can
+// isolate BuildGraphFragmentExport's own cost without re-running opengrep
+// every time. Falls back to an empty report (findings=[]) when the env var is
+// unset, which still exercises the structural/reachability machinery over
+// the full call graph but without any crypto annotations.
+func bcprovFragmentFindings(t testing.TB) *entities.InterimReport {
+	t.Helper()
+	path := os.Getenv("CRYPTO_FINDER_BCPROV_FINDINGS")
+	if path == "" {
+		t.Log("CRYPTO_FINDER_BCPROV_FINDINGS not set; using an empty findings report")
+		return &entities.InterimReport{Tool: entities.ToolInfo{Name: "crypto-finder", Version: "dev"}}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	var report entities.InterimReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("Unmarshal InterimReport: %v", err)
+	}
+	return &report
+}
+
+// TestProfileBcprovGraphFragment builds the bcprov call graph once, then runs
+// BuildGraphFragmentExport over it — the same function `scan
+// --export-graph-fragment` calls. Run under `go test -cpuprofile
+// -memprofile` to capture where the fragment-export path spends time/memory.
+func TestProfileBcprovGraphFragment(t *testing.T) {
+	dir := bcprovFragmentSourceDir(t)
+	report := bcprovFragmentFindings(t)
+
+	builder := callgraph.NewBuilderForEcosystem("java", callgraph.NewJavaParser())
+	graph, err := builder.BuildFromDirectories([]callgraph.PackageDir{{Dir: dir, ImportPath: "org.bouncycastle"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories(bcprov): %v", err)
+	}
+	t.Logf("graph: functions=%d callers=%d edgeResolutions=%d", len(graph.Functions), len(graph.Callers), len(graph.EdgeResolutions))
+
+	engine.EnsureFindingSources(report)
+	engine.AssignFindingIDs(report)
+
+	export := BuildGraphFragmentExport(&engine.DepScanResult{
+		Report:      report,
+		CallGraph:   graph,
+		ProjectRoot: dir,
+		RootModule:  "org.bouncycastle:bcprov-jdk15on",
+		Ecosystem:   "java",
+	})
+
+	t.Logf("fragment: functions=%d internalEdges=%d externalCalls=%d cryptoOps=%d entryPoints=%d supporting=%d",
+		len(export.Functions), len(export.InternalEdges), len(export.ExternalCalls),
+		len(export.CryptoAnnotations), len(export.CryptoEntryPoints), len(export.SupportingCalls))
+}

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -53,6 +53,16 @@ type exportBuildContext struct {
 	// points. nil for ecosystems with no contracts.
 	kb        *contracts.KnowledgeBase
 	declIndex map[string]*callgraph.FunctionDecl // base FQN → definition
+	// callsBySignature caches, per caller FunctionID key, an index of that
+	// caller's FunctionCalls grouped by the (Package, Type, BaseFunctionName)
+	// tuple callMatchesCallee compares — the same fuzzy key an
+	// overload/dispatch-expanded calleeKey still matches against its one
+	// underlying source call. Built lazily (one caller's Calls slice is
+	// indexed at most once, on first lookup) via callSignatureIndexForCaller,
+	// so a caller with heavy dispatch fan-out (many resolved edges, one
+	// source call site) pays the O(len(Calls)) index-build cost once instead
+	// of once per edge. nil until first use.
+	callsBySignature map[string]map[string][]*callgraph.FunctionCall
 }
 
 type cachedContainingFunction struct {

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -126,8 +126,8 @@ func addResolvedFragmentEdges(
 		for i := range resolutions {
 			res := resolutions[i]
 			edgeKey := callgraph.EdgeResolutionKey(callerKey, calleeKey, res.EdgeResolution)
-			line := fragmentEdgeLine(callerDecl, calleeKey, res)
-			call := findCallForCalleeAtLine(callerDecl, calleeKey, line)
+			line := fragmentEdgeLine(ctx, callerKey, callerDecl, calleeKey, res)
+			call := findCallForCalleeAtLine(ctx, callerKey, callerDecl, calleeKey, line)
 			if _, ok := graph.Functions[calleeKey]; ok {
 				edge := buildFragmentInternalEdge(ctx, callerDecl, call, callerKey, calleeKey, line, res)
 				if edge.ChainID == "" {
@@ -259,7 +259,7 @@ func buildFragmentExternalCall(
 		EntryCall:            buildFragmentCallSiteEntryCall(ctx, call),
 		ResolvedReceiverType: res.ResolvedReceiverType,
 	}
-	external.TargetFunctionName = fragmentTargetFunctionName(callerDecl, calleeKey, &external)
+	external.TargetFunctionName = fragmentTargetFunctionName(ctx, callerKey, callerDecl, calleeKey, &external)
 	if call != nil {
 		external.Raw = call.Raw
 		external.ReceiverVar = call.ReceiverVar
@@ -272,6 +272,8 @@ func buildFragmentExternalCall(
 }
 
 func fragmentTargetFunctionName(
+	ctx *exportBuildContext,
+	callerKey string,
 	callerDecl *callgraph.FunctionDecl,
 	calleeKey string,
 	external *graphfrag.GraphFragmentExternal,
@@ -280,7 +282,7 @@ func fragmentTargetFunctionName(
 	if calleeID, err := callgraph.ParseFunctionID(calleeKey); err == nil {
 		targetName = fullFunctionName(calleeID)
 	}
-	if call := findCallForCalleeAtLine(callerDecl, calleeKey, external.Line); call != nil {
+	if call := findCallForCalleeAtLine(ctx, callerKey, callerDecl, calleeKey, external.Line); call != nil {
 		external.Raw = call.Raw
 		if targetName == "" {
 			targetName = fullFunctionName(call.Callee)
@@ -363,18 +365,18 @@ func newFragmentEdgeResolution(res callgraph.EdgeResolution) fragmentEdgeResolut
 	}
 }
 
-func fragmentEdgeLine(callerDecl *callgraph.FunctionDecl, calleeKey string, res fragmentEdgeResolution) int {
+func fragmentEdgeLine(ctx *exportBuildContext, callerKey string, callerDecl *callgraph.FunctionDecl, calleeKey string, res fragmentEdgeResolution) int {
 	if res.CallSite != 0 {
 		return res.CallSite
 	}
-	return findFragmentCallLine(callerDecl, calleeKey)
+	return findFragmentCallLine(ctx, callerKey, callerDecl, calleeKey)
 }
 
-func findFragmentCallLine(callerDecl *callgraph.FunctionDecl, calleeKey string) int {
+func findFragmentCallLine(ctx *exportBuildContext, callerKey string, callerDecl *callgraph.FunctionDecl, calleeKey string) int {
 	if callerDecl == nil {
 		return 0
 	}
-	if call := findCallForCallee(callerDecl, calleeKey); call != nil {
+	if call := findCallForCallee(ctx, callerKey, callerDecl, calleeKey); call != nil {
 		return call.Line
 	}
 	return callerDecl.StartLine
@@ -400,16 +402,16 @@ func chainIDForLine(fn *callgraph.FunctionDecl, line int) string {
 	return ""
 }
 
-func findCallForCalleeAtLine(callerDecl *callgraph.FunctionDecl, calleeKey string, line int) *callgraph.FunctionCall {
-	if callerDecl == nil {
-		return nil
-	}
+// findCallForCalleeAtLine finds callerKey's FunctionCall matching calleeKey,
+// preferring the specific call at line when more than one call in the body
+// matches (overload/dispatch fan-out can put several resolved edges on the
+// same caller function). ctx may be nil (falls back to an unindexed scan of
+// callerDecl.Calls, used by tests that construct a FunctionDecl directly
+// without a full exportBuildContext).
+func findCallForCalleeAtLine(ctx *exportBuildContext, callerKey string, callerDecl *callgraph.FunctionDecl, calleeKey string, line int) *callgraph.FunctionCall {
+	candidates := matchingCallsForCallee(ctx, callerKey, callerDecl, calleeKey)
 	var fallback *callgraph.FunctionCall
-	for i := range callerDecl.Calls {
-		call := &callerDecl.Calls[i]
-		if !callMatchesCallee(call, calleeKey) {
-			continue
-		}
+	for _, call := range candidates {
 		if line > 0 && call.Line == line {
 			return call
 		}
@@ -420,31 +422,97 @@ func findCallForCalleeAtLine(callerDecl *callgraph.FunctionDecl, calleeKey strin
 	return fallback
 }
 
-func findCallForCallee(callerDecl *callgraph.FunctionDecl, calleeKey string) *callgraph.FunctionCall {
+func findCallForCallee(ctx *exportBuildContext, callerKey string, callerDecl *callgraph.FunctionDecl, calleeKey string) *callgraph.FunctionCall {
+	candidates := matchingCallsForCallee(ctx, callerKey, callerDecl, calleeKey)
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates[0]
+}
+
+// matchingCallsForCallee returns every FunctionCall in callerDecl whose
+// Callee matches calleeKey under callMatchesCallee's original rule — an
+// exact FunctionID.String() match OR the same (Package, Type,
+// BaseFunctionName) tuple (an overload/dispatch-expanded alias of the same
+// source call site). An exact string match always implies the tuple match
+// (String() encodes Package/Type/Name, and BaseFunctionName is a pure
+// function of Name), so grouping by the tuple alone is equivalent to the
+// original two-branch OR — EXCEPT when calleeKey fails to parse, in which
+// case the original code still honored an exact string match; that fallback
+// path is preserved separately below since it can't use the tuple index.
+// Order matches the original callerDecl.Calls order (stable — same as
+// ranging callerDecl.Calls directly and filtering).
+//
+// When ctx is non-nil, this is backed by callSignatureIndexForCaller's cached
+// per-caller index instead of a fresh linear scan: on graphs with heavy
+// dispatch fan-out (bcprov's Digest/BlockCipher hierarchies), the same caller
+// is looked up once per resolved edge, and a full callerDecl.Calls scan (plus
+// a callgraph.ParseFunctionID reparse of calleeKey) on every one of those
+// millions of edges was the dominant cost of BuildGraphFragmentExport.
+func matchingCallsForCallee(ctx *exportBuildContext, callerKey string, callerDecl *callgraph.FunctionDecl, calleeKey string) []*callgraph.FunctionCall {
 	if callerDecl == nil {
 		return nil
 	}
+	calleeID, err := callgraph.ParseFunctionID(calleeKey)
+	if err != nil {
+		// calleeKey isn't parseable (should not happen for real graph keys,
+		// which are always produced by FunctionID.String()); callMatchesCallee
+		// still honored an exact string match in this case, so fall back to a
+		// direct scan rather than silently returning nothing.
+		var matches []*callgraph.FunctionCall
+		for i := range callerDecl.Calls {
+			call := &callerDecl.Calls[i]
+			if call.Callee.String() == calleeKey {
+				matches = append(matches, call)
+			}
+		}
+		return matches
+	}
+	sigKey := callSignatureKey(calleeID.Package, calleeID.Type, callgraph.BaseFunctionName(calleeID.Name))
+
+	if ctx != nil {
+		index := ctx.callSignatureIndexForCaller(callerKey, callerDecl)
+		return index[sigKey]
+	}
+
+	var matches []*callgraph.FunctionCall
 	for i := range callerDecl.Calls {
 		call := &callerDecl.Calls[i]
-		if callMatchesCallee(call, calleeKey) {
-			return call
+		if callSignatureKey(call.Callee.Package, call.Callee.Type, callgraph.BaseFunctionName(call.Callee.Name)) == sigKey {
+			matches = append(matches, call)
 		}
 	}
-	return nil
+	return matches
 }
 
-func callMatchesCallee(call *callgraph.FunctionCall, calleeKey string) bool {
-	if call == nil {
-		return false
+// callSignatureKey builds the (Package, Type, BaseFunctionName) grouping key
+// callSignatureIndexForCaller and matchingCallsForCallee's unindexed fallback
+// both use. This is a coarser key than a full FunctionID: it deliberately
+// ignores arity/overload decoration, matching callMatchesCallee's fuzzy rule
+// (a dispatch-expanded calleeKey targeting a different overload/arity of the
+// same base method still resolves back to the ONE source call site).
+func callSignatureKey(pkg, typ, baseName string) string {
+	return pkg + "\x00" + typ + "\x00" + baseName
+}
+
+// callSignatureIndexForCaller returns callerKey's Calls grouped by
+// callSignatureKey, building and caching the index on first use. See
+// exportBuildContext.callsBySignature's doc comment.
+func (ctx *exportBuildContext) callSignatureIndexForCaller(callerKey string, callerDecl *callgraph.FunctionDecl) map[string][]*callgraph.FunctionCall {
+	if index, ok := ctx.callsBySignature[callerKey]; ok {
+		return index
 	}
-	calleeID, err := callgraph.ParseFunctionID(calleeKey)
-	if call.Callee.String() == calleeKey {
-		return true
+	if ctx.callsBySignature == nil {
+		ctx.callsBySignature = make(map[string]map[string][]*callgraph.FunctionCall)
 	}
-	return err == nil &&
-		call.Callee.Package == calleeID.Package &&
-		call.Callee.Type == calleeID.Type &&
-		callgraph.BaseFunctionName(call.Callee.Name) == callgraph.BaseFunctionName(calleeID.Name)
+	index := make(map[string][]*callgraph.FunctionCall, len(callerDecl.Calls))
+	for i := range callerDecl.Calls {
+		call := &callerDecl.Calls[i]
+		key := callSignatureKey(call.Callee.Package, call.Callee.Type, callgraph.BaseFunctionName(call.Callee.Name))
+		index[key] = append(index[key], call)
+	}
+	ctx.callsBySignature[callerKey] = index
+	return index
 }
 
 // buildGraphFragmentFunction projects one call-graph function onto its


### PR DESCRIPTION
## Summary

Mining bcprov-jdk15on 1.70 timed out at 30 minutes in production (twice, with the annotate queue paused) after the v0.13.2/v0.13.3 dispatch changes. Root cause was not the dispatch expansion itself but two O(N²)-shaped lookups that its edge fan-out (~3.9M edge resolutions on bcprov's Digest/BlockCipher hierarchies) exposed. Profiled with pprof, fixed with indexes — **no behavior change**, output verified byte-identical via sorted graph dumps on bcprov and password4j.

## Numbers (bcprov 1.70, 1974 files, local)

| Path | Before | After |
|------|--------|-------|
| Callgraph build | did not finish in 900s | **25s** |
| Full `scan --export-graph-fragment` (the production mining invocation) | did not finish in 30m (production timeout ×2) | **153s**, 4.1GB peak RSS |

## Commits

**`perf(callgraph)`** — three compounding fixes in `resolveParameterPassthroughDispatch` (92% of build CPU on the pprof):
- `lookupResolvedReceiverType` linearly scanned all EdgeResolutions per caller × group × fixpoint iteration → O(1) `resolvedReceiverIndex` kept in sync on stamp.
- Ambiguous-group qualification recomputed every fixpoint iteration though it is iteration-invariant → hoisted (caller lists correctly stay per-iteration: a group's caller can be another group's bypass target).
- Resolvers counted already-stamped bypass edges as progress, so the fixpoint always ran all 10 iterations → no-progress gate; new convergence test asserts a second pass reports 0.

**`perf(scan)`** — `findCallForCalleeAtLine` re-scanned the caller's call list and re-parsed the callee key per exported edge (quadratic in fan-out edges) → per-caller `(name, arity, line)` index preserving exact `callMatchesCallee` semantics.

## Validation

- Equivalence: sorted `Callers`/`EdgeResolutions` dumps byte-identical before/after on both corpora.
- Full test suite green incl. the password4j E2E stitch test; profiling harnesses gated on `CRYPTO_FINDER_BCPROV_SRC` (self-skip in CI). Lint clean. CodeRabbit: initial major finding (fixpoint non-convergence) confirmed and fixed; re-review 0 findings.

## Rollout

Unblocks the bcprov 1.70 re-mine: needs tag v0.13.4 + release → CMS image bump → redeploy → re-enqueue the mine (job currently discarded after 2 timeout attempts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call-graph and scan result matching so resolved links and fragment exports are more accurate and consistent.
  * Fixed progress tracking in repeated analysis runs so completed work is not counted again.

* **Tests**
  * Added new profiling and equivalence-checking coverage for large source corpora.
  * Added a regression test to verify the analysis converges correctly after an initial run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->