### PR TITLE
feat(contracts): add PyOTP protocol contracts

### DIFF
--- a/internal/callgraph/contracts/python/pyotp.yaml
+++ b/internal/callgraph/contracts/python/pyotp.yaml
@@ -1,0 +1,102 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: pyotp
+  coordinates:
+    - pyotp
+  version_range: ">=2.0"
+  description: "PyOTP — HOTP/TOTP one-time password protocol helpers"
+
+contracts:
+  # ── TOTP constructors ────────────────────────────────────────────────────────
+
+  - method: pyotp.TOTP.<init>
+    arity: 1
+    return:
+      type: pyotp.totp.TOTP
+      confidence: high
+    role: factory
+
+  - method: pyotp.totp.TOTP.<init>
+    arity: 1
+    return:
+      type: pyotp.totp.TOTP
+      confidence: high
+    role: factory
+
+  - method: pyotp.totp.TOTP.at
+    arity: 1
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: pyotp.totp.TOTP.now
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: pyotp.totp.TOTP.provisioning_uri
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: pyotp.totp.TOTP.verify
+    arity: 1
+    return:
+      type: builtins.bool
+      confidence: high
+    role: output
+
+  # ── HOTP constructors ────────────────────────────────────────────────────────
+
+  - method: pyotp.HOTP.<init>
+    arity: 1
+    return:
+      type: pyotp.hotp.HOTP
+      confidence: high
+    role: factory
+
+  - method: pyotp.hotp.HOTP.<init>
+    arity: 1
+    return:
+      type: pyotp.hotp.HOTP
+      confidence: high
+    role: factory
+
+  - method: pyotp.hotp.HOTP.at
+    arity: 1
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: pyotp.hotp.HOTP.provisioning_uri
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: pyotp.hotp.HOTP.verify
+    arity: 2
+    return:
+      type: builtins.bool
+      confidence: high
+    role: output
+
+hierarchy:
+  pyotp.totp.TOTP:
+    - pyotp.otp.OTP
+  pyotp.hotp.HOTP:
+    - pyotp.otp.OTP
+  pyotp.otp.OTP:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.bool:
+    - builtins.object

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -252,6 +252,57 @@ func TestLoadEmbedded_Python_Paramiko(t *testing.T) {
 	}
 }
 
+// TestLoadEmbedded_Python_PyOTP verifies the PyOTP constructor aliases used by
+// scanoss/crypto_rules#99 and the output helpers they return.
+func TestLoadEmbedded_Python_PyOTP(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantLib    string
+	}{
+		{"pyotp.TOTP.<init>", 1, "pyotp.totp.TOTP", "pyotp"},
+		{"pyotp.totp.TOTP.<init>", 1, "pyotp.totp.TOTP", "pyotp"},
+		{"pyotp.totp.TOTP.now", 0, "builtins.str", "pyotp"},
+		{"pyotp.totp.TOTP.at", 1, "builtins.str", "pyotp"},
+		{"pyotp.totp.TOTP.verify", 1, "builtins.bool", "pyotp"},
+		{"pyotp.totp.TOTP.provisioning_uri", 0, "builtins.str", "pyotp"},
+		{"pyotp.HOTP.<init>", 1, "pyotp.hotp.HOTP", "pyotp"},
+		{"pyotp.hotp.HOTP.<init>", 1, "pyotp.hotp.HOTP", "pyotp"},
+		{"pyotp.hotp.HOTP.at", 1, "builtins.str", "pyotp"},
+		{"pyotp.hotp.HOTP.verify", 2, "builtins.bool", "pyotp"},
+		{"pyotp.hotp.HOTP.provisioning_uri", 0, "builtins.str", "pyotp"},
+	}
+
+	for _, tt := range tests {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) == 0 {
+			t.Errorf("%s#%d: no contracts found", tt.method, tt.arity)
+			continue
+		}
+		c := got[0]
+		if c.Return.Type != tt.wantReturn {
+			t.Errorf("%s#%d return type = %q, want %q", tt.method, tt.arity, c.Return.Type, tt.wantReturn)
+		}
+		if c.SourceLibrary != tt.wantLib {
+			t.Errorf("%s#%d source library = %q, want %q", tt.method, tt.arity, c.SourceLibrary, tt.wantLib)
+		}
+		if c.Return.Confidence != "high" {
+			t.Errorf("%s#%d confidence = %q, want %q", tt.method, tt.arity, c.Return.Confidence, "high")
+		}
+	}
+
+	for _, typ := range []string{"pyotp.totp.TOTP", "pyotp.hotp.HOTP", "pyotp.otp.OTP"} {
+		if len(kb.Hierarchy[typ]) == 0 {
+			t.Errorf("hierarchy[%q] is empty", typ)
+		}
+	}
+}
+
 // TestLoadEmbedded_Python_CryptodomeAlias verifies that the Cryptodome.* namespace
 // (pycryptodomex package) resolves the same contracts as the Crypto.* namespace
 // (pycryptodome). This covers TASK C: `from Cryptodome.Cipher import AES; AES.new(...)`


### PR DESCRIPTION
Part of scanoss/crypto-finder#56
Triggered by scanoss/crypto_rules#99

## Summary
- Add PyOTP callgraph contracts for the TOTP/HOTP constructor APIs detected by scanoss/crypto_rules#99.
- Cover both top-level aliases (`pyotp.TOTP`, `pyotp.HOTP`) and submodule constructors (`pyotp.totp.TOTP`, `pyotp.hotp.HOTP`).
- Add focused embedded-KB assertions for constructor aliases and OTP output methods.

## Upstream docs checked
- PyOTP docs: https://pyauth.github.io/pyotp/
- API docs list `pyotp.totp.TOTP(...)`, `pyotp.hotp.HOTP(...)`, `TOTP.now()`, `TOTP.at(...)`, and `HOTP.at(...)` return shapes.

## API disposition for scanoss/crypto_rules#99
| API | Disposition | Notes |
|---|---|---|
| `pyotp.TOTP(...)` | contracted | Top-level alias detected by rules. |
| `pyotp.totp.TOTP(...)` | contracted | Canonical TOTP constructor. |
| `pyotp.HOTP(...)` | contracted | Top-level alias detected by rules. |
| `pyotp.hotp.HOTP(...)` | contracted | Canonical HOTP constructor. |
| `TOTP.now()` / `TOTP.at(...)` | contracted | OTP string outputs used by fixtures. |
| `HOTP.at(...)` | contracted | OTP string output used by fixtures. |
| `parse_uri(...)` | skipped-unsupported | Return type depends on URI scheme, not part of PR #99's constructor rule scope. |
| secret helpers / URI builders | skipped-non-crypto-for-this-gap | Not detected by PR #99's protocol constructor rules. |

## Changes
| File | Change |
|---|---|
| `internal/callgraph/contracts/python/pyotp.yaml` | Adds PyOTP HOTP/TOTP contracts and hierarchy. |
| `internal/callgraph/contracts/python_libraries_test.go` | Adds focused PyOTP KB assertions. |

## Test Plan
- [x] `go test ./internal/callgraph/contracts/...`
- [x] `go test ./internal/callgraph/...`

## Notes
- This PR only covers the PyOTP gap from scanoss/crypto_rules#99. Other merged Python rule PRs still need their own contract-gap pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing common PyOTP APIs, including TOTP and HOTP construction, code generation, URI creation, and verification.
  * Improved Python inheritance awareness for these objects, helping call analysis and type resolution work more accurately.
* **Tests**
  * Added coverage to ensure the new PyOTP support is loaded correctly and returns the expected method signatures and result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->