### PR TITLE
feat(callgraph): add Go parser return sources

### DIFF
--- a/internal/callgraph/go_parser.go
+++ b/internal/callgraph/go_parser.go
@@ -332,6 +332,9 @@ func (p *GoParser) walkGoReturnSources(
 	varTypes map[string]string,
 	sources *[]SourceNode,
 ) {
+	if node.Type() == "func_literal" {
+		return
+	}
 	if node.Type() == goNodeReturnStatement {
 		p.appendGoReturnSources(node, src, filePath, analysis, currentReceiverType, currentReceiverVar, varTypes, sources)
 		return

--- a/internal/callgraph/go_parser.go
+++ b/internal/callgraph/go_parser.go
@@ -26,6 +26,9 @@ const (
 	goNodeTypeIdentifier  = "type_identifier"
 	goNodeParameterDecl   = "parameter_declaration"
 	goNodeResult          = "result"
+	goNodeReturnStatement = "return_statement"
+	goNodeExpressionList  = "expression_list"
+	goNodeCallExpression  = "call_expression"
 )
 
 // NewGoParser creates a new Go source parser backed by tree-sitter.
@@ -243,7 +246,9 @@ func (p *GoParser) parseFunctionDecl(node *sitter.Node, src []byte, filePath, pa
 	decl.ReturnType = p.extractReturnType(result, src)
 
 	if body != nil {
-		decl.Calls = p.extractCalls(body, src, filePath, analysis, "", "", p.collectGoVarTypes(params, body, src))
+		varTypes := p.collectGoVarTypes(params, body, src)
+		decl.Calls = p.extractCalls(body, src, filePath, analysis, "", "", varTypes)
+		decl.ReturnSources = p.extractReturnSources(body, src, filePath, analysis, "", "", varTypes)
 	}
 
 	return decl
@@ -295,10 +300,98 @@ func (p *GoParser) parseMethodDecl(node *sitter.Node, src []byte, filePath, pack
 	decl.ReturnType = p.extractReturnType(result, src)
 
 	if body != nil {
-		decl.Calls = p.extractCalls(body, src, filePath, analysis, receiver, receiverVar, p.collectGoVarTypes(params, body, src))
+		varTypes := p.collectGoVarTypes(params, body, src)
+		decl.Calls = p.extractCalls(body, src, filePath, analysis, receiver, receiverVar, varTypes)
+		decl.ReturnSources = p.extractReturnSources(body, src, filePath, analysis, receiver, receiverVar, varTypes)
 	}
 
 	return decl
+}
+
+func (p *GoParser) extractReturnSources(
+	body *sitter.Node,
+	src []byte,
+	filePath string,
+	analysis *FileAnalysis,
+	currentReceiverType string,
+	currentReceiverVar string,
+	varTypes map[string]string,
+) []SourceNode {
+	var sources []SourceNode
+	p.walkGoReturnSources(body, src, filePath, analysis, currentReceiverType, currentReceiverVar, varTypes, &sources)
+	return sources
+}
+
+func (p *GoParser) walkGoReturnSources(
+	node *sitter.Node,
+	src []byte,
+	filePath string,
+	analysis *FileAnalysis,
+	currentReceiverType string,
+	currentReceiverVar string,
+	varTypes map[string]string,
+	sources *[]SourceNode,
+) {
+	if node.Type() == goNodeReturnStatement {
+		p.appendGoReturnSources(node, src, filePath, analysis, currentReceiverType, currentReceiverVar, varTypes, sources)
+		return
+	}
+
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkGoReturnSources(node.Child(i), src, filePath, analysis, currentReceiverType, currentReceiverVar, varTypes, sources)
+	}
+}
+
+func (p *GoParser) appendGoReturnSources(
+	returnNode *sitter.Node,
+	src []byte,
+	filePath string,
+	analysis *FileAnalysis,
+	currentReceiverType string,
+	currentReceiverVar string,
+	varTypes map[string]string,
+	sources *[]SourceNode,
+) {
+	for i := 0; i < int(returnNode.ChildCount()); i++ {
+		child := returnNode.Child(i)
+		if child.Type() != goNodeExpressionList {
+			continue
+		}
+		for j := 0; j < int(child.ChildCount()); j++ {
+			if source, ok := p.goReturnSource(child.Child(j), src, filePath, analysis, currentReceiverType, currentReceiverVar, varTypes); ok {
+				*sources = append(*sources, source)
+			}
+		}
+	}
+}
+
+func (p *GoParser) goReturnSource(
+	expr *sitter.Node,
+	src []byte,
+	filePath string,
+	analysis *FileAnalysis,
+	currentReceiverType string,
+	currentReceiverVar string,
+	varTypes map[string]string,
+) (SourceNode, bool) {
+	location := &SourceLocation{FilePath: filePath, Line: int(expr.StartPoint().Row) + 1}
+	switch expr.Type() {
+	case goNodeCallExpression:
+		call := p.parseCallExpr(expr, src, filePath, analysis, currentReceiverType, currentReceiverVar, varTypes)
+		if call == nil {
+			return SourceNode{}, false
+		}
+		callee := call.Callee
+		return SourceNode{Type: "CALL_RESULT", CallTarget: &callee, Location: location}, true
+	case goNodeIdentifier:
+		return SourceNode{Type: "VARIABLE", Name: expr.Content(src), Location: location}, true
+	case "selector_expression":
+		return SourceNode{Type: "FIELD", Name: expr.Content(src), Location: location}, true
+	case "int_literal", "float_literal", "imaginary_literal", "rune_literal", "raw_string_literal", "interpreted_string_literal", javaNodeBoolLiteralTrue, javaNodeBoolLiteralFalse, "nil":
+		return SourceNode{Type: "VALUE", Value: expr.Content(src), Location: location}, true
+	}
+
+	return SourceNode{}, false
 }
 
 func (p *GoParser) extractReceiverInfo(paramList *sitter.Node, src []byte) (string, string) {

--- a/internal/callgraph/go_parser_test.go
+++ b/internal/callgraph/go_parser_test.go
@@ -138,3 +138,85 @@ func TestGoParser_ParseDirectoryErrors(t *testing.T) {
 		t.Fatal("expected ParseDirectory error for missing directory")
 	}
 }
+
+func TestGoParser_ReturnSources(t *testing.T) {
+	p := NewGoParser()
+	dir := t.TempDir()
+
+	src := `package mypkg
+
+import (
+	alias "crypto/aes"
+	"crypto/cipher"
+)
+
+func direct(value cipher.Block) cipher.Block {
+	return value
+}
+
+func factory(key []byte) (cipher.Block, error) {
+	return alias.NewCipher(key)
+}
+
+func unknown() any {
+	return nil
+}
+
+func bare() {
+	return
+}
+`
+	path := filepath.Join(dir, "returns.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	analysis, err := p.ParseFile(path, "example.com/project/mypkg")
+	if err != nil {
+		t.Fatalf("ParseFile error: %v", err)
+	}
+
+	direct := findGoFunction(t, analysis, "direct")
+	if len(direct.ReturnSources) != 1 {
+		t.Fatalf("direct ReturnSources len = %d, want 1", len(direct.ReturnSources))
+	}
+	if got := direct.ReturnSources[0]; got.Type != "VARIABLE" || got.Name != "value" {
+		t.Fatalf("direct ReturnSources[0] = %+v, want VARIABLE value", got)
+	}
+
+	factory := findGoFunction(t, analysis, "factory")
+	if len(factory.ReturnSources) != 1 {
+		t.Fatalf("factory ReturnSources len = %d, want 1", len(factory.ReturnSources))
+	}
+	callTarget := factory.ReturnSources[0].CallTarget
+	if factory.ReturnSources[0].Type != "CALL_RESULT" || callTarget == nil {
+		t.Fatalf("factory ReturnSources[0] = %+v, want CALL_RESULT", factory.ReturnSources[0])
+	}
+	if callTarget.Package != "crypto/aes" || callTarget.Name != "NewCipher" {
+		t.Fatalf("factory call target = %+v, want crypto/aes.NewCipher", *callTarget)
+	}
+
+	unknown := findGoFunction(t, analysis, "unknown")
+	if len(unknown.ReturnSources) != 1 {
+		t.Fatalf("unknown ReturnSources len = %d, want 1", len(unknown.ReturnSources))
+	}
+	if got := unknown.ReturnSources[0]; got.Type != "VALUE" || got.Value != "nil" {
+		t.Fatalf("unknown ReturnSources[0] = %+v, want VALUE nil", got)
+	}
+
+	bare := findGoFunction(t, analysis, "bare")
+	if len(bare.ReturnSources) != 0 {
+		t.Fatalf("bare ReturnSources len = %d, want 0", len(bare.ReturnSources))
+	}
+}
+
+func findGoFunction(t *testing.T, analysis *FileAnalysis, name string) *FunctionDecl {
+	t.Helper()
+	for i := range analysis.Functions {
+		if analysis.Functions[i].ID.Name == name {
+			return &analysis.Functions[i]
+		}
+	}
+	t.Fatalf("missing function %q", name)
+	return nil
+}

--- a/internal/callgraph/go_parser_test.go
+++ b/internal/callgraph/go_parser_test.go
@@ -165,6 +165,12 @@ func unknown() any {
 func bare() {
 	return
 }
+
+func withClosure(value cipher.Block, wrong cipher.Block) cipher.Block {
+	closure := func() cipher.Block { return wrong }
+	_ = closure
+	return value
+}
 `
 	path := filepath.Join(dir, "returns.go")
 	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
@@ -207,6 +213,11 @@ func bare() {
 	bare := findGoFunction(t, analysis, "bare")
 	if len(bare.ReturnSources) != 0 {
 		t.Fatalf("bare ReturnSources len = %d, want 0", len(bare.ReturnSources))
+	}
+
+	withClosure := findGoFunction(t, analysis, "withClosure")
+	if len(withClosure.ReturnSources) != 1 || withClosure.ReturnSources[0].Name != "value" {
+		t.Fatalf("withClosure ReturnSources = %#v, want only value", withClosure.ReturnSources)
 	}
 }
 


### PR DESCRIPTION
Closes #65

## Summary
- Populates Go `FunctionDecl.ReturnSources` from explicit `return` statements.
- Resolves returned call expressions through the existing Go call parser, preserving the Go FQN convention such as `crypto/aes.NewCipher`.
- Covers direct variable returns, factory-style call returns, literal `nil`, and bare returns.

## Changes
| File | Change |
|------|--------|
| `internal/callgraph/go_parser.go` | Adds return-source extraction for Go parser declarations. |
| `internal/callgraph/go_parser_test.go` | Adds focused parser coverage for Go return-source cases. |

## Test plan
- [x] `GOCACHE=/tmp/crypto-finder-go-build GOPATH=/tmp/crypto-finder-gopath go test ./internal/callgraph/...`

## Notes
- No Go contract resolver wiring or `go/*.yaml` contracts, those stay out of scope for #65.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for analyzing values returned from functions and methods, including direct variables, function calls, selectors, and literal values.
  * Improved handling of method context so return analysis can better resolve receiver-related information.

* **Bug Fixes**
  * Return statements with empty outputs are now handled cleanly.
  * Returned call results are more accurately resolved to their underlying targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->