### PR TITLE
feat(contracts): add Azure Key Vault Keys contracts

### DIFF
--- a/internal/callgraph/contracts/python/azure-keyvault-keys.yaml
+++ b/internal/callgraph/contracts/python/azure-keyvault-keys.yaml
@@ -1,0 +1,111 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: azure-keyvault-keys
+  coordinates:
+    - azure-keyvault-keys
+  version_range: ">=4.0"
+  description: "Azure Key Vault Keys client and cryptography result contracts"
+
+contracts:
+  - method: azure.keyvault.keys.KeyClient.<init>
+    arity: 2
+    return: { type: azure.keyvault.keys.KeyClient, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.KeyClient.get_cryptography_client
+    arity: 1
+    return: { type: azure.keyvault.keys.crypto.CryptographyClient, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.KeyClient.create_rsa_key
+    arity: 1
+    return: { type: azure.keyvault.keys.KeyVaultKey, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.KeyClient.create_ec_key
+    arity: 1
+    return: { type: azure.keyvault.keys.KeyVaultKey, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.KeyClient.create_oct_key
+    arity: 1
+    return: { type: azure.keyvault.keys.KeyVaultKey, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.KeyClient.import_key
+    arity: 2
+    return: { type: azure.keyvault.keys.KeyVaultKey, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.KeyClient.get_key
+    arity: 1
+    return: { type: azure.keyvault.keys.KeyVaultKey, confidence: high }
+
+  - method: azure.keyvault.keys.KeyClient.get_random_bytes
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.<init>
+    arity: 2
+    return: { type: azure.keyvault.keys.crypto.CryptographyClient, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.from_jwk
+    arity: 1
+    return: { type: azure.keyvault.keys.crypto.CryptographyClient, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.encrypt
+    arity: 2
+    return: { type: azure.keyvault.keys.crypto.EncryptResult, confidence: high }
+    role: output
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.decrypt
+    arity: 2
+    return: { type: azure.keyvault.keys.crypto.DecryptResult, confidence: high }
+    role: output
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.wrap_key
+    arity: 2
+    return: { type: azure.keyvault.keys.crypto.WrapResult, confidence: high }
+    role: output
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.unwrap_key
+    arity: 2
+    return: { type: azure.keyvault.keys.crypto.UnwrapResult, confidence: high }
+    role: output
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.sign
+    arity: 2
+    return: { type: azure.keyvault.keys.crypto.SignResult, confidence: high }
+    role: output
+
+  - method: azure.keyvault.keys.crypto.CryptographyClient.verify
+    arity: 3
+    return: { type: azure.keyvault.keys.crypto.VerifyResult, confidence: high }
+    role: output
+
+hierarchy:
+  azure.keyvault.keys.KeyClient:
+    - builtins.object
+  azure.keyvault.keys.KeyVaultKey:
+    - builtins.object
+  azure.keyvault.keys.crypto.CryptographyClient:
+    - builtins.object
+  azure.keyvault.keys.crypto.EncryptResult:
+    - builtins.object
+  azure.keyvault.keys.crypto.DecryptResult:
+    - builtins.object
+  azure.keyvault.keys.crypto.WrapResult:
+    - builtins.object
+  azure.keyvault.keys.crypto.UnwrapResult:
+    - builtins.object
+  azure.keyvault.keys.crypto.SignResult:
+    - builtins.object
+  azure.keyvault.keys.crypto.VerifyResult:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -352,6 +352,52 @@ func TestLoadEmbedded_Python_BenchmarkLibraries(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_Python_AzureKeyVaultKeys(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+	}{
+		{"azure.keyvault.keys.KeyClient.<init>", 2, "azure.keyvault.keys.KeyClient"},
+		{"azure.keyvault.keys.KeyClient.get_cryptography_client", 1, "azure.keyvault.keys.crypto.CryptographyClient"},
+		{"azure.keyvault.keys.KeyClient.create_rsa_key", 1, "azure.keyvault.keys.KeyVaultKey"},
+		{"azure.keyvault.keys.KeyClient.create_ec_key", 1, "azure.keyvault.keys.KeyVaultKey"},
+		{"azure.keyvault.keys.KeyClient.create_oct_key", 1, "azure.keyvault.keys.KeyVaultKey"},
+		{"azure.keyvault.keys.KeyClient.import_key", 2, "azure.keyvault.keys.KeyVaultKey"},
+		{"azure.keyvault.keys.KeyClient.get_key", 1, "azure.keyvault.keys.KeyVaultKey"},
+		{"azure.keyvault.keys.KeyClient.get_random_bytes", 1, "builtins.bytes"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.from_jwk", 1, "azure.keyvault.keys.crypto.CryptographyClient"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.encrypt", 2, "azure.keyvault.keys.crypto.EncryptResult"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.decrypt", 2, "azure.keyvault.keys.crypto.DecryptResult"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.wrap_key", 2, "azure.keyvault.keys.crypto.WrapResult"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.unwrap_key", 2, "azure.keyvault.keys.crypto.UnwrapResult"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.sign", 2, "azure.keyvault.keys.crypto.SignResult"},
+		{"azure.keyvault.keys.crypto.CryptographyClient.verify", 3, "azure.keyvault.keys.crypto.VerifyResult"},
+	}
+
+	for _, tt := range tests {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) == 0 {
+			t.Errorf("%s#%d: no contracts found", tt.method, tt.arity)
+			continue
+		}
+		c := got[0]
+		if c.Return.Type != tt.wantReturn {
+			t.Errorf("%s#%d return type = %q, want %q", tt.method, tt.arity, c.Return.Type, tt.wantReturn)
+		}
+		if c.SourceLibrary != "azure-keyvault-keys" {
+			t.Errorf("%s#%d source library = %q, want azure-keyvault-keys", tt.method, tt.arity, c.SourceLibrary)
+		}
+		if c.Return.Confidence != "high" {
+			t.Errorf("%s#%d confidence = %q, want high", tt.method, tt.arity, c.Return.Confidence)
+		}
+	}
+}
+
 // TestLoadEmbedded_Python_AllLibrariesHaveValidReturnTypes asserts that every
 // contract in the merged Python KB has a non-empty return type and "high"
 // confidence (the only author-facing confidence level per crypto-kb-author skill).


### PR DESCRIPTION
Part of scanoss/crypto-finder#56
Triggered by scanoss/crypto_rules#105

## Summary
- Add Azure Key Vault Keys Python callgraph contracts for `KeyClient`, `CryptographyClient`, key management methods, crypto operation results, and HSM random bytes.
- Cover the APIs detected by scanoss/crypto_rules#105: encryption/decryption, signing/verification, key wrap/unwrap, key creation/import/retrieval, JWK local clients, and random-byte output.
- Add embedded-KB assertions for every contracted rule API in this slice.

## Upstream docs checked
- `CryptographyClient` docs: https://learn.microsoft.com/en-us/python/api/azure-keyvault-keys/azure.keyvault.keys.crypto.cryptographyclient?view=azure-python
- `KeyClient` docs: https://learn.microsoft.com/en-us/python/api/azure-keyvault-keys/azure.keyvault.keys.keyclient?view=azure-python
- Result model docs: https://learn.microsoft.com/en-us/python/api/azure-keyvault-keys/azure.keyvault.keys.crypto.encryptresult?view=azure-python and https://learn.microsoft.com/en-us/python/api/azure-keyvault-keys/azure.keyvault.keys.crypto.signresult?view=azure-python

## API disposition for scanoss/crypto_rules#105
| API | Disposition | Notes |
|---|---|---|
| `KeyClient(...)` | contracted | Produces the client used by key and HSM random-byte rules. |
| `KeyClient.get_cryptography_client(...)` | contracted | Produces `CryptographyClient` for operation rules. |
| `KeyClient.create_rsa_key(...)` | contracted | Returns `KeyVaultKey`. |
| `KeyClient.create_ec_key(...)` | contracted | Returns `KeyVaultKey`. |
| `KeyClient.create_oct_key(...)` | contracted | Returns `KeyVaultKey`. |
| `KeyClient.import_key(...)` | contracted | Returns `KeyVaultKey`. |
| `KeyClient.get_key(...)` | contracted | Returns `KeyVaultKey`. |
| `KeyClient.get_random_bytes(...)` | contracted | Returns `bytes`. |
| `CryptographyClient(...)` | contracted | Direct client construction. |
| `CryptographyClient.from_jwk(...)` | contracted | Returns local-only `CryptographyClient`. |
| `CryptographyClient.encrypt(...)` | contracted | Returns `EncryptResult`. |
| `CryptographyClient.decrypt(...)` | contracted | Returns `DecryptResult`. |
| `CryptographyClient.wrap_key(...)` | contracted | Returns `WrapResult`. |
| `CryptographyClient.unwrap_key(...)` | contracted | Returns `UnwrapResult`. |
| `CryptographyClient.sign(...)` | contracted | Returns `SignResult`. |
| `CryptographyClient.verify(...)` | contracted | Returns `VerifyResult`. |
| algorithm enum constants | skipped-informational | Detection metadata inputs, not method-return contracts. |

## Changes
| File | Change |
|---|---|
| `internal/callgraph/contracts/python/azure-keyvault-keys.yaml` | Adds Azure Key Vault Keys contracts and hierarchy. |
| `internal/callgraph/contracts/python_libraries_test.go` | Adds focused embedded-KB assertions. |

## Test Plan
- [x] `go test ./internal/callgraph/contracts/...`
- [x] `go test ./internal/callgraph/...`

## Scope
This PR only covers the Azure Key Vault Keys gap triggered by scanoss/crypto_rules#105. Other merged Python rule PRs still need separate contract-gap passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Key Vault Keys in the Python callgraph library metadata, including key management and cryptography operations such as encrypt, decrypt, wrap, unwrap, sign, and verify.
  * Included class and result type mappings to improve method resolution for related key and crypto objects.

* **Tests**
  * Added coverage to verify the new Azure Key Vault Keys contracts load correctly and resolve to the expected return types with high confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->