### PR TITLE
feat(contracts): add Java Tier 0 gap contracts

### DIFF
--- a/internal/callgraph/contracts/java/apache-sshd.yaml
+++ b/internal/callgraph/contracts/java/apache-sshd.yaml
@@ -1,0 +1,99 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: apache-sshd
+  coordinates:
+    - "org.apache.sshd:sshd-core"
+    - "org.apache.sshd:sshd-common"
+  version_range: ">=2,<3"
+  description: "Apache MINA SSHD factory contracts for key, cipher, MAC, and fingerprint flows"
+
+contracts:
+  - method: org.apache.sshd.common.config.keys.KeyUtils.generateKeyPair
+    arity: 2
+    return:
+      type: java.security.KeyPair
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.cloneKeyPair
+    arity: 2
+    return:
+      type: java.security.KeyPair
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.getDefaultFingerPrintFactory
+    arity: 0
+    return:
+      type: org.apache.sshd.common.digest.DigestFactory
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.getFingerPrint
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.getFingerPrint
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.getFingerPrint
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.getRawFingerprint
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+  - method: org.apache.sshd.common.config.keys.KeyUtils.getRawFingerprint
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+  - method: org.apache.sshd.common.cipher.BuiltinCiphers.fromFactoryName
+    arity: 1
+    return:
+      type: org.apache.sshd.common.cipher.BuiltinCiphers
+      confidence: high
+  - method: org.apache.sshd.common.cipher.BuiltinCiphers.resolveFactory
+    arity: 1
+    return:
+      type: org.apache.sshd.common.cipher.CipherFactory
+      confidence: high
+  - method: org.apache.sshd.common.cipher.BuiltinCiphers.create
+    arity: 0
+    return:
+      type: org.apache.sshd.common.cipher.Cipher
+      confidence: high
+  - method: org.apache.sshd.common.mac.BuiltinMacs.fromFactoryName
+    arity: 1
+    return:
+      type: org.apache.sshd.common.mac.BuiltinMacs
+      confidence: high
+  - method: org.apache.sshd.common.mac.BuiltinMacs.resolveFactory
+    arity: 1
+    return:
+      type: org.apache.sshd.common.mac.MacFactory
+      confidence: high
+  - method: org.apache.sshd.common.mac.BuiltinMacs.create
+    arity: 0
+    return:
+      type: org.apache.sshd.common.mac.Mac
+      confidence: high
+
+hierarchy:
+  org.apache.sshd.common.digest.DigestFactory:
+    - java.lang.Object
+  org.apache.sshd.common.cipher.CipherFactory:
+    - java.lang.Object
+  org.apache.sshd.common.cipher.Cipher:
+    - java.lang.Object
+  org.apache.sshd.common.cipher.BuiltinCiphers:
+    - org.apache.sshd.common.cipher.CipherFactory
+  org.apache.sshd.common.mac.MacFactory:
+    - java.lang.Object
+  org.apache.sshd.common.mac.Mac:
+    - java.lang.Object
+  org.apache.sshd.common.mac.BuiltinMacs:
+    - org.apache.sshd.common.mac.MacFactory
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/apache-sshd.yaml
+++ b/internal/callgraph/contracts/java/apache-sshd.yaml
@@ -80,6 +80,31 @@ contracts:
     return:
       type: org.apache.sshd.common.mac.Mac
       confidence: high
+  - method: org.apache.sshd.common.signature.BuiltinSignatures.fromFactoryName
+    arity: 1
+    return:
+      type: org.apache.sshd.common.signature.BuiltinSignatures
+      confidence: high
+  - method: org.apache.sshd.common.signature.BuiltinSignatures.resolveFactory
+    arity: 1
+    return:
+      type: org.apache.sshd.common.signature.SignatureFactory
+      confidence: high
+  - method: org.apache.sshd.common.signature.BuiltinSignatures.create
+    arity: 0
+    return:
+      type: org.apache.sshd.common.signature.Signature
+      confidence: high
+  - method: org.apache.sshd.client.SshClient.setUpDefaultClient
+    arity: 0
+    return:
+      type: org.apache.sshd.client.SshClient
+      confidence: high
+  - method: org.apache.sshd.server.SshServer.setUpDefaultServer
+    arity: 0
+    return:
+      type: org.apache.sshd.server.SshServer
+      confidence: high
 
 hierarchy:
   org.apache.sshd.common.digest.DigestFactory:
@@ -96,4 +121,14 @@ hierarchy:
     - java.lang.Object
   org.apache.sshd.common.mac.BuiltinMacs:
     - org.apache.sshd.common.mac.MacFactory
+  org.apache.sshd.common.signature.SignatureFactory:
+    - java.lang.Object
+  org.apache.sshd.common.signature.Signature:
+    - java.lang.Object
+  org.apache.sshd.common.signature.BuiltinSignatures:
+    - org.apache.sshd.common.signature.SignatureFactory
+  org.apache.sshd.client.SshClient:
+    - java.lang.Object
+  org.apache.sshd.server.SshServer:
+    - java.lang.Object
   java.lang.Object: []

--- a/internal/callgraph/contracts/java/jjwt.yaml
+++ b/internal/callgraph/contracts/java/jjwt.yaml
@@ -1,0 +1,92 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: jjwt
+  coordinates:
+    - "io.jsonwebtoken:jjwt-api"
+    - "io.jsonwebtoken:jjwt-impl"
+  version_range: ">=0.12,<1.0"
+  description: "JJWT fluent builder and parser contracts for signed and encrypted JWT flows"
+
+contracts:
+  - method: io.jsonwebtoken.Jwts.builder
+    arity: 0
+    return:
+      type: io.jsonwebtoken.JwtBuilder
+      confidence: high
+  - method: io.jsonwebtoken.JwtBuilder.signWith
+    arity: 1
+    return:
+      type: io.jsonwebtoken.JwtBuilder
+      confidence: high
+  - method: io.jsonwebtoken.JwtBuilder.signWith
+    arity: 2
+    return:
+      type: io.jsonwebtoken.JwtBuilder
+      confidence: high
+  - method: io.jsonwebtoken.JwtBuilder.compact
+    arity: 0
+    return:
+      type: java.lang.String
+      confidence: high
+  - method: io.jsonwebtoken.Jwts.parser
+    arity: 0
+    return:
+      type: io.jsonwebtoken.JwtParserBuilder
+      confidence: high
+  - method: io.jsonwebtoken.JwtParserBuilder.verifyWith
+    arity: 1
+    return:
+      type: io.jsonwebtoken.JwtParserBuilder
+      confidence: high
+  - method: io.jsonwebtoken.JwtParserBuilder.decryptWith
+    arity: 1
+    return:
+      type: io.jsonwebtoken.JwtParserBuilder
+      confidence: high
+  - method: io.jsonwebtoken.JwtParserBuilder.build
+    arity: 0
+    return:
+      type: io.jsonwebtoken.JwtParser
+      confidence: high
+  - method: io.jsonwebtoken.JwtParser.parseSignedClaims
+    arity: 1
+    return:
+      type: io.jsonwebtoken.Jws
+      confidence: high
+  - method: io.jsonwebtoken.JwtParser.parseSignedClaims
+    arity: 2
+    return:
+      type: io.jsonwebtoken.Jws
+      confidence: high
+  - method: io.jsonwebtoken.JwtParser.parseSignedContent
+    arity: 1
+    return:
+      type: io.jsonwebtoken.Jws
+      confidence: high
+  - method: io.jsonwebtoken.JwtParser.parseEncryptedClaims
+    arity: 1
+    return:
+      type: io.jsonwebtoken.Jwe
+      confidence: high
+  - method: io.jsonwebtoken.JwtParser.parseEncryptedContent
+    arity: 1
+    return:
+      type: io.jsonwebtoken.Jwe
+      confidence: high
+
+hierarchy:
+  io.jsonwebtoken.JwtBuilder:
+    - java.lang.Object
+  io.jsonwebtoken.JwtParserBuilder:
+    - java.lang.Object
+  io.jsonwebtoken.JwtParser:
+    - java.lang.Object
+  io.jsonwebtoken.Jwt:
+    - java.lang.Object
+  io.jsonwebtoken.Jws:
+    - io.jsonwebtoken.Jwt
+  io.jsonwebtoken.Jwe:
+    - io.jsonwebtoken.Jwt
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/nimbus-jose-jwt.yaml
+++ b/internal/callgraph/contracts/java/nimbus-jose-jwt.yaml
@@ -1,0 +1,90 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: nimbus-jose-jwt
+  coordinates:
+    - "com.nimbusds:nimbus-jose-jwt"
+  version_range: ">=9,<11"
+  description: "Nimbus JOSE + JWT contracts for JWS construction, signing, verification, and compact serialization"
+
+contracts:
+  - method: com.nimbusds.jose.JWSObject.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.JWSObject
+      confidence: high
+  - method: com.nimbusds.jose.JWSObject.parse
+    arity: 1
+    return:
+      type: com.nimbusds.jose.JWSObject
+      confidence: high
+  - method: com.nimbusds.jose.JWSObject.sign
+    arity: 1
+    return:
+      type: void
+      confidence: high
+  - method: com.nimbusds.jose.JWSObject.verify
+    arity: 1
+    return:
+      type: boolean
+      confidence: high
+  - method: com.nimbusds.jose.JWSObject.serialize
+    arity: 0
+    return:
+      type: java.lang.String
+      confidence: high
+  - method: com.nimbusds.jose.JWSObject.getPayload
+    arity: 0
+    return:
+      type: com.nimbusds.jose.Payload
+      confidence: high
+  - method: com.nimbusds.jose.crypto.RSASSASigner.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.RSASSASigner
+      confidence: high
+  - method: com.nimbusds.jose.crypto.RSASSASigner.sign
+    arity: 2
+    return:
+      type: com.nimbusds.jose.util.Base64URL
+      confidence: high
+  - method: com.nimbusds.jose.crypto.RSASSAVerifier.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.RSASSAVerifier
+      confidence: high
+  - method: com.nimbusds.jose.crypto.RSASSAVerifier.verify
+    arity: 3
+    return:
+      type: boolean
+      confidence: high
+  - method: com.nimbusds.jose.jwk.RSAKey.toPublicJWK
+    arity: 0
+    return:
+      type: com.nimbusds.jose.jwk.RSAKey
+      confidence: high
+  - method: com.nimbusds.jose.jwk.RSAKey.parse
+    arity: 1
+    return:
+      type: com.nimbusds.jose.jwk.RSAKey
+      confidence: high
+
+hierarchy:
+  com.nimbusds.jose.JWSObject:
+    - java.lang.Object
+  com.nimbusds.jose.Payload:
+    - java.lang.Object
+  com.nimbusds.jose.JWSSigner:
+    - java.lang.Object
+  com.nimbusds.jose.JWSVerifier:
+    - java.lang.Object
+  com.nimbusds.jose.crypto.RSASSASigner:
+    - com.nimbusds.jose.JWSSigner
+  com.nimbusds.jose.crypto.RSASSAVerifier:
+    - com.nimbusds.jose.JWSVerifier
+  com.nimbusds.jose.jwk.RSAKey:
+    - java.lang.Object
+  com.nimbusds.jose.util.Base64URL:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/nimbus-jose-jwt.yaml
+++ b/internal/callgraph/contracts/java/nimbus-jose-jwt.yaml
@@ -39,10 +39,55 @@ contracts:
     return:
       type: com.nimbusds.jose.Payload
       confidence: high
+  - method: com.nimbusds.jose.crypto.DirectEncrypter.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.DirectEncrypter
+      confidence: high
+  - method: com.nimbusds.jose.crypto.DirectDecrypter.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.DirectDecrypter
+      confidence: high
+  - method: com.nimbusds.jose.crypto.ECDHEncrypter.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.ECDHEncrypter
+      confidence: high
+  - method: com.nimbusds.jose.crypto.ECDHDecrypter.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.ECDHDecrypter
+      confidence: high
+  - method: com.nimbusds.jose.crypto.RSAEncrypter.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.RSAEncrypter
+      confidence: high
+  - method: com.nimbusds.jose.crypto.RSADecrypter.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.RSADecrypter
+      confidence: high
   - method: com.nimbusds.jose.crypto.RSASSASigner.<init>
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.RSASSASigner
+      confidence: high
+  - method: com.nimbusds.jose.crypto.ECDSASigner.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.ECDSASigner
+      confidence: high
+  - method: com.nimbusds.jose.crypto.Ed25519Signer.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.Ed25519Signer
+      confidence: high
+  - method: com.nimbusds.jose.crypto.MACSigner.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.MACSigner
       confidence: high
   - method: com.nimbusds.jose.crypto.RSASSASigner.sign
     arity: 2
@@ -53,6 +98,21 @@ contracts:
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.RSASSAVerifier
+      confidence: high
+  - method: com.nimbusds.jose.crypto.ECDSAVerifier.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.ECDSAVerifier
+      confidence: high
+  - method: com.nimbusds.jose.crypto.Ed25519Verifier.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.Ed25519Verifier
+      confidence: high
+  - method: com.nimbusds.jose.crypto.MACVerifier.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.crypto.MACVerifier
       confidence: high
   - method: com.nimbusds.jose.crypto.RSASSAVerifier.verify
     arity: 3
@@ -79,9 +139,37 @@ hierarchy:
     - java.lang.Object
   com.nimbusds.jose.JWSVerifier:
     - java.lang.Object
+  com.nimbusds.jose.JWEEncrypter:
+    - java.lang.Object
+  com.nimbusds.jose.JWEDecrypter:
+    - java.lang.Object
+  com.nimbusds.jose.crypto.DirectEncrypter:
+    - com.nimbusds.jose.JWEEncrypter
+  com.nimbusds.jose.crypto.DirectDecrypter:
+    - com.nimbusds.jose.JWEDecrypter
+  com.nimbusds.jose.crypto.ECDHEncrypter:
+    - com.nimbusds.jose.JWEEncrypter
+  com.nimbusds.jose.crypto.ECDHDecrypter:
+    - com.nimbusds.jose.JWEDecrypter
+  com.nimbusds.jose.crypto.RSAEncrypter:
+    - com.nimbusds.jose.JWEEncrypter
+  com.nimbusds.jose.crypto.RSADecrypter:
+    - com.nimbusds.jose.JWEDecrypter
   com.nimbusds.jose.crypto.RSASSASigner:
     - com.nimbusds.jose.JWSSigner
+  com.nimbusds.jose.crypto.ECDSASigner:
+    - com.nimbusds.jose.JWSSigner
+  com.nimbusds.jose.crypto.Ed25519Signer:
+    - com.nimbusds.jose.JWSSigner
+  com.nimbusds.jose.crypto.MACSigner:
+    - com.nimbusds.jose.JWSSigner
   com.nimbusds.jose.crypto.RSASSAVerifier:
+    - com.nimbusds.jose.JWSVerifier
+  com.nimbusds.jose.crypto.ECDSAVerifier:
+    - com.nimbusds.jose.JWSVerifier
+  com.nimbusds.jose.crypto.Ed25519Verifier:
+    - com.nimbusds.jose.JWSVerifier
+  com.nimbusds.jose.crypto.MACVerifier:
     - com.nimbusds.jose.JWSVerifier
   com.nimbusds.jose.jwk.RSAKey:
     - java.lang.Object

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -72,9 +72,15 @@ func TestLoadEmbeddedJavaIncludesTier0GapContracts(t *testing.T) {
 		{"com.nimbusds.jose.JWSObject.<init>", 2, "com.nimbusds.jose.JWSObject", "nimbus-jose-jwt"},
 		{"com.nimbusds.jose.JWSObject.verify", 1, "boolean", "nimbus-jose-jwt"},
 		{"com.nimbusds.jose.crypto.RSASSASigner.sign", 2, "com.nimbusds.jose.util.Base64URL", "nimbus-jose-jwt"},
+		{"com.nimbusds.jose.crypto.DirectEncrypter.<init>", 1, "com.nimbusds.jose.crypto.DirectEncrypter", "nimbus-jose-jwt"},
+		{"com.nimbusds.jose.crypto.ECDSASigner.<init>", 1, "com.nimbusds.jose.crypto.ECDSASigner", "nimbus-jose-jwt"},
+		{"com.nimbusds.jose.crypto.MACVerifier.<init>", 1, "com.nimbusds.jose.crypto.MACVerifier", "nimbus-jose-jwt"},
 		{"org.apache.sshd.common.config.keys.KeyUtils.generateKeyPair", 2, "java.security.KeyPair", "apache-sshd"},
 		{"org.apache.sshd.common.cipher.BuiltinCiphers.resolveFactory", 1, "org.apache.sshd.common.cipher.CipherFactory", "apache-sshd"},
 		{"org.apache.sshd.common.mac.BuiltinMacs.create", 0, "org.apache.sshd.common.mac.Mac", "apache-sshd"},
+		{"org.apache.sshd.common.signature.BuiltinSignatures.create", 0, "org.apache.sshd.common.signature.Signature", "apache-sshd"},
+		{"org.apache.sshd.client.SshClient.setUpDefaultClient", 0, "org.apache.sshd.client.SshClient", "apache-sshd"},
+		{"org.apache.sshd.server.SshServer.setUpDefaultServer", 0, "org.apache.sshd.server.SshServer", "apache-sshd"},
 	}
 
 	for _, tt := range tests {

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -1,6 +1,7 @@
 package contracts_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
@@ -77,12 +78,14 @@ func TestLoadEmbeddedJavaIncludesTier0GapContracts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := kb.ContractsFor(tt.method, tt.arity)
-		if len(got) != 1 {
-			t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
-		}
-		if got[0].Return.Type != tt.wantReturn || got[0].SourceLibrary != tt.wantLib {
-			t.Fatalf("%s#%d = %#v, want %s from %s", tt.method, tt.arity, got[0], tt.wantReturn, tt.wantLib)
-		}
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.wantReturn || got[0].SourceLibrary != tt.wantLib {
+				t.Fatalf("%s#%d = %#v, want %s from %s", tt.method, tt.arity, got[0], tt.wantReturn, tt.wantLib)
+			}
+		})
 	}
 }

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -49,3 +49,40 @@ func TestLoadEmbeddedJavaIncludesPassword4JAndBouncyCastleContracts(t *testing.T
 		t.Fatalf("ECKeyPairGenerator.generateKeyPair#0 = %#v, want AsymmetricCipherKeyPair from bouncycastle", bcKeyPair[0])
 	}
 }
+
+func TestLoadEmbeddedJavaIncludesTier0GapContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantLib    string
+	}{
+		{"io.jsonwebtoken.Jwts.builder", 0, "io.jsonwebtoken.JwtBuilder", "jjwt"},
+		{"io.jsonwebtoken.JwtBuilder.signWith", 1, "io.jsonwebtoken.JwtBuilder", "jjwt"},
+		{"io.jsonwebtoken.JwtParserBuilder.build", 0, "io.jsonwebtoken.JwtParser", "jjwt"},
+		{"io.jsonwebtoken.JwtParser.parseSignedClaims", 1, "io.jsonwebtoken.Jws", "jjwt"},
+		{"com.nimbusds.jose.JWSObject.<init>", 2, "com.nimbusds.jose.JWSObject", "nimbus-jose-jwt"},
+		{"com.nimbusds.jose.JWSObject.verify", 1, "boolean", "nimbus-jose-jwt"},
+		{"com.nimbusds.jose.crypto.RSASSASigner.sign", 2, "com.nimbusds.jose.util.Base64URL", "nimbus-jose-jwt"},
+		{"org.apache.sshd.common.config.keys.KeyUtils.generateKeyPair", 2, "java.security.KeyPair", "apache-sshd"},
+		{"org.apache.sshd.common.cipher.BuiltinCiphers.resolveFactory", 1, "org.apache.sshd.common.cipher.CipherFactory", "apache-sshd"},
+		{"org.apache.sshd.common.mac.BuiltinMacs.create", 0, "org.apache.sshd.common.mac.Mac", "apache-sshd"},
+	}
+
+	for _, tt := range tests {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) != 1 {
+			t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+		}
+		if got[0].Return.Type != tt.wantReturn || got[0].SourceLibrary != tt.wantLib {
+			t.Fatalf("%s#%d = %#v, want %s from %s", tt.method, tt.arity, got[0], tt.wantReturn, tt.wantLib)
+		}
+	}
+}


### PR DESCRIPTION
Refs #55

## Summary
- add Java contract KBs for the first priority pairing gaps: JJWT, Nimbus JOSE + JWT, and Apache MINA SSHD
- cover fluent JWT/JWS builder-parser flows plus SSHD key, cipher, MAC, signature, client, and server factory returns
- add embedded KB regression coverage for the new Java contracts

## Exhaustive API audit for current rule scope

Source inventory: current `scanoss/crypto_rules` Java rules for the #55 first-priority slice.

### Contracted / covered
- **JJWT**: `JwtBuilder.signWith(...)` is covered by the existing JJWT builder-flow contracts in this PR.
- **Nimbus JOSE + JWT**: covered JWS object construction/parse/sign/verify/serialize flows, RSA signer/verifier flows, RSA JWK parsing, JWE encrypter/decrypter constructors (`Direct*`, `ECDH*`, `RSA*`), and JWS signer/verifier constructors (`RSASSA*`, `ECDSA*`, `Ed25519*`, `MAC*`).
- **Apache MINA SSHD**: covered `KeyUtils` key/fingerprint helpers, `BuiltinCiphers` factories, `BuiltinMacs` factories, `BuiltinSignatures` factories, `SshClient.setUpDefaultClient()`, and `SshServer.setUpDefaultServer()`.

### Explicitly skipped in this PR
- `JWSAlgorithm.$C`, `BuiltinCiphers.$C`, `BuiltinMacs.$C`, and `BuiltinSignatures.$C` are enum/static constant references in the current rules, not method/constructor return contracts. They are detection metadata inputs, so they are intentionally not represented as YAML return-type contracts.

### Follow-up remains on #55
- Medium/future Java items from #55, such as Netty, JSch, Cloud KMS, Vault, and broader BouncyCastle expansion, remain outside this first-priority PR slice.

## Research notes
- JJWT source/docs confirm `Jwts.builder()`, `signWith(...)`, `Jwts.parser()`, `verifyWith(...)`, `build()`, and `parseSignedClaims(...)` as the main signed JWT chain.
- Nimbus docs/source confirm `JWSObject.sign(...)`, `verify(...)`, `serialize()`, `parse(...)`, and signer/verifier/encrypter/decrypter constructor flows.
- Apache MINA SSHD source confirms `KeyUtils`, `BuiltinCiphers`, `BuiltinMacs`, `BuiltinSignatures`, `SshClient`, and `SshServer` factory return shapes.

## Verification
- [x] `GOCACHE=/tmp/crypto-finder-go-build GOMODCACHE=/tmp/crypto-finder-gomod go test ./internal/callgraph/contracts/...`
- [x] `GOCACHE=/tmp/crypto-finder-go-build GOMODCACHE=/tmp/crypto-finder-gomod go test ./internal/callgraph/...`

## Scope
This intentionally covers the first pairing-gap slice from #55 only. The medium-priority Java contract backlog remains on the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Java JWT and SSH-related libraries in the call-graph system.
  * Improved coverage for common signing, parsing, key generation, and cipher/MAC workflows.

* **Tests**
  * Added automated checks to verify the new Java contract mappings load correctly and return the expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
