### PR TITLE
feat(callgraph): add Rust parser return sources

### DIFF
--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -15,6 +15,7 @@ import (
 const (
 	rustNodeCallExpression      = "call_expression"
 	rustNodeExpressionStatement = "expression_statement"
+	rustNodeFunctionItem        = "function_item"
 )
 
 // RustParser extracts function declarations, calls, and imports from Rust source files
@@ -226,7 +227,7 @@ func (p *RustParser) extractDeclarations(root *sitter.Node, src []byte, filePath
 	for i := 0; i < int(root.ChildCount()); i++ {
 		child := root.Child(i)
 		switch child.Type() {
-		case "function_item":
+		case rustNodeFunctionItem:
 			decl := p.parseFunctionItem(child, src, filePath, packagePath, "", analysis)
 			if decl != nil {
 				analysis.Functions = append(analysis.Functions, *decl)
@@ -314,7 +315,7 @@ func (p *RustParser) walkForReturnSources(node *sitter.Node, src []byte, filePat
 		}
 		return
 	}
-	if node.Type() == "function_item" || node.Type() == "closure_expression" {
+	if node.Type() == rustNodeFunctionItem || node.Type() == "closure_expression" {
 		return
 	}
 	for i := 0; i < int(node.ChildCount()); i++ {
@@ -403,7 +404,7 @@ func (p *RustParser) processImplBlock(node *sitter.Node, src []byte, filePath, p
 
 	for i := 0; i < int(body.ChildCount()); i++ {
 		child := body.Child(i)
-		if child.Type() == "function_item" {
+		if child.Type() == rustNodeFunctionItem {
 			decl := p.parseFunctionItem(child, src, filePath, packagePath, typeName, analysis)
 			if decl != nil {
 				analysis.Functions = append(analysis.Functions, *decl)

--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -301,10 +301,7 @@ func (p *RustParser) parseFunctionItem(node *sitter.Node, src []byte, filePath, 
 func (p *RustParser) extractReturnSources(body *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string) []SourceNode {
 	var sources []SourceNode
 	p.walkForReturnSources(body, src, filePath, analysis, currentReceiverType, varTypes, &sources)
-	if len(sources) > 0 {
-		return sources
-	}
-	return p.traceRustTailExpression(body, src, filePath, analysis, currentReceiverType, varTypes)
+	return append(sources, p.traceRustTailExpression(body, src, filePath, analysis, currentReceiverType, varTypes)...)
 }
 
 func (p *RustParser) walkForReturnSources(node *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string, sources *[]SourceNode) {
@@ -315,6 +312,9 @@ func (p *RustParser) walkForReturnSources(node *sitter.Node, src []byte, filePat
 		if expr := rustReturnExpressionNode(node); expr != nil {
 			*sources = append(*sources, p.traceRustReturnExpression(expr, src, filePath, analysis, currentReceiverType, varTypes)...)
 		}
+		return
+	}
+	if node.Type() == "function_item" || node.Type() == "closure_expression" {
 		return
 	}
 	for i := 0; i < int(node.ChildCount()); i++ {

--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -12,6 +12,11 @@ import (
 	"github.com/smacker/go-tree-sitter/rust"
 )
 
+const (
+	rustNodeCallExpression      = "call_expression"
+	rustNodeExpressionStatement = "expression_statement"
+)
+
 // RustParser extracts function declarations, calls, and imports from Rust source files
 // using tree-sitter for fast, accurate parsing.
 type RustParser struct {
@@ -287,9 +292,91 @@ func (p *RustParser) parseFunctionItem(node *sitter.Node, src []byte, filePath, 
 	if body != nil {
 		varTypes := collectRustVarTypes(paramsNode, body, src)
 		decl.Calls = p.extractCalls(body, src, filePath, analysis, typeName, varTypes)
+		decl.ReturnSources = p.extractReturnSources(body, src, filePath, analysis, typeName, varTypes)
 	}
 
 	return decl
+}
+
+func (p *RustParser) extractReturnSources(body *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string) []SourceNode {
+	var sources []SourceNode
+	p.walkForReturnSources(body, src, filePath, analysis, currentReceiverType, varTypes, &sources)
+	if len(sources) > 0 {
+		return sources
+	}
+	return p.traceRustTailExpression(body, src, filePath, analysis, currentReceiverType, varTypes)
+}
+
+func (p *RustParser) walkForReturnSources(node *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string, sources *[]SourceNode) {
+	if node == nil {
+		return
+	}
+	if node.Type() == "return_expression" {
+		if expr := rustReturnExpressionNode(node); expr != nil {
+			*sources = append(*sources, p.traceRustReturnExpression(expr, src, filePath, analysis, currentReceiverType, varTypes)...)
+		}
+		return
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkForReturnSources(node.Child(i), src, filePath, analysis, currentReceiverType, varTypes, sources)
+	}
+}
+
+func rustReturnExpressionNode(node *sitter.Node) *sitter.Node {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		child := node.Child(i)
+		if child.IsNamed() && child.Type() != "return" {
+			return child
+		}
+	}
+	return nil
+}
+
+func (p *RustParser) traceRustTailExpression(body *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string) []SourceNode {
+	if body == nil || body.Type() != goNodeBlock {
+		return nil
+	}
+	for i := int(body.NamedChildCount()) - 1; i >= 0; i-- {
+		child := body.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if child.Type() == rustNodeExpressionStatement && child.NamedChildCount() == 1 && !strings.HasSuffix(strings.TrimSpace(child.Content(src)), ";") {
+			return p.traceRustReturnExpression(child.NamedChild(0), src, filePath, analysis, currentReceiverType, varTypes)
+		}
+		if child.Type() != rustNodeExpressionStatement {
+			return p.traceRustReturnExpression(child, src, filePath, analysis, currentReceiverType, varTypes)
+		}
+		return nil
+	}
+	return nil
+}
+
+func (p *RustParser) traceRustReturnExpression(node *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string) []SourceNode {
+	if node == nil {
+		return nil
+	}
+	switch node.Type() {
+	case rustNodeCallExpression:
+		call := p.parseCallExpr(node, src, filePath, analysis, currentReceiverType, varTypes)
+		if call == nil {
+			return nil
+		}
+		return []SourceNode{{
+			Type:       "CALL_RESULT",
+			Value:      strings.TrimSpace(node.Content(src)),
+			CallTarget: &call.Callee,
+		}}
+	case goNodeIdentifier:
+		name := node.Content(src)
+		return []SourceNode{{
+			Type:         "VARIABLE",
+			Name:         name,
+			DeclaredType: varTypes[name],
+			Location:     &SourceLocation{FilePath: filePath, Line: int(node.StartPoint().Row) + 1},
+		}}
+	}
+	return nil
 }
 
 // processImplBlock processes an impl block, extracting the type name
@@ -357,7 +444,7 @@ func (p *RustParser) extractCalls(body *sitter.Node, src []byte, filePath string
 }
 
 func (p *RustParser) walkForCalls(node *sitter.Node, src []byte, filePath string, analysis *FileAnalysis, currentReceiverType string, varTypes map[string]string, calls *[]FunctionCall) {
-	if node.Type() == "call_expression" {
+	if node.Type() == rustNodeCallExpression {
 		if call := p.parseCallExpr(node, src, filePath, analysis, currentReceiverType, varTypes); call != nil {
 			*calls = append(*calls, *call)
 		}

--- a/internal/callgraph/rust_parser_extra_test.go
+++ b/internal/callgraph/rust_parser_extra_test.go
@@ -100,3 +100,27 @@ fn bare() { return; }`)
 		}
 	}
 }
+
+func TestRustParser_ReturnSources_RespectFunctionScope(t *testing.T) {
+	fns := parseRustInline(t, `fn mixed(flag: bool, early: Key, tail: Key) -> Key {
+    if flag { return early; }
+    tail
+}
+fn outer(real: Key, wrong: Key) -> Key {
+    let closure = || { return wrong; };
+    fn nested(wrong: Key) -> Key { return wrong; }
+    let _ = closure;
+    let _ = nested;
+    return real;
+}`)
+
+	mixed := rustFunctionByName(t, fns, "mixed")
+	if len(mixed.ReturnSources) != 2 || mixed.ReturnSources[0].Name != "early" || mixed.ReturnSources[1].Name != "tail" {
+		t.Fatalf("mixed ReturnSources = %#v, want early and tail", mixed.ReturnSources)
+	}
+
+	outer := rustFunctionByName(t, fns, "outer")
+	if len(outer.ReturnSources) != 1 || outer.ReturnSources[0].Name != "real" {
+		t.Fatalf("outer ReturnSources = %#v, want only real", outer.ReturnSources)
+	}
+}

--- a/internal/callgraph/rust_parser_extra_test.go
+++ b/internal/callgraph/rust_parser_extra_test.go
@@ -31,3 +31,72 @@ func TestRustParser_ParseFile_ModuleScopedFunctionUsesPackageNotType(t *testing.
 		t.Fatalf("unexpected scoped call callee: %#v", call.Callee)
 	}
 }
+
+func parseRustInline(t *testing.T, src string) []FunctionDecl {
+	t.Helper()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "lib.rs")
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	analyses, err := NewRustParser().ParseDirectory(dir, "mycrate")
+	if err != nil {
+		t.Fatalf("ParseDirectory: %v", err)
+	}
+	if len(analyses) != 1 {
+		t.Fatalf("expected 1 analysis, got %d", len(analyses))
+	}
+	return analyses[0].Functions
+}
+
+func rustFunctionByName(t *testing.T, fns []FunctionDecl, name string) *FunctionDecl {
+	t.Helper()
+	for i := range fns {
+		if fns[i].ID.Name == name {
+			return &fns[i]
+		}
+	}
+	t.Fatalf("function %q not found in %#v", name, fns)
+	return nil
+}
+
+func TestRustParser_ReturnIdentifier_PopulatesReturnSources(t *testing.T) {
+	fns := parseRustInline(t, `fn direct(key: Key) -> Key { return key; }`)
+	fn := rustFunctionByName(t, fns, "direct")
+	if len(fn.ReturnSources) != 1 {
+		t.Fatalf("expected 1 return source, got %#v", fn.ReturnSources)
+	}
+	rs := fn.ReturnSources[0]
+	if rs.Type != "VARIABLE" || rs.Name != "key" || rs.DeclaredType != "Key" {
+		t.Fatalf("unexpected return source: %#v", rs)
+	}
+}
+
+func TestRustParser_ReturnFactory_PopulatesCallTarget(t *testing.T) {
+	fns := parseRustInline(t, `fn factory(unbound: UnboundKey) -> LessSafeKey {
+    ring::aead::LessSafeKey::new(unbound)
+}`)
+	fn := rustFunctionByName(t, fns, "factory")
+	if len(fn.ReturnSources) != 1 {
+		t.Fatalf("expected 1 return source, got %#v", fn.ReturnSources)
+	}
+	rs := fn.ReturnSources[0]
+	if rs.Type != "CALL_RESULT" || rs.CallTarget == nil {
+		t.Fatalf("expected call-result return source with target, got %#v", rs)
+	}
+	want := FunctionID{Package: "ring::aead", Type: "LessSafeKey", Name: "new"}
+	if *rs.CallTarget != want {
+		t.Fatalf("CallTarget = %#v, want %#v", *rs.CallTarget, want)
+	}
+}
+
+func TestRustParser_UnknownAndBareReturn_NoReturnSources(t *testing.T) {
+	fns := parseRustInline(t, `fn unknown(flag: bool) -> Key { if flag { key } else { other } }
+fn bare() { return; }`)
+	for _, name := range []string{"unknown", "bare"} {
+		fn := rustFunctionByName(t, fns, name)
+		if len(fn.ReturnSources) != 0 {
+			t.Fatalf("%s: expected no return sources, got %#v", name, fn.ReturnSources)
+		}
+	}
+}


### PR DESCRIPTION
Closes #64

## Summary
- Populate Rust `FunctionDecl.ReturnSources` for mapped return expressions.
- Cover explicit identifier returns, implicit factory/tail returns, and unknown/bare-return cases.
- Pin the Rust call target convention for `ring::aead::LessSafeKey::new`.

## Changes
| File | Change |
|------|--------|
| `internal/callgraph/rust_parser.go` | Extracts Rust return-source nodes from explicit returns and implicit tail expressions. |
| `internal/callgraph/rust_parser_extra_test.go` | Adds focused parser tests for direct returns, factory returns, and unmapped returns. |

## Test plan
- [x] `GOCACHE=/tmp/crypto-finder-go-build GOPATH=/tmp/crypto-finder-gopath go test ./internal/callgraph/...`

## Checklist
- [x] Linked an agent-ready issue
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Rust code analysis to detect return-value sources in functions, including returned variables and values created by calls.
  * Better handling of tail expressions and explicit returns when identifying what a function returns.
* **Bug Fixes**
  * Functions with bare `return` or unclear return paths now avoid reporting misleading return-source data.
  * Added coverage to verify return-source detection across common Rust return patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->