### PR TITLE
perf: reduce graph export and dependency scan memory

### DIFF
--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -92,9 +92,10 @@ func (b *Builder) PackageSeparator() string {
 func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) (*CallGraph, error) {
 	buildStart := time.Now()
 	graph := &CallGraph{
-		Functions:       make(map[string]*FunctionDecl),
-		Callers:         make(map[string][]string),
-		EdgeResolutions: make(map[string]EdgeResolution),
+		Functions:             make(map[string]*FunctionDecl),
+		Callers:               make(map[string][]string),
+		EdgeResolutions:       make(map[string]EdgeResolution),
+		EdgeResolutionsByPair: make(map[string][]EdgeResolution),
 	}
 
 	// Phase 1: Parse source files only for packages that need full analysis
@@ -377,12 +378,43 @@ func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind Ed
 		MethodName:   method,
 		Arity:        arity,
 		CallSite:     callSite,
+		callerKey:    callerKey,
+		calleeKey:    calleeKey,
 	}
 	key := EdgeResolutionKey(callerKey, calleeKey, resolution)
-	if existing, ok := graph.EdgeResolutions[key]; ok && edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
+	if existing, ok := graph.EdgeResolutions[key]; ok {
+		if edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
+			return
+		}
+		graph.EdgeResolutions[key] = resolution
+		upsertEdgeResolutionByPair(graph, callerKey, calleeKey, resolution)
 		return
 	}
 	graph.EdgeResolutions[key] = resolution
+	upsertEdgeResolutionByPair(graph, callerKey, calleeKey, resolution)
+}
+
+func upsertEdgeResolutionByPair(graph *CallGraph, callerKey, calleeKey string, resolution EdgeResolution) {
+	if graph.EdgeResolutionsByPair == nil {
+		graph.EdgeResolutionsByPair = make(map[string][]EdgeResolution)
+	}
+	pairKey := EdgeResolutionPairKey(callerKey, calleeKey)
+	values := graph.EdgeResolutionsByPair[pairKey]
+	for i := range values {
+		if sameEdgeResolutionVariant(values[i], resolution) {
+			values[i] = resolution
+			graph.EdgeResolutionsByPair[pairKey] = values
+			return
+		}
+	}
+	graph.EdgeResolutionsByPair[pairKey] = append(values, resolution)
+}
+
+func sameEdgeResolutionVariant(a, b EdgeResolution) bool {
+	return a.CallSite == b.CallSite &&
+		a.DeclaredType == b.DeclaredType &&
+		a.MethodName == b.MethodName &&
+		a.Arity == b.Arity
 }
 
 func indexMethodsByName(graph *CallGraph) map[string][]*FunctionDecl {
@@ -1208,24 +1240,136 @@ func resolveQualifiedPassthroughGroup(graph *CallGraph, qg *qualifiedPassthrough
 // identity so a group here has >1 entries exactly when the stitcher would judge
 // that call site ambiguous.
 func groupAmbiguousDispatchEdges(graph *CallGraph) map[dispatchAmbiguousGroupKey][]edgeResolutionEntry {
-	groups := make(map[dispatchAmbiguousGroupKey][]edgeResolutionEntry)
+	candidateSites, callersByID := passthroughCandidateCallSites(graph)
+	if len(candidateSites) == 0 {
+		return nil
+	}
+
+	edgesByCaller := interfaceDispatchEdgesByCaller(graph)
+	compactGroups := make(map[compactDispatchGroupKey][]edgeResolutionEntry)
+	for callerKey, candidate := range candidateSites {
+		entries := edgesByCaller[callerKey]
+		if len(entries) < 2 {
+			continue
+		}
+		for i := range entries {
+			entry := entries[i]
+			res := entry.resolution
+			if !containsDispatchCallSite(candidate.sites, res.CallSite, res.MethodName, res.Arity) {
+				continue
+			}
+			gk := compactDispatchGroupKey{CallerID: candidate.id, CallSite: res.CallSite, MethodName: res.MethodName, Arity: res.Arity}
+			compactGroups[gk] = append(compactGroups[gk], entry)
+		}
+	}
+
+	groups := make(map[dispatchAmbiguousGroupKey][]edgeResolutionEntry, len(compactGroups))
+	for gk, entries := range compactGroups {
+		if len(entries) < 2 {
+			continue
+		}
+		groups[dispatchAmbiguousGroupKey{
+			Caller:     callersByID[gk.CallerID],
+			CallSite:   gk.CallSite,
+			MethodName: gk.MethodName,
+			Arity:      gk.Arity,
+		}] = entries
+	}
+	return groups
+}
+
+func interfaceDispatchEdgesByCaller(graph *CallGraph) map[string][]edgeResolutionEntry {
+	edgesByCaller := make(map[string][]edgeResolutionEntry)
 	for key, res := range graph.EdgeResolutions {
 		if res.Kind != EdgeKindInterfaceDispatch {
 			continue
 		}
-		callerKey, calleeKey, ok := splitEdgeResolutionKey(key)
-		if !ok {
+		callerKey, calleeKey := res.callerKey, res.calleeKey
+		if callerKey == "" || calleeKey == "" {
+			var ok bool
+			callerKey, calleeKey, ok = splitEdgeResolutionKey(key)
+			if !ok {
+				continue
+			}
+		}
+		edgesByCaller[callerKey] = append(edgesByCaller[callerKey], edgeResolutionEntry{calleeKey: calleeKey, resolution: res})
+	}
+	return edgesByCaller
+}
+
+type dispatchCallSiteKey struct {
+	CallSite   int
+	MethodName string
+	Arity      int
+}
+
+type compactDispatchGroupKey struct {
+	CallerID   int
+	CallSite   int
+	MethodName string
+	Arity      int
+}
+
+type passthroughCandidateCaller struct {
+	id    int
+	sites []dispatchCallSiteKey
+}
+
+func passthroughCandidateCallSites(graph *CallGraph) (map[string]passthroughCandidateCaller, []string) {
+	candidates := make(map[string]passthroughCandidateCaller)
+	callersByID := make([]string, 0)
+	for callerKey, fn := range graph.Functions {
+		sites := passthroughCandidateSites(fn)
+		if len(sites) == 0 {
 			continue
 		}
-		gk := dispatchAmbiguousGroupKey{Caller: callerKey, CallSite: res.CallSite, MethodName: res.MethodName, Arity: res.Arity}
-		groups[gk] = append(groups[gk], edgeResolutionEntry{calleeKey: calleeKey, resolution: res})
+		candidates[callerKey] = passthroughCandidateCaller{id: len(callersByID), sites: sites}
+		callersByID = append(callersByID, callerKey)
 	}
-	for gk, entries := range groups {
-		if len(entries) < 2 {
-			delete(groups, gk)
+	return candidates, callersByID
+}
+
+func passthroughCandidateSites(fn *FunctionDecl) []dispatchCallSiteKey {
+	if fn == nil {
+		return nil
+	}
+	sites := make([]dispatchCallSiteKey, 0, len(fn.Calls))
+	for i := range fn.Calls {
+		call := &fn.Calls[i]
+		if !canPassthroughReceiver(fn, call) {
+			continue
+		}
+		method, arity := methodBaseArity(call.Callee.Name)
+		site := dispatchCallSiteKey{CallSite: call.Line, MethodName: method, Arity: arity}
+		if !containsDispatchCallSite(sites, site.CallSite, site.MethodName, site.Arity) {
+			sites = append(sites, site)
 		}
 	}
-	return groups
+	return sites
+}
+
+func containsDispatchCallSite(sites []dispatchCallSiteKey, callSite int, methodName string, arity int) bool {
+	for i := range sites {
+		if sites[i].CallSite == callSite && sites[i].MethodName == methodName && sites[i].Arity == arity {
+			return true
+		}
+	}
+	return false
+}
+
+func canPassthroughReceiver(fn *FunctionDecl, call *FunctionCall) bool {
+	if call.ReceiverVar == "" {
+		return true
+	}
+	if len(fn.Calls) != 1 {
+		return false
+	}
+	for i := range fn.Parameters {
+		if fn.Parameters[i].Name != "" && fn.Parameters[i].Name == call.ReceiverVar {
+			return true
+		}
+	}
+	return false
 }
 
 // edgeResolutionEntry pairs one EdgeResolutions map entry with its parsed
@@ -1396,13 +1540,14 @@ func findCallAtSite(fn *FunctionDecl, gk dispatchAmbiguousGroupKey) (FunctionCal
 func candidateOwnersByType(entries []edgeResolutionEntry) map[string][]string {
 	owners := make(map[string][]string, len(entries))
 	seen := make(map[string]bool, len(entries))
-	for _, e := range entries {
-		id, err := ParseFunctionID(e.calleeKey)
-		if err != nil || id.Type == "" || seen[e.calleeKey] {
+	for i := range entries {
+		calleeKey := entries[i].calleeKey
+		id, err := ParseFunctionID(calleeKey)
+		if err != nil || id.Type == "" || seen[calleeKey] {
 			continue
 		}
-		seen[e.calleeKey] = true
-		owners[id.Type] = append(owners[id.Type], e.calleeKey)
+		seen[calleeKey] = true
+		owners[id.Type] = append(owners[id.Type], calleeKey)
 	}
 	return owners
 }
@@ -1695,6 +1840,7 @@ func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, li
 	}
 	res.ResolvedReceiverType = resolvedType
 	graph.EdgeResolutions[key] = res
+	upsertEdgeResolutionByPair(graph, callerKey, targetKey, res)
 	receiverIdx[resolvedReceiverIndexKey(callerKey, targetKey)] = resolvedReceiverEntry{resolvedType: resolvedType, line: line}
 }
 

--- a/internal/callgraph/parameter_passthrough_dispatch_test.go
+++ b/internal/callgraph/parameter_passthrough_dispatch_test.go
@@ -238,3 +238,48 @@ func TestResolveParameterPassthroughDispatch_ConvergesToZero(t *testing.T) {
 		t.Fatalf("second resolveParameterPassthroughDispatch pass resolved %d, want 0 (fixpoint must not re-count existing bypass edges)", n)
 	}
 }
+
+func TestGroupAmbiguousDispatchEdges_IgnoresNonPassthroughCallers(t *testing.T) {
+	passthroughID := FunctionID{Package: "com.acme", Type: "Builder", Name: "with#1"}
+	nonPassthroughID := FunctionID{Package: "com.acme", Type: "Builder", Name: "helper#0"}
+	ifaceID := FunctionID{Package: "com.acme", Type: "Sink", Name: "run#0"}
+	implAID := FunctionID{Package: "com.acme", Type: "SinkImplA", Name: "run#0"}
+	implBID := FunctionID{Package: "com.acme", Type: "SinkImplB", Name: "run#0"}
+
+	graph := &CallGraph{
+		Functions: map[string]*FunctionDecl{
+			passthroughID.String(): {
+				ID:         passthroughID,
+				Parameters: []FunctionParameter{{Type: "Sink", Name: "s"}},
+				Calls:      []FunctionCall{{Callee: ifaceID, ReceiverVar: "s", Line: 10}},
+			},
+			nonPassthroughID.String(): {
+				ID:    nonPassthroughID,
+				Calls: []FunctionCall{{Callee: ifaceID, ReceiverVar: "local", Line: 20}},
+			},
+		},
+		EdgeResolutions: map[string]EdgeResolution{},
+	}
+
+	for _, caller := range []FunctionID{passthroughID, nonPassthroughID} {
+		callSite := 20
+		if caller == passthroughID {
+			callSite = 10
+		}
+		for _, callee := range []FunctionID{implAID, implBID} {
+			res := EdgeResolution{Kind: EdgeKindInterfaceDispatch, MethodName: "run", Arity: 0, CallSite: callSite}
+			graph.EdgeResolutions[EdgeResolutionKey(caller.String(), callee.String(), res)] = res
+		}
+	}
+
+	groups := groupAmbiguousDispatchEdges(graph)
+	if len(groups) != 1 {
+		t.Fatalf("groups len = %d, want 1: %#v", len(groups), groups)
+	}
+	if _, ok := groups[dispatchAmbiguousGroupKey{Caller: passthroughID.String(), CallSite: 10, MethodName: "run", Arity: 0}]; !ok {
+		t.Fatalf("expected passthrough group, got %#v", groups)
+	}
+	if _, ok := groups[dispatchAmbiguousGroupKey{Caller: nonPassthroughID.String(), CallSite: 20, MethodName: "run", Arity: 0}]; ok {
+		t.Fatalf("non-passthrough caller should not be grouped: %#v", groups)
+	}
+}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -306,6 +306,10 @@ type CallGraph struct {
 	// use this to refuse to present over-broad name/arity dispatch guesses as
 	// typed reachability proof.
 	EdgeResolutions map[string]EdgeResolution
+	// EdgeResolutionsByPair mirrors EdgeResolutions by caller/callee pair so
+	// export paths can avoid rebuilding that index for very large dispatch
+	// graphs.
+	EdgeResolutionsByPair map[string][]EdgeResolution
 }
 
 // EdgeKind classifies how confidently a caller->callee edge was resolved.
@@ -354,6 +358,8 @@ type EdgeResolution struct {
 	MethodName   string // base method name (no arity decoration)
 	Arity        int
 	CallSite     int // source line of the call expression
+	callerKey    string
+	calleeKey    string
 
 	// ResolvedReceiverType is the concrete receiver type resolveParameterPassthroughDispatch
 	// determined for THIS specific dispatch edge, when the call site is a
@@ -380,6 +386,27 @@ func EdgeResolutionKey(callerKey, calleeKey string, resolution EdgeResolution) s
 // variants for one caller->callee pair.
 func EdgeResolutionKeyPrefix(callerKey, calleeKey string) string {
 	return callerKey + "\x00" + calleeKey + "\x00"
+}
+
+// EdgeResolutionPairKey is the stable key shared by all resolution variants
+// for one caller->callee pair.
+func EdgeResolutionPairKey(callerKey, calleeKey string) string {
+	return callerKey + "\x00" + calleeKey
+}
+
+// EdgeResolutionEndpoints returns the caller/callee pair for a stored edge
+// resolution. Values recorded by this package carry endpoints directly so
+// large export paths do not need to repeatedly split the map key; hand-built
+// tests or older in-memory fixtures still fall back to parsing the key.
+func EdgeResolutionEndpoints(key string, resolution EdgeResolution) (callerKey, calleeKey string, ok bool) {
+	if resolution.callerKey != "" && resolution.calleeKey != "" {
+		return resolution.callerKey, resolution.calleeKey, true
+	}
+	parts := strings.SplitN(key, "\x00", 3)
+	if len(parts) < 3 {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 // functionArity parses the "#<n>" arity suffix from a decorated function name.

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -173,7 +173,7 @@ func init() {
 			"Duplicates are removed automatically.")
 	scanCmd.Flags().StringVar(&scanDepEcosystem, "dep-ecosystem", "auto", "Dependency ecosystem: auto, go, java, python, rust")
 
-	scanCmd.Flags().IntVar(&scanDepWorkers, "dep-workers", 0, "Number of parallel dependency scan workers (default: half of CPU cores, max 8)")
+	scanCmd.Flags().IntVar(&scanDepWorkers, "dep-workers", 0, "Number of parallel dependency scan workers (default: half of CPU cores, max 8; Java max 2)")
 	scanCmd.Flags().StringVar(&scanFindingsCache, "findings-cache", "", fmt.Sprintf("FindingsCache backend: %v (default: %s; can also be set via SCANOSS_FINDINGS_CACHE_BACKEND)", AllowedFindingsCacheBackends, config.DefaultFindingsCacheBackend))
 	scanCmd.Flags().StringVar(&scanExportCallgraph, "export-callgraph", "", "Export the crypto-scoped call graph to a file")
 	scanCmd.Flags().StringVar(&scanExportCgFormat, "export-callgraph-format", "json", "Call graph export format (only json is supported)")

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -59,11 +59,12 @@ const (
 	ecosystemJava         = "java"
 
 	findingsCacheBackendDisk     = "disk"
+	findingsCacheBackendNone     = "none"
 	findingsCacheBackendPostgres = "postgres"
 )
 
 // AllowedFindingsCacheBackends lists the FindingsCache backends supported by the tool.
-var AllowedFindingsCacheBackends = []string{findingsCacheBackendDisk, findingsCacheBackendPostgres}
+var AllowedFindingsCacheBackends = []string{findingsCacheBackendDisk, findingsCacheBackendNone, findingsCacheBackendPostgres}
 
 // AllowedScanners lists the scanners supported by the tool.
 // TODO: We'll support more scanners in the future (e.g., cbom-toolkit).
@@ -855,6 +856,9 @@ func newFindingsCache(ctx context.Context, cfg *config.Config) (engine.FindingsC
 			return nil, noop, nil
 		}
 		return fc, noop, nil
+
+	case findingsCacheBackendNone:
+		return nil, noop, nil
 
 	case findingsCacheBackendPostgres:
 		dsn := cfg.GetFindingsCacheDSN()

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -17,17 +17,36 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/scanoss/crypto-finder/internal/config"
 	"github.com/scanoss/crypto-finder/internal/engine"
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/internal/javaruntime"
 	scanutil "github.com/scanoss/crypto-finder/internal/scan"
 	"github.com/scanoss/crypto-finder/internal/scanner/semgrep"
 )
+
+func TestNewFindingsCache_NoneBackend(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := &config.Config{}
+	if err := cfg.Initialize(config.InitOptions{FindingsCacheBackend: findingsCacheBackendNone}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	cache, closeCache, err := newFindingsCache(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newFindingsCache: %v", err)
+	}
+	defer closeCache()
+	if cache != nil {
+		t.Fatal("expected nil cache for none backend")
+	}
+}
 
 func validateScanFlags(target string) error {
 	normalizedLanguages, err := scanutil.ValidateFlags(target, scanutil.ValidationOptions{

--- a/internal/dependency/maven_resolver.go
+++ b/internal/dependency/maven_resolver.go
@@ -28,6 +28,10 @@ const (
 	// internally; on top of that each invocation forks a JVM, so going beyond
 	// ~8 yields diminishing returns and wastes RAM.
 	sourceFallbackMaxWorkers = 8
+	// mavenDependencyTreeTimeout bounds best-effort graph metadata extraction.
+	// If tree extraction is slow or flaky, dependency scanning falls back to the
+	// old conservative all-dependencies callgraph input set.
+	mavenDependencyTreeTimeout = 2 * time.Minute
 )
 
 // pomProject represents the minimal pom.xml structure needed for resolution.
@@ -134,6 +138,8 @@ func (r *MavenResolver) Resolve(ctx context.Context, targetDir string) (*Resolve
 		return result, nil
 	}
 
+	r.populateDependencyGraph(ctx, targetDir, result, len(deps))
+
 	// Step 4: Download source JARs (best-effort)
 	cache, err := NewSourceCache()
 	if err != nil {
@@ -161,13 +167,6 @@ func (r *MavenResolver) Resolve(ctx context.Context, targetDir string) (*Resolve
 		withSources++
 	}
 
-	// Step 6 — skipped: `mvn dependency:tree` was used to populate
-	// result.VersionedGraph / result.Graph, but no consumer reads those
-	// fields today (engine/callgraph builds packages from depResults +
-	// resolver.WorkspaceMembers, not from the tree). For large transitive
-	// trees this call alone takes minutes. Re-enable behind a flag if a
-	// downstream consumer ever needs the graph.
-
 	log.Info().
 		Int("total", len(deps)).
 		Int("withSources", withSources).
@@ -188,6 +187,65 @@ func buildWorkspaceMembers(rootModule, targetDir string, modules []string) []Wor
 		})
 	}
 	return members
+}
+
+func (r *MavenResolver) populateDependencyGraph(ctx context.Context, targetDir string, result *ResolveResult, depCount int) {
+	if depCount < 2 {
+		return
+	}
+	graphCtx, cancel := context.WithTimeout(ctx, mavenDependencyTreeTimeout)
+	defer cancel()
+	versioned, err := r.listDependencyTree(graphCtx, targetDir)
+	if err != nil {
+		log.Debug().Err(err).Msg("Maven dependency tree unavailable; dependency callgraph pruning will fall back")
+		return
+	}
+	if len(versioned) == 0 {
+		return
+	}
+	result.VersionedGraph = versioned
+	result.Graph = legacyGraphFromVersioned(versioned)
+}
+
+func (r *MavenResolver) listDependencyTree(ctx context.Context, targetDir string) (map[string][]Ref, error) {
+	tmpFile, err := os.CreateTemp("", "mvn-tree-*.txt")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			log.Debug().Err(removeErr).Str("path", tmpPath).Msg("Failed to remove temporary file")
+		}
+	}()
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("close temp file: %w", err)
+	}
+
+	// #nosec G702 -- exec.CommandContext is used without a shell and with fixed arguments.
+	cmd := exec.CommandContext(ctx, "mvn", "dependency:tree",
+		"-DoutputFile="+tmpPath,
+		"-Dscope=compile",
+		"-DoutputType=text",
+		"--fail-never",
+	)
+	cmd.Dir = targetDir
+	if err := r.configureMavenCommand(cmd); err != nil {
+		return nil, err
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("mvn dependency:tree: %w stderr: %s", err, truncate(stderr.String(), 500))
+	}
+
+	// #nosec G703 -- tmpPath is created by os.CreateTemp in this function.
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("read Maven dependency tree output: %w", err)
+	}
+	return r.parseTreeOutput(string(data)), nil
 }
 
 func (r *MavenResolver) resolveWithFallbacks(

--- a/internal/dependency/maven_resolver_test.go
+++ b/internal/dependency/maven_resolver_test.go
@@ -358,17 +358,11 @@ exit 1
 		t.Fatalf("expected empty source directory for dependency without sources, got %q", withoutSources.Dir)
 	}
 
-	// Graph / VersionedGraph are intentionally not populated by Maven anymore:
-	// `mvn dependency:tree` was minutes of work whose output had no consumer.
-	// They exist on ResolveResult only because other resolvers (Gradle, Cargo)
-	// still produce them. If a Maven downstream consumer ever needs the graph,
-	// re-enable Step 6 in maven_resolver.go behind a flag and restore these
-	// assertions.
-	if len(result.Graph) != 0 {
-		t.Fatalf("expected Graph to be empty (Maven no longer runs dependency:tree), got %d entries", len(result.Graph))
+	if got := result.Graph["com.acme:app"]; len(got) != 2 {
+		t.Fatalf("Graph root children = %#v, want two dependencies", got)
 	}
-	if len(result.VersionedGraph) != 0 {
-		t.Fatalf("expected VersionedGraph to be empty, got %d entries", len(result.VersionedGraph))
+	if got := result.VersionedGraph["com.acme:app@1.0.0"]; len(got) != 2 {
+		t.Fatalf("VersionedGraph root children = %#v, want two dependencies", got)
 	}
 }
 

--- a/internal/engine/dependency_scanner.go
+++ b/internal/engine/dependency_scanner.go
@@ -564,11 +564,11 @@ func (ds *DependencyScanner) collectPackageSets(
 }
 
 func callGraphDependencySet(resolved *dependency.ResolveResult, depResults []depScanResult) map[string]bool {
-	if resolved == nil || len(resolved.Graph) == 0 {
-		return nil
-	}
 	targets := cryptoDependencyModules(depResults)
 	if len(targets) == 0 {
+		return map[string]bool{}
+	}
+	if resolved == nil || len(resolved.Graph) == 0 {
 		return nil
 	}
 	roots := dependencyGraphRoots(resolved)
@@ -603,6 +603,19 @@ func cryptoDependencyModules(depResults []depScanResult) map[string]bool {
 }
 
 func dependencyGraphRoots(resolved *dependency.ResolveResult) []string {
+	explicit := explicitDependencyGraphRoots(resolved)
+	for i := range explicit {
+		if _, ok := resolved.Graph[explicit[i]]; ok {
+			return explicit
+		}
+	}
+	if inferred := dependencyGraphSourceRoots(resolved.Graph); len(inferred) > 0 {
+		return inferred
+	}
+	return explicit
+}
+
+func explicitDependencyGraphRoots(resolved *dependency.ResolveResult) []string {
 	if len(resolved.WorkspaceMembers) > 0 {
 		roots := make([]string, 0, len(resolved.WorkspaceMembers))
 		for i := range resolved.WorkspaceMembers {
@@ -616,6 +629,23 @@ func dependencyGraphRoots(resolved *dependency.ResolveResult) []string {
 		return nil
 	}
 	return []string{resolved.RootModule}
+}
+
+func dependencyGraphSourceRoots(graph map[string][]string) []string {
+	children := make(map[string]bool)
+	for _, values := range graph {
+		for _, child := range values {
+			children[child] = true
+		}
+	}
+	roots := make([]string, 0)
+	for parent := range graph {
+		if !children[parent] {
+			roots = append(roots, parent)
+		}
+	}
+	sort.Strings(roots)
+	return roots
 }
 
 func reachableDependencyModules(graph map[string][]string, roots []string) map[string]bool {

--- a/internal/engine/dependency_scanner.go
+++ b/internal/engine/dependency_scanner.go
@@ -301,6 +301,17 @@ func (ds *DependencyScanner) loadFilteredRules(ecosystem string) ([]string, func
 	return prepareRulePathsForScanner(allRules, languages)
 }
 
+func dependencyScanWorkers(configured int, ecosystem string) int {
+	if configured > 0 {
+		return configured
+	}
+	limit := maxWorkers
+	if ecosystem == languageJava {
+		limit = 2
+	}
+	return min(max(runtime.NumCPU()/2, 1), limit)
+}
+
 // scanDependenciesParallel scans all dependencies concurrently using a worker pool.
 func (ds *DependencyScanner) scanDependenciesParallel(
 	ctx context.Context,
@@ -309,10 +320,7 @@ func (ds *DependencyScanner) scanDependenciesParallel(
 	rulesHash string,
 	opts DepScanOptions,
 ) []depScanResult {
-	workers := opts.Workers
-	if workers <= 0 {
-		workers = min(max(runtime.NumCPU()/2, 1), maxWorkers)
-	}
+	workers := dependencyScanWorkers(opts.Workers, ds.resolver.Ecosystem())
 
 	orderedDeps := canonicalDependencies(deps)
 
@@ -429,7 +437,7 @@ func (ds *DependencyScanner) scanSingleDep(
 				Str("module", dep.Module).
 				Str("version", dep.Version).
 				Msg("Cache hit for dependency scan")
-			return depScanResult{key: key, dep: dep, report: report, status: depScanStatusScanned}
+			return depScanResult{key: key, dep: dep, report: dependencyReportWithFindings(report), status: depScanStatusScanned}
 		} else if err != nil {
 			log.Warn().Err(err).Str("module", dep.Module).Msg("Cache read error, scanning normally")
 		}
@@ -454,10 +462,17 @@ func (ds *DependencyScanner) scanSingleDep(
 	return depScanResult{
 		key:    key,
 		dep:    dep,
-		report: report,
+		report: dependencyReportWithFindings(report),
 		status: scanStatusForError(err),
 		err:    err,
 	}
+}
+
+func dependencyReportWithFindings(report *entities.InterimReport) *entities.InterimReport {
+	if !hasFindings(report) {
+		return nil
+	}
+	return report
 }
 
 func scanStatusForError(err error) depScanStatus {
@@ -521,10 +536,10 @@ func (ds *DependencyScanner) collectPackageSets(
 		})
 	}
 
-	// Source-available deps participate in reachability even when they have no
-	// direct crypto findings. A non-crypto dep can be the only bridge between
-	// user code and a crypto-bearing transitive dependency. Keep bytecode-only
-	// indexing as a fallback for Java deps that cannot be source-parsed.
+	// Source-available deps participate in reachability when they can sit on a
+	// user-code -> crypto-dependency path. Without resolver graph proof, keep the
+	// old conservative behavior and parse every scanned dependency.
+	graphDeps := callGraphDependencySet(resolved, depResults)
 	for i := range depResults {
 		result := &depResults[i]
 		pkg := callgraph.PackageDir{
@@ -534,7 +549,9 @@ func (ds *DependencyScanner) collectPackageSets(
 			CompiledArtifactPath: result.dep.CompiledArtifactPath,
 		}
 		if result.status == depScanStatusScanned && result.dep.Dir != "" {
-			sets.graphPackages = append(sets.graphPackages, pkg)
+			if graphDeps == nil || graphDeps[result.dep.Module] {
+				sets.graphPackages = append(sets.graphPackages, pkg)
+			}
 			continue
 		}
 
@@ -544,6 +561,102 @@ func (ds *DependencyScanner) collectPackageSets(
 	}
 
 	return sets
+}
+
+func callGraphDependencySet(resolved *dependency.ResolveResult, depResults []depScanResult) map[string]bool {
+	if resolved == nil || len(resolved.Graph) == 0 {
+		return nil
+	}
+	targets := cryptoDependencyModules(depResults)
+	if len(targets) == 0 {
+		return nil
+	}
+	roots := dependencyGraphRoots(resolved)
+	if len(roots) == 0 {
+		return nil
+	}
+	reachable := reachableDependencyModules(resolved.Graph, roots)
+	for target := range targets {
+		if !reachable[target] {
+			return nil
+		}
+	}
+	ancestors := dependencyTargetAncestors(resolved.Graph, targets)
+	keep := make(map[string]bool, len(ancestors))
+	for module := range ancestors {
+		if reachable[module] {
+			keep[module] = true
+		}
+	}
+	return keep
+}
+
+func cryptoDependencyModules(depResults []depScanResult) map[string]bool {
+	targets := make(map[string]bool)
+	for i := range depResults {
+		result := &depResults[i]
+		if result.status == depScanStatusScanned && hasFindings(result.report) && result.dep.Module != "" {
+			targets[result.dep.Module] = true
+		}
+	}
+	return targets
+}
+
+func dependencyGraphRoots(resolved *dependency.ResolveResult) []string {
+	if len(resolved.WorkspaceMembers) > 0 {
+		roots := make([]string, 0, len(resolved.WorkspaceMembers))
+		for i := range resolved.WorkspaceMembers {
+			if resolved.WorkspaceMembers[i].Name != "" {
+				roots = append(roots, resolved.WorkspaceMembers[i].Name)
+			}
+		}
+		return roots
+	}
+	if resolved.RootModule == "" {
+		return nil
+	}
+	return []string{resolved.RootModule}
+}
+
+func reachableDependencyModules(graph map[string][]string, roots []string) map[string]bool {
+	seen := make(map[string]bool)
+	stack := append([]string(nil), roots...)
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		module := stack[last]
+		stack = stack[:last]
+		if seen[module] {
+			continue
+		}
+		seen[module] = true
+		stack = append(stack, graph[module]...)
+	}
+	return seen
+}
+
+func dependencyTargetAncestors(graph map[string][]string, targets map[string]bool) map[string]bool {
+	reverse := make(map[string][]string, len(graph))
+	for parent, children := range graph {
+		for _, child := range children {
+			reverse[child] = append(reverse[child], parent)
+		}
+	}
+	seen := make(map[string]bool)
+	stack := make([]string, 0, len(targets))
+	for target := range targets {
+		stack = append(stack, target)
+	}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		module := stack[last]
+		stack = stack[:last]
+		if seen[module] {
+			continue
+		}
+		seen[module] = true
+		stack = append(stack, reverse[module]...)
+	}
+	return seen
 }
 
 // buildUserPackages returns the set of package names that constitute user code.
@@ -740,6 +853,9 @@ func dependencyLess(a, b dependency.Dependency) bool {
 }
 
 func hasFindings(report *entities.InterimReport) bool {
+	if report == nil {
+		return false
+	}
 	for _, f := range report.Findings {
 		if len(f.CryptographicAssets) > 0 {
 			return true

--- a/internal/engine/dependency_scanner.go
+++ b/internal/engine/dependency_scanner.go
@@ -117,7 +117,18 @@ func (ds *DependencyScanner) ScanWithDependencies(
 	}
 
 	depResults := ds.scanDependenciesParallel(ctx, resolved.Dependencies, filteredRulePaths, rulesHash, opts)
-	logDependencyScanSummary(summarizeDependencyResults(depResults))
+	summary := summarizeDependencyResults(depResults)
+	logDependencyScanSummary(summary)
+	if summary.totalDepFindings == 0 {
+		log.Info().Msg("No dependency crypto findings, skipping dependency call graph")
+		return &DepScanResult{
+			Report:       ds.mergeReports(userReport, depResults),
+			RootModule:   resolved.RootModule,
+			Ecosystem:    ds.resolver.Ecosystem(),
+			ProjectRoot:  opts.ScanOptions.Target,
+			Dependencies: canonicalDependencies(resolved.Dependencies),
+		}, nil
+	}
 
 	graph, err := ds.buildDependencyCallGraph(opts.ScanOptions.Target, resolved, depResults)
 	if err != nil {

--- a/internal/engine/dependency_scanner.go
+++ b/internal/engine/dependency_scanner.go
@@ -117,18 +117,7 @@ func (ds *DependencyScanner) ScanWithDependencies(
 	}
 
 	depResults := ds.scanDependenciesParallel(ctx, resolved.Dependencies, filteredRulePaths, rulesHash, opts)
-	summary := summarizeDependencyResults(depResults)
-	logDependencyScanSummary(summary)
-	if summary.totalDepFindings == 0 {
-		log.Info().Msg("No dependency crypto findings, skipping dependency call graph")
-		return &DepScanResult{
-			Report:       ds.mergeReports(userReport, depResults),
-			RootModule:   resolved.RootModule,
-			Ecosystem:    ds.resolver.Ecosystem(),
-			ProjectRoot:  opts.ScanOptions.Target,
-			Dependencies: canonicalDependencies(resolved.Dependencies),
-		}, nil
-	}
+	logDependencyScanSummary(summarizeDependencyResults(depResults))
 
 	graph, err := ds.buildDependencyCallGraph(opts.ScanOptions.Target, resolved, depResults)
 	if err != nil {

--- a/internal/engine/dependency_scanner_test.go
+++ b/internal/engine/dependency_scanner_test.go
@@ -68,12 +68,6 @@ func (noopCallgraphParser) SubPackagePath(parentPath, dirName string) string {
 }
 func (noopCallgraphParser) PackageSeparator() string { return "/" }
 
-type failingCallgraphParser struct{ noopCallgraphParser }
-
-func (failingCallgraphParser) ParseDirectory(string, string) ([]*callgraph.FileAnalysis, error) {
-	return nil, errors.New("callgraph should be skipped")
-}
-
 func TestNewDependencyScanner(t *testing.T) {
 	orchestrator := &Orchestrator{}
 	resolver := &fakeResolver{ecosystem: "go"}
@@ -427,53 +421,6 @@ func TestDependencyScanner_LoadFilteredRulesAndScanSingleDep(t *testing.T) {
 	}
 	if cache.putCalls != 1 || cache.putLastKey == "" {
 		t.Fatalf("expected cache put call after successful scan, puts=%d key=%q", cache.putCalls, cache.putLastKey)
-	}
-}
-
-func TestDependencyScanner_ScanWithDependencies_SkipsCallGraphWhenNoDependencyFindings(t *testing.T) {
-	ruleDir := t.TempDir()
-	rulePath := filepath.Join(ruleDir, "go.yaml")
-	if err := os.WriteFile(rulePath, []byte("rules:\n  - languages: [go]\n"), 0o600); err != nil {
-		t.Fatalf("write rule: %v", err)
-	}
-
-	var scanCalls atomic.Int32
-	mockScan := &mockScanner{
-		scanFunc: func(_ context.Context, _ string, _ []string, _ entities.ToolInfo) (*entities.InterimReport, error) {
-			scanCalls.Add(1)
-			return &entities.InterimReport{}, nil
-		},
-	}
-	registry := scanner.NewRegistry()
-	registry.Register("test-scanner", mockScan)
-	orchestrator := NewOrchestrator(&mockDetector{}, rules.NewManager(&mockRuleSource{loadFunc: func() ([]string, error) {
-		return []string{rulePath}, nil
-	}}), registry)
-
-	dep := dependency.Dependency{Module: "example.com/no-crypto", Version: "v1", Dir: t.TempDir()}
-	ds := &DependencyScanner{
-		orchestrator: orchestrator,
-		resolver: &fakeResolver{ecosystem: "go", resolveFn: func(_ context.Context, _ string) (*dependency.ResolveResult, error) {
-			return &dependency.ResolveResult{
-				RootModule:   "example.com/root",
-				Dependencies: []dependency.Dependency{dep},
-				Graph:        map[string][]string{"example.com/root": {"example.com/no-crypto"}},
-			}, nil
-		}},
-		cgBuilder: callgraph.NewBuilder(failingCallgraphParser{}),
-	}
-
-	result, err := ds.ScanWithDependencies(context.Background(), &entities.InterimReport{}, DepScanOptions{
-		ScanOptions: ScanOptions{Target: t.TempDir(), ScannerName: "test-scanner"},
-	})
-	if err != nil {
-		t.Fatalf("ScanWithDependencies: %v", err)
-	}
-	if result.CallGraph != nil {
-		t.Fatal("expected nil call graph when dependency scans have no crypto findings")
-	}
-	if scanCalls.Load() != 1 {
-		t.Fatalf("scan calls = %d, want 1", scanCalls.Load())
 	}
 }
 

--- a/internal/engine/dependency_scanner_test.go
+++ b/internal/engine/dependency_scanner_test.go
@@ -755,6 +755,28 @@ func TestDetachDeadlineKeepCancel(t *testing.T) {
 	})
 }
 
+func TestDependencyScanner_CollectPackageSets_DropsDepsWhenNoneHaveFindings(t *testing.T) {
+	ds := &DependencyScanner{resolver: &fakeResolver{ecosystem: "go"}}
+	resolved := &dependency.ResolveResult{
+		RootModule: "example.com/root",
+		Graph: map[string][]string{
+			"example.com/root": {"example.com/no-crypto"},
+		},
+	}
+	depResults := []depScanResult{
+		{
+			dep:    dependency.Dependency{Module: "example.com/no-crypto", Version: "v1", Dir: "/deps/no-crypto"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+	}
+
+	sets := ds.collectPackageSets("/user/project", resolved, depResults)
+	if hasPackage(sets.graphPackages, "example.com/no-crypto") {
+		t.Fatalf("unexpected no-crypto dependency in graphPackages: %#v", sets.graphPackages)
+	}
+}
+
 func TestDependencyScanner_CollectPackageSets_PrunesDepsOutsideCryptoPaths(t *testing.T) {
 	ds := &DependencyScanner{resolver: &fakeResolver{ecosystem: "go"}}
 	resolved := &dependency.ResolveResult{
@@ -793,6 +815,42 @@ func TestDependencyScanner_CollectPackageSets_PrunesDepsOutsideCryptoPaths(t *te
 		t.Fatalf("expected crypto package in graphPackages: %#v", sets.graphPackages)
 	}
 	if hasPackage(sets.graphPackages, "example.com/unused") {
+		t.Fatalf("unexpected unused package in graphPackages: %#v", sets.graphPackages)
+	}
+}
+
+func TestDependencyScanner_CollectPackageSets_PrunesWithInferredGraphRoots(t *testing.T) {
+	ds := &DependencyScanner{resolver: &fakeResolver{ecosystem: "java"}}
+	resolved := &dependency.ResolveResult{
+		RootModule: "com.acme",
+		Graph: map[string][]string{
+			"com.acme:app":       {"org.example:bridge", "org.example:unused"},
+			"org.example:bridge": {"org.example:crypto"},
+		},
+	}
+	depResults := []depScanResult{
+		{
+			dep:    dependency.Dependency{Module: "org.example:bridge", Version: "1.0.0", Dir: "/deps/bridge"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+		{
+			dep:    dependency.Dependency{Module: "org.example:crypto", Version: "1.0.0", Dir: "/deps/crypto"},
+			status: depScanStatusScanned,
+			report: reportWithCryptoAsset(),
+		},
+		{
+			dep:    dependency.Dependency{Module: "org.example:unused", Version: "1.0.0", Dir: "/deps/unused"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+	}
+
+	sets := ds.collectPackageSets("/user/project", resolved, depResults)
+	if !hasPackage(sets.graphPackages, "org.example:bridge") || !hasPackage(sets.graphPackages, "org.example:crypto") {
+		t.Fatalf("expected bridge and crypto deps in graphPackages: %#v", sets.graphPackages)
+	}
+	if hasPackage(sets.graphPackages, "org.example:unused") {
 		t.Fatalf("unexpected unused package in graphPackages: %#v", sets.graphPackages)
 	}
 }

--- a/internal/engine/dependency_scanner_test.go
+++ b/internal/engine/dependency_scanner_test.go
@@ -424,6 +424,43 @@ func TestDependencyScanner_LoadFilteredRulesAndScanSingleDep(t *testing.T) {
 	}
 }
 
+func TestDependencyScanner_ScanSingleDep_DropsNoFindingReportsFromMemory(t *testing.T) {
+	mockScan := &mockScanner{
+		scanFunc: func(_ context.Context, _ string, _ []string, _ entities.ToolInfo) (*entities.InterimReport, error) {
+			return &entities.InterimReport{}, nil
+		},
+	}
+	registry := scanner.NewRegistry()
+	registry.Register("test-scanner", mockScan)
+
+	orchestrator := NewOrchestrator(&mockDetector{}, rules.NewManager(&mockRuleSource{loadFunc: func() ([]string, error) {
+		return []string{"/rules/go.yaml"}, nil
+	}}), registry)
+	cache := &fakeFindingsCache{getMap: map[string]*entities.InterimReport{}}
+	ds := &DependencyScanner{
+		orchestrator:  orchestrator,
+		resolver:      &fakeResolver{ecosystem: "go"},
+		findingsCache: cache,
+	}
+
+	dep := dependency.Dependency{Module: "github.com/acme/no-crypto", Version: "v1", Dir: t.TempDir()}
+	res := ds.scanSingleDep(context.Background(), dep, dep.Module+"@"+dep.Version, []string{"/rules/go.yaml"}, "hash", DepScanOptions{
+		ScanOptions: ScanOptions{ScannerName: "test-scanner"},
+	})
+	if res.err != nil {
+		t.Fatalf("scanSingleDep: %v", res.err)
+	}
+	if res.status != depScanStatusScanned {
+		t.Fatalf("status = %v, want scanned", res.status)
+	}
+	if res.report != nil {
+		t.Fatal("expected no-finding dependency report to be dropped from memory")
+	}
+	if cache.putCalls != 1 {
+		t.Fatalf("expected no-finding report to still be cached, puts=%d", cache.putCalls)
+	}
+}
+
 func TestDependencyScanner_LoadFilteredRules_MalformedParameterConditionAborts(t *testing.T) {
 	ruleDir := t.TempDir()
 	brokenRule := filepath.Join(ruleDir, "broken.yaml")
@@ -463,6 +500,18 @@ rules:
 	}
 	if !strings.Contains(err.Error(), "param[]==true") {
 		t.Errorf("error %q does not contain the raw malformed predicate", err.Error())
+	}
+}
+
+func TestDependencyScanWorkers_DefaultsAreMemorySafeForJava(t *testing.T) {
+	if got := dependencyScanWorkers(0, "java"); got < 1 || got > 2 {
+		t.Fatalf("java default workers = %d, want 1..2", got)
+	}
+	if got := dependencyScanWorkers(6, "java"); got != 6 {
+		t.Fatalf("explicit java workers = %d, want 6", got)
+	}
+	if got := dependencyScanWorkers(0, "go"); got < 1 || got > maxWorkers {
+		t.Fatalf("go default workers = %d, want 1..%d", got, maxWorkers)
 	}
 }
 
@@ -704,4 +753,93 @@ func TestDetachDeadlineKeepCancel(t *testing.T) {
 			t.Fatalf("child was not canceled by its own cancel func")
 		}
 	})
+}
+
+func TestDependencyScanner_CollectPackageSets_PrunesDepsOutsideCryptoPaths(t *testing.T) {
+	ds := &DependencyScanner{resolver: &fakeResolver{ecosystem: "go"}}
+	resolved := &dependency.ResolveResult{
+		RootModule: "example.com/root",
+		Graph: map[string][]string{
+			"example.com/root":   {"example.com/bridge", "example.com/unused"},
+			"example.com/bridge": {"example.com/crypto"},
+		},
+	}
+	depResults := []depScanResult{
+		{
+			dep:    dependency.Dependency{Module: "example.com/bridge", Version: "v1", Dir: "/deps/bridge"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+		{
+			dep:    dependency.Dependency{Module: "example.com/crypto", Version: "v1", Dir: "/deps/crypto"},
+			status: depScanStatusScanned,
+			report: reportWithCryptoAsset(),
+		},
+		{
+			dep:    dependency.Dependency{Module: "example.com/unused", Version: "v1", Dir: "/deps/unused"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+	}
+
+	sets := ds.collectPackageSets("/user/project", resolved, depResults)
+	if !hasPackage(sets.graphPackages, "example.com/root") {
+		t.Fatalf("expected root package in graphPackages: %#v", sets.graphPackages)
+	}
+	if !hasPackage(sets.graphPackages, "example.com/bridge") {
+		t.Fatalf("expected bridge package in graphPackages: %#v", sets.graphPackages)
+	}
+	if !hasPackage(sets.graphPackages, "example.com/crypto") {
+		t.Fatalf("expected crypto package in graphPackages: %#v", sets.graphPackages)
+	}
+	if hasPackage(sets.graphPackages, "example.com/unused") {
+		t.Fatalf("unexpected unused package in graphPackages: %#v", sets.graphPackages)
+	}
+}
+
+func TestDependencyScanner_CollectPackageSets_FallsBackWhenGraphIncomplete(t *testing.T) {
+	ds := &DependencyScanner{resolver: &fakeResolver{ecosystem: "go"}}
+	resolved := &dependency.ResolveResult{
+		RootModule: "example.com/root",
+		Graph: map[string][]string{
+			"example.com/root": {"example.com/bridge"},
+		},
+	}
+	depResults := []depScanResult{
+		{
+			dep:    dependency.Dependency{Module: "example.com/bridge", Version: "v1", Dir: "/deps/bridge"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+		{
+			dep:    dependency.Dependency{Module: "example.com/crypto", Version: "v1", Dir: "/deps/crypto"},
+			status: depScanStatusScanned,
+			report: reportWithCryptoAsset(),
+		},
+		{
+			dep:    dependency.Dependency{Module: "example.com/unused", Version: "v1", Dir: "/deps/unused"},
+			status: depScanStatusScanned,
+			report: &entities.InterimReport{},
+		},
+	}
+
+	sets := ds.collectPackageSets("/user/project", resolved, depResults)
+	if !hasPackage(sets.graphPackages, "example.com/bridge") ||
+		!hasPackage(sets.graphPackages, "example.com/crypto") ||
+		!hasPackage(sets.graphPackages, "example.com/unused") {
+		t.Fatalf("expected conservative fallback to keep all scanned deps: %#v", sets.graphPackages)
+	}
+}
+
+func reportWithCryptoAsset() *entities.InterimReport {
+	return &entities.InterimReport{Findings: []entities.Finding{{CryptographicAssets: []entities.CryptographicAsset{{}}}}}
+}
+
+func hasPackage(pkgs []callgraph.PackageDir, importPath string) bool {
+	for i := range pkgs {
+		if pkgs[i].ImportPath == importPath {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/engine/dependency_scanner_test.go
+++ b/internal/engine/dependency_scanner_test.go
@@ -68,6 +68,12 @@ func (noopCallgraphParser) SubPackagePath(parentPath, dirName string) string {
 }
 func (noopCallgraphParser) PackageSeparator() string { return "/" }
 
+type failingCallgraphParser struct{ noopCallgraphParser }
+
+func (failingCallgraphParser) ParseDirectory(string, string) ([]*callgraph.FileAnalysis, error) {
+	return nil, errors.New("callgraph should be skipped")
+}
+
 func TestNewDependencyScanner(t *testing.T) {
 	orchestrator := &Orchestrator{}
 	resolver := &fakeResolver{ecosystem: "go"}
@@ -421,6 +427,53 @@ func TestDependencyScanner_LoadFilteredRulesAndScanSingleDep(t *testing.T) {
 	}
 	if cache.putCalls != 1 || cache.putLastKey == "" {
 		t.Fatalf("expected cache put call after successful scan, puts=%d key=%q", cache.putCalls, cache.putLastKey)
+	}
+}
+
+func TestDependencyScanner_ScanWithDependencies_SkipsCallGraphWhenNoDependencyFindings(t *testing.T) {
+	ruleDir := t.TempDir()
+	rulePath := filepath.Join(ruleDir, "go.yaml")
+	if err := os.WriteFile(rulePath, []byte("rules:\n  - languages: [go]\n"), 0o600); err != nil {
+		t.Fatalf("write rule: %v", err)
+	}
+
+	var scanCalls atomic.Int32
+	mockScan := &mockScanner{
+		scanFunc: func(_ context.Context, _ string, _ []string, _ entities.ToolInfo) (*entities.InterimReport, error) {
+			scanCalls.Add(1)
+			return &entities.InterimReport{}, nil
+		},
+	}
+	registry := scanner.NewRegistry()
+	registry.Register("test-scanner", mockScan)
+	orchestrator := NewOrchestrator(&mockDetector{}, rules.NewManager(&mockRuleSource{loadFunc: func() ([]string, error) {
+		return []string{rulePath}, nil
+	}}), registry)
+
+	dep := dependency.Dependency{Module: "example.com/no-crypto", Version: "v1", Dir: t.TempDir()}
+	ds := &DependencyScanner{
+		orchestrator: orchestrator,
+		resolver: &fakeResolver{ecosystem: "go", resolveFn: func(_ context.Context, _ string) (*dependency.ResolveResult, error) {
+			return &dependency.ResolveResult{
+				RootModule:   "example.com/root",
+				Dependencies: []dependency.Dependency{dep},
+				Graph:        map[string][]string{"example.com/root": {"example.com/no-crypto"}},
+			}, nil
+		}},
+		cgBuilder: callgraph.NewBuilder(failingCallgraphParser{}),
+	}
+
+	result, err := ds.ScanWithDependencies(context.Background(), &entities.InterimReport{}, DepScanOptions{
+		ScanOptions: ScanOptions{Target: t.TempDir(), ScannerName: "test-scanner"},
+	})
+	if err != nil {
+		t.Fatalf("ScanWithDependencies: %v", err)
+	}
+	if result.CallGraph != nil {
+		t.Fatal("expected nil call graph when dependency scans have no crypto findings")
+	}
+	if scanCalls.Load() != 1 {
+		t.Fatalf("scan calls = %d, want 1", scanCalls.Load())
 	}
 }
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -58,43 +58,47 @@ func NewJSONWriter() *JSONWriter {
 func (w *JSONWriter) Write(report *entities.InterimReport, destination string) error {
 	// Validate report
 	if report == nil {
-		return fmt.Errorf("report cannot be nil")
+		return fmt.Errorf("output: report cannot be nil")
 	}
 
 	// Determine output destination
 	//nolint:nestif // Separate stdout and file paths are inherently nested
 	if destination == "" || destination == "-" {
 		if err := w.writeJSON(report, os.Stdout); err != nil {
-			return fmt.Errorf("failed to write JSON to stdout: %w", err)
+			return fmt.Errorf("output: failed to write JSON to stdout: %w", err)
 		}
 		// Add newline for better terminal output
 		if _, err := os.Stdout.WriteString("\n"); err != nil {
-			return fmt.Errorf("failed to write newline to stdout: %w", err)
+			return fmt.Errorf("output: failed to write newline to stdout: %w", err)
 		}
 	} else {
 		// Write to file
 		// Convert to absolute path
 		absPath, err := filepath.Abs(destination)
 		if err != nil {
-			return fmt.Errorf("failed to resolve destination path: %w", err)
+			return fmt.Errorf("output: failed to resolve destination path: %w", err)
 		}
 
 		// Check parent directory exists
 		parentDir := filepath.Dir(absPath)
 		if _, err := os.Stat(parentDir); os.IsNotExist(err) {
-			return fmt.Errorf("parent directory does not exist: %s", parentDir)
+			return fmt.Errorf("output: parent directory does not exist: %s", parentDir)
 		}
 
 		file, err := os.OpenFile(absPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 		if err != nil {
-			return fmt.Errorf("failed to write JSON file: %w", err)
+			return fmt.Errorf("output: failed to open JSON file: %w", err)
 		}
 		writeErr := w.writeJSON(report, file)
-		if closeErr := file.Close(); writeErr == nil {
-			writeErr = closeErr
-		}
+		closeErr := file.Close()
 		if writeErr != nil {
-			return fmt.Errorf("failed to write JSON file: %w", writeErr)
+			if closeErr != nil {
+				return fmt.Errorf("output: failed to write JSON file: %w (close failed: %w)", writeErr, closeErr)
+			}
+			return fmt.Errorf("output: failed to write JSON file: %w", writeErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("output: failed to close JSON file: %w", closeErr)
 		}
 	}
 
@@ -107,5 +111,8 @@ func (w *JSONWriter) writeJSON(report *entities.InterimReport, dst io.Writer) er
 	if w.PrettyPrint {
 		enc.SetIndent("", w.Indent)
 	}
-	return enc.Encode(report)
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("output: failed to encode JSON: %w", err)
+	}
+	return nil
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -19,9 +19,9 @@
 package output
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -61,24 +61,11 @@ func (w *JSONWriter) Write(report *entities.InterimReport, destination string) e
 		return fmt.Errorf("report cannot be nil")
 	}
 
-	// Marshal to JSON with HTML escaping disabled to preserve <init> etc.
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if w.PrettyPrint {
-		enc.SetIndent("", w.Indent)
-	}
-	if err := enc.Encode(report); err != nil {
-		return fmt.Errorf("failed to marshal report to JSON: %w", err)
-	}
-	data := buf.Bytes()
-
 	// Determine output destination
 	//nolint:nestif // Separate stdout and file paths are inherently nested
 	if destination == "" || destination == "-" {
-		// Write to stdout
-		if _, err := os.Stdout.Write(data); err != nil {
-			return fmt.Errorf("failed to write to stdout: %w", err)
+		if err := w.writeJSON(report, os.Stdout); err != nil {
+			return fmt.Errorf("failed to write JSON to stdout: %w", err)
 		}
 		// Add newline for better terminal output
 		if _, err := os.Stdout.WriteString("\n"); err != nil {
@@ -98,12 +85,27 @@ func (w *JSONWriter) Write(report *entities.InterimReport, destination string) e
 			return fmt.Errorf("parent directory does not exist: %s", parentDir)
 		}
 
-		// Write to file
-		// 0o600 = rw------- (owner can read/write only)
-		if err := os.WriteFile(absPath, data, 0o600); err != nil {
+		file, err := os.OpenFile(absPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			return fmt.Errorf("failed to write JSON file: %w", err)
+		}
+		if err := w.writeJSON(report, file); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("failed to write JSON file: %w", err)
+		}
+		if err := file.Close(); err != nil {
 			return fmt.Errorf("failed to write JSON file: %w", err)
 		}
 	}
 
 	return nil
+}
+
+func (w *JSONWriter) writeJSON(report *entities.InterimReport, dst io.Writer) error {
+	enc := json.NewEncoder(dst)
+	enc.SetEscapeHTML(false)
+	if w.PrettyPrint {
+		enc.SetIndent("", w.Indent)
+	}
+	return enc.Encode(report)
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -89,12 +89,12 @@ func (w *JSONWriter) Write(report *entities.InterimReport, destination string) e
 		if err != nil {
 			return fmt.Errorf("failed to write JSON file: %w", err)
 		}
-		if err := w.writeJSON(report, file); err != nil {
-			_ = file.Close()
-			return fmt.Errorf("failed to write JSON file: %w", err)
+		writeErr := w.writeJSON(report, file)
+		if closeErr := file.Close(); writeErr == nil {
+			writeErr = closeErr
 		}
-		if err := file.Close(); err != nil {
-			return fmt.Errorf("failed to write JSON file: %w", err)
+		if writeErr != nil {
+			return fmt.Errorf("failed to write JSON file: %w", writeErr)
 		}
 	}
 

--- a/internal/scan/annotate.go
+++ b/internal/scan/annotate.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -270,11 +269,7 @@ func MarshalAnnotateExport(payload *graphfrag.GraphFragmentExport) ([]byte, erro
 // WriteAnnotateExport writes an annotate-only graph-fragment export to path as
 // indented JSON, matching the formatting of ExportGraphFragment.
 func WriteAnnotateExport(path string, payload *graphfrag.GraphFragmentExport) error {
-	data, err := MarshalAnnotateExport(payload)
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := writeIndentedJSONFile(path, payload); err != nil {
 		return fmt.Errorf("scan: failed to write annotation to %s: %w", path, err)
 	}
 	return nil

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -63,7 +63,9 @@ type exportBuildContext struct {
 	// so a caller with heavy dispatch fan-out (many resolved edges, one
 	// source call site) pays the O(len(Calls)) index-build cost once instead
 	// of once per edge. nil until first use.
-	callsBySignature map[string]map[string][]*callgraph.FunctionCall
+	callsBySignature     map[string]map[string][]*callgraph.FunctionCall
+	calleeSignatureKeys  map[string]string
+	chainIDsByCallerLine map[string]map[int]string
 }
 
 type cachedContainingFunction struct {

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -1,7 +1,7 @@
 package scan
 
 import (
-	"bytes"
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -51,8 +51,9 @@ type exportBuildContext struct {
 	// kb holds the ecosystem's callgraph contracts, used to attach contract-role
 	// supporting calls (fluent lifecycle methods) to synthesized terminal entry
 	// points. nil for ecosystems with no contracts.
-	kb        *contracts.KnowledgeBase
-	declIndex map[string]*callgraph.FunctionDecl // base FQN → definition
+	kb            *contracts.KnowledgeBase
+	declIndex     map[string]*callgraph.FunctionDecl        // base FQN → definition
+	declsByMethod map[string][]operationContractDeclaration // method name → definitions
 	// callsBySignature caches, per caller FunctionID key, an index of that
 	// caller's FunctionCalls grouped by the (Package, Type, BaseFunctionName)
 	// tuple callMatchesCallee compares — the same fuzzy key an
@@ -334,24 +335,11 @@ func ExportCallGraph(path, format string, result *engine.DepScanResult) error {
 		Msg("Starting integration call graph export")
 
 	buildStart := time.Now()
-	payload := buildCallGraphExportV2(result)
+	payload, err := buildCallGraphExportV2ToFile(path, result)
 	buildDuration := time.Since(buildStart)
-
-	serializeStart := time.Now()
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetIndent("", "  ")
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(payload); err != nil {
-		return fmt.Errorf("failed to serialize call graph export: %w", err)
+	if err != nil {
+		return err
 	}
-	serializeDuration := time.Since(serializeStart)
-
-	writeStart := time.Now()
-	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("failed to write call graph to %s: %w", path, err)
-	}
-	writeDuration := time.Since(writeStart)
 
 	log.Info().
 		Str("file", path).
@@ -360,12 +348,226 @@ func ExportCallGraph(path, format string, result *engine.DepScanResult) error {
 		Int("edges", payload.ScanMetadata.EdgeCount).
 		Int("findings", len(payload.FindingGraphs)).
 		Dur("build_duration", buildDuration).
-		Dur("serialize_duration", serializeDuration).
-		Dur("write_duration", writeDuration).
 		Dur("total_duration", time.Since(exportStart)).
 		Msg("Exported integration call graph")
 
 	return nil
+}
+
+func buildCallGraphExportV2ToFile(path string, result *engine.DepScanResult) (callGraphExportV2, error) {
+	ctx := newExportBuildContext(result)
+	assets := callGraphExportAssets(result.Report)
+	meta := buildCallGraphExportScanMeta(result)
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return callGraphExportV2{}, fmt.Errorf("failed to write call graph to %s: %w", path, err)
+	}
+	bw := bufio.NewWriterSize(file, 1<<20)
+	writer := graphFragmentJSONWriter{w: bw}
+
+	if _, err = writer.w.WriteString("{\n"); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+	if err = writer.writeField("schema_version", callGraphSchemaVersion); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+	if err = writer.writeField("scan_metadata", meta); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+	if err = writer.startArrayField("finding_graphs"); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+
+	index := make(map[string]*entryPointData)
+	supportingByID := make(map[string]callGraphSupportingCall)
+	referencedSupporting := make(map[string]struct{})
+	buildStart := time.Now()
+	for i := range assets {
+		item := assets[i]
+		supporting := deriveSupportingCallsForFinding(ctx, item.finding, item.asset)
+		for _, support := range supporting {
+			if support.SupportingID == "" {
+				continue
+			}
+			if _, exists := supportingByID[support.SupportingID]; !exists {
+				supportingByID[support.SupportingID] = support
+			}
+		}
+		fg := buildFindingGraph(ctx, item.finding, item.asset)
+		fg.SupportingCallIDs = supportingCallIDsOf(supporting)
+		addFindingGraphToEntryPointIndex(index, &fg)
+		addFindingGraphSupportingToEntryPointIndex(index, &fg, supportingByID, referencedSupporting)
+		if err = writer.writeArrayElement(i, fg); err != nil {
+			_ = file.Close()
+			return callGraphExportV2{}, err
+		}
+		processed := i + 1
+		if processed%callGraphExportProgress == 0 || processed == len(assets) {
+			log.Info().
+				Int("processed", processed).
+				Int("total", len(assets)).
+				Dur("elapsed", time.Since(buildStart)).
+				Msg("Building integration call graph export")
+		}
+	}
+	if err = writer.endArrayField(len(assets)); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+
+	supportingCalls := sortedSupportingCalls(supportingByID)
+	for i := range supportingCalls {
+		if _, ok := referencedSupporting[supportingCalls[i].SupportingID]; ok {
+			continue
+		}
+		addSupportingCallToEntryPointIndex(index, supportingCalls[i])
+	}
+	if err = writeGraphFragmentArrayField(&writer, "supporting_calls", supportingCalls, true); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+	entryPoints := flattenEntryPointIndex(ctx.kb, index)
+	entryPoints = appendSynthesizedOperationEntryPoints(ctx, result, entryPoints)
+	if err = writeGraphFragmentArrayField(&writer, "crypto_entry_points", entryPoints, true); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+	if _, err = writer.w.WriteString("\n}\n"); err != nil {
+		_ = file.Close()
+		return callGraphExportV2{}, err
+	}
+	if flushErr := bw.Flush(); err == nil {
+		err = flushErr
+	}
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return callGraphExportV2{}, fmt.Errorf("failed to write call graph to %s: %w", path, err)
+	}
+
+	return callGraphExportV2{
+		SchemaVersion:     callGraphSchemaVersion,
+		ScanMetadata:      meta,
+		FindingGraphs:     make([]callGraphExportFinding, len(assets)),
+		SupportingCalls:   supportingCalls,
+		CryptoEntryPoints: entryPoints,
+	}, nil
+}
+
+type callGraphExportAsset struct {
+	finding entities.Finding
+	asset   entities.CryptographicAsset
+}
+
+func callGraphExportAssets(report *entities.InterimReport) []callGraphExportAsset {
+	if report == nil {
+		return nil
+	}
+	var assets []callGraphExportAsset
+	for _, finding := range report.Findings {
+		for i := range finding.CryptographicAssets {
+			assets = append(assets, callGraphExportAsset{finding: finding, asset: finding.CryptographicAssets[i]})
+		}
+	}
+	return assets
+}
+
+func sortedSupportingCalls(values map[string]callGraphSupportingCall) []callGraphSupportingCall {
+	out := make([]callGraphSupportingCall, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].SupportingID < out[j].SupportingID
+	})
+	return out
+}
+
+func buildCallGraphExportScanMeta(result *engine.DepScanResult) callGraphExportScanMeta {
+	meta := callGraphExportScanMeta{
+		Ecosystem:     result.Ecosystem,
+		RootModule:    result.RootModule,
+		ExportedAt:    time.Now().UTC().Format(time.RFC3339),
+		FunctionCount: len(result.CallGraph.Functions),
+		EdgeCount:     countCallGraphEdges(result.CallGraph),
+	}
+	if result.Report != nil {
+		meta.ToolName = result.Report.Tool.Name
+		meta.ToolVersion = result.Report.Tool.Version
+	}
+	if result.Ecosystem == ecosystemJava && result.CallGraph != nil && result.CallGraph.JavaPlatformSignatures != nil {
+		javaMeta := result.CallGraph.JavaPlatformSignatures
+		meta.JavaRequestedJDKMajor = javaMeta.RequestedMajor
+		meta.JavaRuntimeVersion = javaMeta.RuntimeVersion
+		used := javaMeta.SignaturesUsed
+		meta.JavaPlatformSignaturesUsed = &used
+		meta.JavaPlatformSignatureSource = javaMeta.SignatureSource
+		meta.JavaPlatformSignatureUnavailableReason = javaMeta.UnavailableReason
+	}
+	return meta
+}
+
+func writeCallGraphJSONFile(path string, payload callGraphExportV2) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+
+	bw := bufio.NewWriterSize(file, 1<<20)
+	writer := graphFragmentJSONWriter{w: bw}
+	err = writer.writeCallGraph(payload)
+	if flushErr := bw.Flush(); err == nil {
+		err = flushErr
+	}
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func (w *graphFragmentJSONWriter) writeCallGraph(payload callGraphExportV2) error {
+	if _, err := w.w.WriteString("{\n"); err != nil {
+		return err
+	}
+	if err := w.writeField("schema_version", payload.SchemaVersion); err != nil {
+		return err
+	}
+	if err := w.writeField("scan_metadata", payload.ScanMetadata); err != nil {
+		return err
+	}
+	if err := writeGraphFragmentArrayField(w, "finding_graphs", payload.FindingGraphs, false); err != nil {
+		return err
+	}
+	if err := writeGraphFragmentArrayField(w, "supporting_calls", payload.SupportingCalls, true); err != nil {
+		return err
+	}
+	if err := writeGraphFragmentArrayField(w, "crypto_entry_points", payload.CryptoEntryPoints, true); err != nil {
+		return err
+	}
+	_, err := w.w.WriteString("\n}\n")
+	return err
+}
+
+func writeIndentedJSONFile(path string, payload any) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(payload); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 // --- Build pipeline ---
@@ -967,25 +1169,37 @@ func (ctx *exportBuildContext) synthesizeContractOperationEntryPoint(
 }
 
 func (ctx *exportBuildContext) operationContractDeclarations(c contracts.Contract) []operationContractDeclaration {
-	direct := ctx.declIndex[c.Method]
 	contractClass, contractMethod := splitFunctionName(c.Method)
-	out := make([]operationContractDeclaration, 0, 1)
-	if direct != nil && functionDeclArityMatches(direct, c.Arity) {
-		out = append(out, operationContractDeclaration{declFQN: c.Method, decl: direct})
+	candidates := ctx.declsByMethod[contractMethod]
+	if candidates == nil {
+		candidates = ctx.operationContractDeclarationCandidates(contractMethod)
 	}
-	for declFQN, decl := range ctx.declIndex {
-		if decl == direct {
-			continue
-		}
+	out := make([]operationContractDeclaration, 0, len(candidates))
+	for _, candidate := range candidates {
+		declFQN, decl := candidate.declFQN, candidate.decl
 		declClass, declMethod := splitFunctionName(declFQN)
-		if declMethod != contractMethod || !functionDeclArityMatches(decl, c.Arity) || !ctx.typeOrAncestor(contractClass, declClass) {
+		if declMethod != contractMethod || !functionDeclArityMatches(decl, c.Arity) {
 			continue
 		}
-		out = append(out, operationContractDeclaration{declFQN: declFQN, decl: decl})
+		if declFQN != c.Method && !ctx.typeOrAncestor(contractClass, declClass) {
+			continue
+		}
+		out = append(out, candidate)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].declFQN < out[j].declFQN
 	})
+	return out
+}
+
+func (ctx *exportBuildContext) operationContractDeclarationCandidates(method string) []operationContractDeclaration {
+	out := make([]operationContractDeclaration, 0, 1)
+	for declFQN, decl := range ctx.declIndex {
+		_, declMethod := splitFunctionName(declFQN)
+		if declMethod == method {
+			out = append(out, operationContractDeclaration{declFQN: declFQN, decl: decl})
+		}
+	}
 	return out
 }
 
@@ -1135,8 +1349,14 @@ func newExportBuildContext(result *engine.DepScanResult) *exportBuildContext {
 		// Future overload-aware lookup should store []*callgraph.FunctionDecl per
 		// base FQN instead.
 		ctx.declIndex = make(map[string]*callgraph.FunctionDecl, len(result.CallGraph.Functions))
+		ctx.declsByMethod = make(map[string][]operationContractDeclaration)
 		for _, fn := range result.CallGraph.Functions {
 			if fqn := exportFunctionFQN(fn.ID); fqn != "" {
+				_, method := splitFunctionName(fqn)
+				ctx.declsByMethod[method] = append(ctx.declsByMethod[method], operationContractDeclaration{
+					declFQN: fqn,
+					decl:    fn,
+				})
 				if _, exists := ctx.declIndex[fqn]; !exists {
 					ctx.declIndex[fqn] = fn
 				}

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -366,58 +366,38 @@ func buildCallGraphExportV2ToFile(path string, result *engine.DepScanResult) (ca
 	bw := bufio.NewWriterSize(file, 1<<20)
 	writer := graphFragmentJSONWriter{w: bw}
 
-	if _, err = writer.w.WriteString("{\n"); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
-	}
-	if err = writer.writeField("schema_version", callGraphSchemaVersion); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
-	}
-	if err = writer.writeField("scan_metadata", meta); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
-	}
-	if err = writer.startArrayField("finding_graphs"); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
+	streamed, writeErr := streamCallGraphExport(&writer, ctx, result, assets, meta)
+	if err := finishBufferedOutput(file, bw, writeErr); err != nil {
+		return callGraphExportV2{}, fmt.Errorf("failed to write call graph to %s: %w", path, err)
 	}
 
-	index := make(map[string]*entryPointData)
-	supportingByID := make(map[string]callGraphSupportingCall)
-	referencedSupporting := make(map[string]struct{})
-	buildStart := time.Now()
-	for i := range assets {
-		item := assets[i]
-		supporting := deriveSupportingCallsForFinding(ctx, item.finding, item.asset)
-		for _, support := range supporting {
-			if support.SupportingID == "" {
-				continue
-			}
-			if _, exists := supportingByID[support.SupportingID]; !exists {
-				supportingByID[support.SupportingID] = support
-			}
-		}
-		fg := buildFindingGraph(ctx, item.finding, item.asset)
-		fg.SupportingCallIDs = supportingCallIDsOf(supporting)
-		addFindingGraphToEntryPointIndex(index, &fg)
-		addFindingGraphSupportingToEntryPointIndex(index, &fg, supportingByID, referencedSupporting)
-		if err = writer.writeArrayElement(i, fg); err != nil {
-			_ = file.Close()
-			return callGraphExportV2{}, err
-		}
-		processed := i + 1
-		if processed%callGraphExportProgress == 0 || processed == len(assets) {
-			log.Info().
-				Int("processed", processed).
-				Int("total", len(assets)).
-				Dur("elapsed", time.Since(buildStart)).
-				Msg("Building integration call graph export")
-		}
+	return callGraphExportV2{
+		SchemaVersion:     callGraphSchemaVersion,
+		ScanMetadata:      meta,
+		FindingGraphs:     make([]callGraphExportFinding, len(assets)),
+		SupportingCalls:   streamed.supportingCalls,
+		CryptoEntryPoints: streamed.entryPoints,
+	}, nil
+}
+
+type streamedCallGraphExport struct {
+	supportingCalls []callGraphSupportingCall
+	entryPoints     []callGraphCryptoEntryPoint
+}
+
+func streamCallGraphExport(
+	writer *graphFragmentJSONWriter,
+	ctx *exportBuildContext,
+	result *engine.DepScanResult,
+	assets []callGraphExportAsset,
+	meta callGraphExportScanMeta,
+) (streamedCallGraphExport, error) {
+	if err := writeCallGraphPrefix(writer, meta); err != nil {
+		return streamedCallGraphExport{}, err
 	}
-	if err = writer.endArrayField(len(assets)); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
+	index, supportingByID, referencedSupporting, err := streamFindingGraphs(writer, ctx, assets)
+	if err != nil {
+		return streamedCallGraphExport{}, err
 	}
 
 	supportingCalls := sortedSupportingCalls(supportingByID)
@@ -427,37 +407,96 @@ func buildCallGraphExportV2ToFile(path string, result *engine.DepScanResult) (ca
 		}
 		addSupportingCallToEntryPointIndex(index, supportingCalls[i])
 	}
-	if err = writeGraphFragmentArrayField(&writer, "supporting_calls", supportingCalls, true); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
+	if err := writeGraphFragmentArrayField(writer, "supporting_calls", supportingCalls, true); err != nil {
+		return streamedCallGraphExport{}, err
 	}
+
 	entryPoints := flattenEntryPointIndex(ctx.kb, index)
 	entryPoints = appendSynthesizedOperationEntryPoints(ctx, result, entryPoints)
-	if err = writeGraphFragmentArrayField(&writer, "crypto_entry_points", entryPoints, true); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
+	if err := writeGraphFragmentArrayField(writer, "crypto_entry_points", entryPoints, true); err != nil {
+		return streamedCallGraphExport{}, err
 	}
-	if _, err = writer.w.WriteString("\n}\n"); err != nil {
-		_ = file.Close()
-		return callGraphExportV2{}, err
+	if _, err := writer.w.WriteString("\n}\n"); err != nil {
+		return streamedCallGraphExport{}, err
 	}
-	if flushErr := bw.Flush(); err == nil {
-		err = flushErr
+	return streamedCallGraphExport{supportingCalls: supportingCalls, entryPoints: entryPoints}, nil
+}
+
+func writeCallGraphPrefix(writer *graphFragmentJSONWriter, meta callGraphExportScanMeta) error {
+	if _, err := writer.w.WriteString("{\n"); err != nil {
+		return err
+	}
+	if err := writer.writeField("schema_version", callGraphSchemaVersion); err != nil {
+		return err
+	}
+	if err := writer.writeField("scan_metadata", meta); err != nil {
+		return err
+	}
+	return writer.startArrayField("finding_graphs")
+}
+
+func streamFindingGraphs(
+	writer *graphFragmentJSONWriter,
+	ctx *exportBuildContext,
+	assets []callGraphExportAsset,
+) (map[string]*entryPointData, map[string]callGraphSupportingCall, map[string]struct{}, error) {
+	index := make(map[string]*entryPointData)
+	supportingByID := make(map[string]callGraphSupportingCall)
+	referencedSupporting := make(map[string]struct{})
+	buildStart := time.Now()
+
+	for i := range assets {
+		item := assets[i]
+		supporting := deriveSupportingCallsForFinding(ctx, item.finding, item.asset)
+		indexSupportingCalls(supportingByID, supporting)
+
+		fg := buildFindingGraph(ctx, item.finding, item.asset)
+		fg.SupportingCallIDs = supportingCallIDsOf(supporting)
+		addFindingGraphToEntryPointIndex(index, &fg)
+		addFindingGraphSupportingToEntryPointIndex(index, &fg, supportingByID, referencedSupporting)
+		if err := writer.writeArrayElement(i, fg); err != nil {
+			return nil, nil, nil, err
+		}
+		logCallGraphExportProgress(i+1, len(assets), buildStart)
+	}
+	if err := writer.endArrayField(len(assets)); err != nil {
+		return nil, nil, nil, err
+	}
+	return index, supportingByID, referencedSupporting, nil
+}
+
+func indexSupportingCalls(dst map[string]callGraphSupportingCall, supporting []callGraphSupportingCall) {
+	for i := range supporting {
+		support := supporting[i]
+		if support.SupportingID == "" {
+			continue
+		}
+		if _, exists := dst[support.SupportingID]; !exists {
+			dst[support.SupportingID] = support
+		}
+	}
+}
+
+func logCallGraphExportProgress(processed, total int, start time.Time) {
+	if processed%callGraphExportProgress != 0 && processed != total {
+		return
+	}
+	log.Info().
+		Int("processed", processed).
+		Int("total", total).
+		Dur("elapsed", time.Since(start)).
+		Msg("Building integration call graph export")
+}
+
+func finishBufferedOutput(file *os.File, bw *bufio.Writer, writeErr error) error {
+	err := writeErr
+	if err == nil {
+		err = bw.Flush()
 	}
 	if closeErr := file.Close(); err == nil {
 		err = closeErr
 	}
-	if err != nil {
-		return callGraphExportV2{}, fmt.Errorf("failed to write call graph to %s: %w", path, err)
-	}
-
-	return callGraphExportV2{
-		SchemaVersion:     callGraphSchemaVersion,
-		ScanMetadata:      meta,
-		FindingGraphs:     make([]callGraphExportFinding, len(assets)),
-		SupportingCalls:   supportingCalls,
-		CryptoEntryPoints: entryPoints,
-	}, nil
+	return err
 }
 
 type callGraphExportAsset struct {
@@ -480,8 +519,8 @@ func callGraphExportAssets(report *entities.InterimReport) []callGraphExportAsse
 
 func sortedSupportingCalls(values map[string]callGraphSupportingCall) []callGraphSupportingCall {
 	out := make([]callGraphSupportingCall, 0, len(values))
-	for _, value := range values {
-		out = append(out, value)
+	for key := range values {
+		out = append(out, values[key])
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		return out[i].SupportingID < out[j].SupportingID
@@ -513,47 +552,6 @@ func buildCallGraphExportScanMeta(result *engine.DepScanResult) callGraphExportS
 	return meta
 }
 
-func writeCallGraphJSONFile(path string, payload callGraphExportV2) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
-	if err != nil {
-		return err
-	}
-
-	bw := bufio.NewWriterSize(file, 1<<20)
-	writer := graphFragmentJSONWriter{w: bw}
-	err = writer.writeCallGraph(payload)
-	if flushErr := bw.Flush(); err == nil {
-		err = flushErr
-	}
-	if closeErr := file.Close(); err == nil {
-		err = closeErr
-	}
-	return err
-}
-
-func (w *graphFragmentJSONWriter) writeCallGraph(payload callGraphExportV2) error {
-	if _, err := w.w.WriteString("{\n"); err != nil {
-		return err
-	}
-	if err := w.writeField("schema_version", payload.SchemaVersion); err != nil {
-		return err
-	}
-	if err := w.writeField("scan_metadata", payload.ScanMetadata); err != nil {
-		return err
-	}
-	if err := writeGraphFragmentArrayField(w, "finding_graphs", payload.FindingGraphs, false); err != nil {
-		return err
-	}
-	if err := writeGraphFragmentArrayField(w, "supporting_calls", payload.SupportingCalls, true); err != nil {
-		return err
-	}
-	if err := writeGraphFragmentArrayField(w, "crypto_entry_points", payload.CryptoEntryPoints, true); err != nil {
-		return err
-	}
-	_, err := w.w.WriteString("\n}\n")
-	return err
-}
-
 func writeIndentedJSONFile(path string, payload any) error {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -563,11 +561,11 @@ func writeIndentedJSONFile(path string, payload any) error {
 	enc := json.NewEncoder(file)
 	enc.SetIndent("", "  ")
 	enc.SetEscapeHTML(false)
-	if err := enc.Encode(payload); err != nil {
-		_ = file.Close()
-		return err
+	err = enc.Encode(payload)
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
 	}
-	return file.Close()
+	return err
 }
 
 // --- Build pipeline ---
@@ -961,8 +959,8 @@ func flattenReachableSupportingCalls(values map[string]callGraphReachableSupport
 		return nil
 	}
 	out := make([]callGraphReachableSupportingCall, 0, len(values))
-	for _, value := range values {
-		out = append(out, value)
+	for key := range values {
+		out = append(out, values[key])
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].SupportingID < out[j].SupportingID

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -1,9 +1,10 @@
 package scan
 
 import (
-	"bytes"
+	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -34,18 +35,300 @@ func ExportGraphFragment(path, format string, result *engine.DepScanResult) erro
 		return fmt.Errorf("scan: unsupported graph fragment format %q (supported: json)", format)
 	}
 
-	payload := BuildGraphFragmentExport(result)
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetIndent("", "  ")
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(payload); err != nil {
-		return fmt.Errorf("scan: failed to serialize graph fragment export: %w", err)
-	}
-	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+	if err := writeGraphFragmentJSONFile(path, result); err != nil {
 		return fmt.Errorf("scan: failed to write graph fragment to %s: %w", path, err)
 	}
 	return nil
+}
+
+func writeGraphFragmentJSONFile(path string, result *engine.DepScanResult) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+
+	bw := bufio.NewWriterSize(file, 1<<20)
+	writer := graphFragmentJSONWriter{w: bw}
+	err = writer.writeResult(result)
+	if flushErr := bw.Flush(); err == nil {
+		err = flushErr
+	}
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+type graphFragmentJSONWriter struct {
+	w         *bufio.Writer
+	needComma bool
+}
+
+func (w *graphFragmentJSONWriter) writeResult(result *engine.DepScanResult) error {
+	if _, err := w.w.WriteString("{\n"); err != nil {
+		return err
+	}
+	if err := w.writeField("schema_version", graphfrag.SchemaVersion); err != nil {
+		return err
+	}
+
+	ctx := newExportBuildContext(result)
+	meta := buildGraphFragmentScanMetadata(result)
+	var err error
+	var functionIndex map[string]int
+	functionIndex, meta.FunctionCount, err = w.writeFunctions(ctx)
+	if err != nil {
+		return err
+	}
+	meta.InternalEdges, meta.ExternalCalls, err = w.writeEdges(ctx, functionIndex)
+	if err != nil {
+		return err
+	}
+
+	cryptoAnnotations := buildGraphFragmentCryptoAnnotations(ctx, result)
+	meta.CryptoOps = len(cryptoAnnotations)
+	if err := writeGraphFragmentArrayField(w, "crypto_annotations", cryptoAnnotations, true); err != nil {
+		return err
+	}
+	supportingCalls := buildGraphFragmentSupportingCalls(ctx, result)
+	meta.SupportingCalls = len(supportingCalls)
+	if err := writeGraphFragmentArrayField(w, "supporting_calls", supportingCalls, true); err != nil {
+		return err
+	}
+	entryPoints := buildGraphFragmentCryptoEntryPoints(ctx, result)
+	entryPoints = appendSynthesizedOperationEntryPointsFragment(ctx, result, entryPoints)
+	meta.CryptoEntryPoints = len(entryPoints)
+	if err := writeGraphFragmentArrayField(w, "crypto_entry_points", entryPoints, true); err != nil {
+		return err
+	}
+	if err := w.writeField("scan_metadata", meta); err != nil {
+		return err
+	}
+	_, err = w.w.WriteString("\n}\n")
+	return err
+}
+
+func (w *graphFragmentJSONWriter) writeFunctions(ctx *exportBuildContext) (map[string]int, int, error) {
+	if err := w.startArrayField("functions"); err != nil {
+		return nil, 0, err
+	}
+	functionIndex := make(map[string]int, len(ctx.graph.Functions))
+	count := 0
+	for _, key := range sortedKeys(ctx.graph.Functions) {
+		decl := ctx.graph.Functions[key]
+		if err := w.writeArrayElement(count, buildGraphFragmentFunction(ctx, decl.ID, decl)); err != nil {
+			return nil, 0, err
+		}
+		functionIndex[key] = count
+		count++
+	}
+	return functionIndex, count, w.endArrayField(count)
+}
+
+func (w *graphFragmentJSONWriter) writeEdges(ctx *exportBuildContext, functionIndex map[string]int) (int, int, error) {
+	strings := newFragmentStringInterner()
+	if err := w.startArrayField("internal_edges_compact"); err != nil {
+		return 0, 0, err
+	}
+
+	internalCount := 0
+	var pending *graphfrag.GraphFragmentEdge
+	var externalCalls []graphfrag.GraphFragmentExternal
+	flush := func() error {
+		if pending == nil {
+			return nil
+		}
+		compact := compactGraphFragmentEdge(*pending, functionIndex, strings)
+		if err := w.writeArrayElement(internalCount, compact); err != nil {
+			return err
+		}
+		internalCount++
+		return nil
+	}
+
+	for _, calleeKey := range sortedKeys(ctx.graph.Callers) {
+		calls, err := buildResolvedFragmentEdges(ctx, calleeKey, func(edge graphfrag.GraphFragmentEdge) error {
+			if pending != nil && fragmentEdgeSameKey(*pending, edge) {
+				*pending = edge
+				return nil
+			}
+			if err := flush(); err != nil {
+				return err
+			}
+			pending = &edge
+			return nil
+		})
+		if err != nil {
+			return 0, 0, err
+		}
+		externalCalls = append(externalCalls, calls...)
+	}
+	if err := flush(); err != nil {
+		return 0, 0, err
+	}
+	if err := w.endArrayField(internalCount); err != nil {
+		return 0, 0, err
+	}
+	if err := writeGraphFragmentArrayField(w, "internal_edge_strings", strings.values, true); err != nil {
+		return 0, 0, err
+	}
+
+	externalCalls = sortedFragmentExternalCalls(externalCalls)
+	if err := writeGraphFragmentArrayField(w, "external_calls", externalCalls, true); err != nil {
+		return 0, 0, err
+	}
+	return internalCount, len(externalCalls), nil
+}
+
+func (w *graphFragmentJSONWriter) startArrayField(name string) error {
+	if err := w.startField(name); err != nil {
+		return err
+	}
+	_, err := w.w.WriteString("[")
+	return err
+}
+
+func (w *graphFragmentJSONWriter) writeArrayElement(index int, value any) error {
+	if index == 0 {
+		if _, err := w.w.WriteString("\n    "); err != nil {
+			return err
+		}
+	} else if _, err := w.w.WriteString(",\n    "); err != nil {
+		return err
+	}
+	return writeJSONValue(w.w, value)
+}
+
+func (w *graphFragmentJSONWriter) endArrayField(count int) error {
+	if count == 0 {
+		_, err := w.w.WriteString("]")
+		return err
+	}
+	_, err := w.w.WriteString("\n  ]")
+	return err
+}
+
+type fragmentStringInterner struct {
+	values  []string
+	indexes map[string]int
+}
+
+func newFragmentStringInterner() *fragmentStringInterner {
+	return &fragmentStringInterner{
+		values:  []string{""},
+		indexes: map[string]int{"": 0},
+	}
+}
+
+func (i *fragmentStringInterner) index(value string) int {
+	if idx, ok := i.indexes[value]; ok {
+		return idx
+	}
+	idx := len(i.values)
+	i.values = append(i.values, value)
+	i.indexes[value] = idx
+	return idx
+}
+
+func compactGraphFragmentEdge(edge graphfrag.GraphFragmentEdge, functionIndex map[string]int, strings *fragmentStringInterner) graphfrag.GraphFragmentCompactEdge {
+	return graphfrag.GraphFragmentCompactEdge{
+		Caller:               functionIndex[edge.CallerKey],
+		Callee:               functionIndex[edge.CalleeKey],
+		Line:                 edge.Line,
+		Resolution:           strings.index(edge.Resolution),
+		DeclaredType:         strings.index(edge.DeclaredType),
+		MethodName:           strings.index(edge.MethodName),
+		Arity:                edge.Arity,
+		ReceiverVar:          strings.index(edge.ReceiverVar),
+		AssignedVar:          strings.index(edge.AssignedVar),
+		ChainID:              strings.index(edge.ChainID),
+		StartCol:             edge.StartCol,
+		EndCol:               edge.EndCol,
+		ResolvedReceiverType: strings.index(edge.ResolvedReceiverType),
+		EntryCall:            edge.EntryCall,
+	}
+}
+
+func (w *graphFragmentJSONWriter) writeField(name string, value any) error {
+	if err := w.startField(name); err != nil {
+		return err
+	}
+	return writeJSONValue(w.w, value)
+}
+
+func writeGraphFragmentArrayField[T any](w *graphFragmentJSONWriter, name string, values []T, omitEmpty bool) error {
+	if omitEmpty && len(values) == 0 {
+		return nil
+	}
+	if err := w.startArrayField(name); err != nil {
+		return err
+	}
+	for i := range values {
+		if err := w.writeArrayElement(i, values[i]); err != nil {
+			return err
+		}
+	}
+	return w.endArrayField(len(values))
+}
+
+func (w *graphFragmentJSONWriter) startField(name string) error {
+	if w.needComma {
+		if _, err := w.w.WriteString(",\n"); err != nil {
+			return err
+		}
+	}
+	w.needComma = true
+	_, err := fmt.Fprintf(w.w, "  %q: ", name)
+	return err
+}
+
+func writeJSONValue(dst io.Writer, value any) error {
+	trimmer := trailingNewlineTrimmer{dst: dst}
+	enc := json.NewEncoder(&trimmer)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(value); err != nil {
+		return err
+	}
+	return trimmer.Flush()
+}
+
+type trailingNewlineTrimmer struct {
+	dst     io.Writer
+	held    byte
+	hasHeld bool
+}
+
+func (w *trailingNewlineTrimmer) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if w.hasHeld {
+		if _, err := w.dst.Write([]byte{w.held}); err != nil {
+			return 0, err
+		}
+		w.hasHeld = false
+	}
+	if len(p) > 1 {
+		if _, err := w.dst.Write(p[:len(p)-1]); err != nil {
+			return 0, err
+		}
+	}
+	w.held = p[len(p)-1]
+	w.hasHeld = true
+	return len(p), nil
+}
+
+func (w *trailingNewlineTrimmer) Flush() error {
+	if !w.hasHeld {
+		return nil
+	}
+	if w.held == '\n' {
+		w.hasHeld = false
+		return nil
+	}
+	_, err := w.dst.Write([]byte{w.held})
+	w.hasHeld = false
+	return err
 }
 
 // BuildGraphFragmentExport projects a dependency scan result onto the public
@@ -53,17 +336,7 @@ func ExportGraphFragment(path, format string, result *engine.DepScanResult) erro
 func BuildGraphFragmentExport(result *engine.DepScanResult) graphfrag.GraphFragmentExport {
 	out := graphfrag.GraphFragmentExport{
 		SchemaVersion: graphfrag.SchemaVersion,
-		ScanMetadata: graphfrag.GraphFragmentScanMetadata{
-			Ecosystem:        result.Ecosystem,
-			RootModule:       result.RootModule,
-			GraphAlgoVersion: graphfrag.GraphAlgoVersion,
-			ExportedAt:       time.Now().UTC().Format(time.RFC3339),
-		},
-	}
-	if result.Report != nil {
-		out.ScanMetadata.ToolName = result.Report.Tool.Name
-		out.ScanMetadata.ToolVersion = result.Report.Tool.Version
-		out.ScanMetadata.RulesVersion = result.Report.Rules.Version
+		ScanMetadata:  buildGraphFragmentScanMetadata(result),
 	}
 	if result.CallGraph == nil {
 		return out
@@ -96,29 +369,58 @@ func BuildGraphFragmentExport(result *engine.DepScanResult) graphfrag.GraphFragm
 	return out
 }
 
+func buildGraphFragmentScanMetadata(result *engine.DepScanResult) graphfrag.GraphFragmentScanMetadata {
+	meta := graphfrag.GraphFragmentScanMetadata{
+		Ecosystem:        result.Ecosystem,
+		RootModule:       result.RootModule,
+		GraphAlgoVersion: graphfrag.GraphAlgoVersion,
+		ExportedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+	if result.Report != nil {
+		meta.ToolName = result.Report.Tool.Name
+		meta.ToolVersion = result.Report.Tool.Version
+		meta.RulesVersion = result.Report.Rules.Version
+	}
+	return meta
+}
+
 func buildGraphFragmentResolvedEdges(ctx *exportBuildContext) ([]graphfrag.GraphFragmentEdge, []graphfrag.GraphFragmentExternal) {
 	if ctx == nil || ctx.graph == nil {
 		return nil, nil
 	}
 
-	internalByKey := map[string]graphfrag.GraphFragmentEdge{}
-	externalByKey := map[string]graphfrag.GraphFragmentExternal{}
+	internalEdges := make([]graphfrag.GraphFragmentEdge, 0, len(ctx.graph.EdgeResolutions))
+	var externalCalls []graphfrag.GraphFragmentExternal
 	for _, calleeKey := range sortedKeys(ctx.graph.Callers) {
-		addResolvedFragmentEdges(ctx, calleeKey, internalByKey, externalByKey)
+		internalEdges, externalCalls = addResolvedFragmentEdges(ctx, calleeKey, internalEdges, externalCalls)
 	}
 
-	return sortedFragmentEdges(internalByKey), sortedFragmentExternalCalls(externalByKey)
+	return sortedFragmentEdges(internalEdges), sortedFragmentExternalCalls(externalCalls)
 }
 
 func addResolvedFragmentEdges(
 	ctx *exportBuildContext,
 	calleeKey string,
-	internalByKey map[string]graphfrag.GraphFragmentEdge,
-	externalByKey map[string]graphfrag.GraphFragmentExternal,
-) {
+	internalEdges []graphfrag.GraphFragmentEdge,
+	externalCalls []graphfrag.GraphFragmentExternal,
+) ([]graphfrag.GraphFragmentEdge, []graphfrag.GraphFragmentExternal) {
+	calls, _ := buildResolvedFragmentEdges(ctx, calleeKey, func(edge graphfrag.GraphFragmentEdge) error {
+		internalEdges = append(internalEdges, edge)
+		return nil
+	})
+	externalCalls = append(externalCalls, calls...)
+	return internalEdges, externalCalls
+}
+
+func buildResolvedFragmentEdges(
+	ctx *exportBuildContext,
+	calleeKey string,
+	emitInternal func(graphfrag.GraphFragmentEdge) error,
+) ([]graphfrag.GraphFragmentExternal, error) {
 	graph := ctx.graph
 	callers := append([]string(nil), graph.Callers[calleeKey]...)
 	sort.Strings(callers)
+	var externalCalls []graphfrag.GraphFragmentExternal
 	for _, callerKey := range callers {
 		callerDecl := graph.Functions[callerKey]
 		if callerDecl == nil {
@@ -127,7 +429,6 @@ func addResolvedFragmentEdges(
 		resolutions := resolveFragmentEdges(ctx, callerKey, calleeKey)
 		for i := range resolutions {
 			res := resolutions[i]
-			edgeKey := callgraph.EdgeResolutionKey(callerKey, calleeKey, res.EdgeResolution)
 			line := fragmentEdgeLine(ctx, callerKey, callerDecl, calleeKey, res)
 			call := findCallForCalleeAtLine(ctx, callerKey, callerDecl, calleeKey, line)
 			if _, ok := graph.Functions[calleeKey]; ok {
@@ -135,16 +436,19 @@ func addResolvedFragmentEdges(
 				if edge.ChainID == "" {
 					edge.ChainID = chainIDForLine(callerDecl, line)
 				}
-				internalByKey[edgeKey] = edge
+				if err := emitInternal(edge); err != nil {
+					return nil, err
+				}
 				continue
 			}
 			external := buildFragmentExternalCall(ctx, callerDecl, call, callerKey, calleeKey, line, res)
 			if external.ChainID == "" {
 				external.ChainID = chainIDForLine(callerDecl, line)
 			}
-			externalByKey[edgeKey] = external
+			externalCalls = append(externalCalls, external)
 		}
 	}
+	return externalCalls, nil
 }
 
 // buildFragmentCallSiteEntryCall constructs the GraphFragmentCallSite for a
@@ -302,22 +606,94 @@ func sortedKeys[V any](values map[string]V) []string {
 	return keys
 }
 
-func sortedFragmentEdges(values map[string]graphfrag.GraphFragmentEdge) []graphfrag.GraphFragmentEdge {
-	keys := sortedKeys(values)
-	out := make([]graphfrag.GraphFragmentEdge, 0, len(keys))
-	for _, key := range keys {
-		out = append(out, values[key])
+func sortedFragmentEdges(values []graphfrag.GraphFragmentEdge) []graphfrag.GraphFragmentEdge {
+	if len(values) == 0 {
+		return nil
+	}
+	sort.SliceStable(values, func(i, j int) bool {
+		return fragmentEdgeLess(values[i], values[j])
+	})
+	out := values[:0]
+	for i := range values {
+		if i+1 < len(values) && fragmentEdgeSameKey(values[i], values[i+1]) {
+			continue
+		}
+		out = append(out, values[i])
 	}
 	return out
 }
 
-func sortedFragmentExternalCalls(values map[string]graphfrag.GraphFragmentExternal) []graphfrag.GraphFragmentExternal {
-	keys := sortedKeys(values)
-	out := make([]graphfrag.GraphFragmentExternal, 0, len(keys))
-	for _, key := range keys {
-		out = append(out, values[key])
+func sortedFragmentExternalCalls(values []graphfrag.GraphFragmentExternal) []graphfrag.GraphFragmentExternal {
+	if len(values) == 0 {
+		return nil
+	}
+	sort.SliceStable(values, func(i, j int) bool {
+		return fragmentExternalLess(values[i], values[j])
+	})
+	out := values[:0]
+	for i := range values {
+		if i+1 < len(values) && fragmentExternalSameKey(values[i], values[i+1]) {
+			continue
+		}
+		out = append(out, values[i])
 	}
 	return out
+}
+
+func fragmentEdgeLess(a, b graphfrag.GraphFragmentEdge) bool {
+	if a.CallerKey != b.CallerKey {
+		return a.CallerKey < b.CallerKey
+	}
+	if a.CalleeKey != b.CalleeKey {
+		return a.CalleeKey < b.CalleeKey
+	}
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	if a.DeclaredType != b.DeclaredType {
+		return a.DeclaredType < b.DeclaredType
+	}
+	if a.MethodName != b.MethodName {
+		return a.MethodName < b.MethodName
+	}
+	return a.Arity < b.Arity
+}
+
+func fragmentEdgeSameKey(a, b graphfrag.GraphFragmentEdge) bool {
+	return a.CallerKey == b.CallerKey &&
+		a.CalleeKey == b.CalleeKey &&
+		a.Line == b.Line &&
+		a.DeclaredType == b.DeclaredType &&
+		a.MethodName == b.MethodName &&
+		a.Arity == b.Arity
+}
+
+func fragmentExternalLess(a, b graphfrag.GraphFragmentExternal) bool {
+	if a.CallerKey != b.CallerKey {
+		return a.CallerKey < b.CallerKey
+	}
+	if a.TargetKey != b.TargetKey {
+		return a.TargetKey < b.TargetKey
+	}
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	if a.DeclaredType != b.DeclaredType {
+		return a.DeclaredType < b.DeclaredType
+	}
+	if a.MethodName != b.MethodName {
+		return a.MethodName < b.MethodName
+	}
+	return a.Arity < b.Arity
+}
+
+func fragmentExternalSameKey(a, b graphfrag.GraphFragmentExternal) bool {
+	return a.CallerKey == b.CallerKey &&
+		a.TargetKey == b.TargetKey &&
+		a.Line == b.Line &&
+		a.DeclaredType == b.DeclaredType &&
+		a.MethodName == b.MethodName &&
+		a.Arity == b.Arity
 }
 
 type fragmentEdgeResolution struct {

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -653,6 +653,9 @@ func fragmentEdgeLess(a, b graphfrag.GraphFragmentEdge) bool {
 	if a.Line != b.Line {
 		return a.Line < b.Line
 	}
+	if a.Resolution != b.Resolution {
+		return a.Resolution < b.Resolution
+	}
 	if a.DeclaredType != b.DeclaredType {
 		return a.DeclaredType < b.DeclaredType
 	}
@@ -666,6 +669,7 @@ func fragmentEdgeSameKey(a, b graphfrag.GraphFragmentEdge) bool {
 	return a.CallerKey == b.CallerKey &&
 		a.CalleeKey == b.CalleeKey &&
 		a.Line == b.Line &&
+		a.Resolution == b.Resolution &&
 		a.DeclaredType == b.DeclaredType &&
 		a.MethodName == b.MethodName &&
 		a.Arity == b.Arity
@@ -681,6 +685,9 @@ func fragmentExternalLess(a, b graphfrag.GraphFragmentExternal) bool {
 	if a.Line != b.Line {
 		return a.Line < b.Line
 	}
+	if a.Resolution != b.Resolution {
+		return a.Resolution < b.Resolution
+	}
 	if a.DeclaredType != b.DeclaredType {
 		return a.DeclaredType < b.DeclaredType
 	}
@@ -694,6 +701,7 @@ func fragmentExternalSameKey(a, b graphfrag.GraphFragmentExternal) bool {
 	return a.CallerKey == b.CallerKey &&
 		a.TargetKey == b.TargetKey &&
 		a.Line == b.Line &&
+		a.Resolution == b.Resolution &&
 		a.DeclaredType == b.DeclaredType &&
 		a.MethodName == b.MethodName &&
 		a.Arity == b.Arity

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -126,7 +126,7 @@ func (w *graphFragmentJSONWriter) writeFunctions(ctx *exportBuildContext) (map[s
 }
 
 func (w *graphFragmentJSONWriter) writeEdges(ctx *exportBuildContext, functionIndex map[string]int) (int, int, error) {
-	strings := newFragmentStringInterner()
+	stringInterner := newFragmentStringInterner()
 	if err := w.startArrayField("internal_edges_compact"); err != nil {
 		return 0, 0, err
 	}
@@ -138,7 +138,7 @@ func (w *graphFragmentJSONWriter) writeEdges(ctx *exportBuildContext, functionIn
 		if pending == nil {
 			return nil
 		}
-		compact := compactGraphFragmentEdge(*pending, functionIndex, strings)
+		compact := compactGraphFragmentEdge(*pending, functionIndex, stringInterner)
 		if err := w.writeArrayElement(internalCount, compact); err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func (w *graphFragmentJSONWriter) writeEdges(ctx *exportBuildContext, functionIn
 	if err := w.endArrayField(internalCount); err != nil {
 		return 0, 0, err
 	}
-	if err := writeGraphFragmentArrayField(w, "internal_edge_strings", strings.values, true); err != nil {
+	if err := writeGraphFragmentArrayField(w, "internal_edge_strings", stringInterner.values, true); err != nil {
 		return 0, 0, err
 	}
 
@@ -230,21 +230,21 @@ func (i *fragmentStringInterner) index(value string) int {
 	return idx
 }
 
-func compactGraphFragmentEdge(edge graphfrag.GraphFragmentEdge, functionIndex map[string]int, strings *fragmentStringInterner) graphfrag.GraphFragmentCompactEdge {
+func compactGraphFragmentEdge(edge graphfrag.GraphFragmentEdge, functionIndex map[string]int, stringInterner *fragmentStringInterner) graphfrag.GraphFragmentCompactEdge {
 	return graphfrag.GraphFragmentCompactEdge{
 		Caller:               functionIndex[edge.CallerKey],
 		Callee:               functionIndex[edge.CalleeKey],
 		Line:                 edge.Line,
-		Resolution:           strings.index(edge.Resolution),
-		DeclaredType:         strings.index(edge.DeclaredType),
-		MethodName:           strings.index(edge.MethodName),
+		Resolution:           stringInterner.index(edge.Resolution),
+		DeclaredType:         stringInterner.index(edge.DeclaredType),
+		MethodName:           stringInterner.index(edge.MethodName),
 		Arity:                edge.Arity,
-		ReceiverVar:          strings.index(edge.ReceiverVar),
-		AssignedVar:          strings.index(edge.AssignedVar),
-		ChainID:              strings.index(edge.ChainID),
+		ReceiverVar:          stringInterner.index(edge.ReceiverVar),
+		AssignedVar:          stringInterner.index(edge.AssignedVar),
+		ChainID:              stringInterner.index(edge.ChainID),
 		StartCol:             edge.StartCol,
 		EndCol:               edge.EndCol,
-		ResolvedReceiverType: strings.index(edge.ResolvedReceiverType),
+		ResolvedReceiverType: stringInterner.index(edge.ResolvedReceiverType),
 		EntryCall:            edge.EntryCall,
 	}
 }
@@ -404,10 +404,13 @@ func addResolvedFragmentEdges(
 	internalEdges []graphfrag.GraphFragmentEdge,
 	externalCalls []graphfrag.GraphFragmentExternal,
 ) ([]graphfrag.GraphFragmentEdge, []graphfrag.GraphFragmentExternal) {
-	calls, _ := buildResolvedFragmentEdges(ctx, calleeKey, func(edge graphfrag.GraphFragmentEdge) error {
+	calls, err := buildResolvedFragmentEdges(ctx, calleeKey, func(edge graphfrag.GraphFragmentEdge) error {
 		internalEdges = append(internalEdges, edge)
 		return nil
 	})
+	if err != nil {
+		return internalEdges, externalCalls
+	}
 	externalCalls = append(externalCalls, calls...)
 	return internalEdges, externalCalls
 }

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph"
@@ -437,7 +436,7 @@ func buildResolvedFragmentEdges(
 			if _, ok := graph.Functions[calleeKey]; ok {
 				edge := buildFragmentInternalEdge(ctx, callerDecl, call, callerKey, calleeKey, line, res)
 				if edge.ChainID == "" {
-					edge.ChainID = chainIDForLine(callerDecl, line)
+					edge.ChainID = ctx.chainIDForLine(callerKey, callerDecl, line)
 				}
 				if err := emitInternal(edge); err != nil {
 					return nil, err
@@ -446,7 +445,7 @@ func buildResolvedFragmentEdges(
 			}
 			external := buildFragmentExternalCall(ctx, callerDecl, call, callerKey, calleeKey, line, res)
 			if external.ChainID == "" {
-				external.ChainID = chainIDForLine(callerDecl, line)
+				external.ChainID = ctx.chainIDForLine(callerKey, callerDecl, line)
 			}
 			externalCalls = append(externalCalls, external)
 		}
@@ -730,15 +729,25 @@ func indexFragmentEdgeResolutions(graph *callgraph.CallGraph) map[string][]fragm
 	if graph == nil || len(graph.EdgeResolutions) == 0 {
 		return nil
 	}
+	if len(graph.EdgeResolutionsByPair) > 0 {
+		index := make(map[string][]fragmentEdgeResolution, len(graph.EdgeResolutionsByPair))
+		for pairKey, resolutions := range graph.EdgeResolutionsByPair {
+			values := make([]fragmentEdgeResolution, 0, len(resolutions))
+			for i := range resolutions {
+				values = append(values, newFragmentEdgeResolution(resolutions[i]))
+			}
+			index[pairKey] = values
+		}
+		return index
+	}
 	index := make(map[string][]fragmentEdgeResolution)
-	keys := sortedKeys(graph.EdgeResolutions)
-	for _, key := range keys {
-		parts := strings.SplitN(key, "\x00", 3)
-		if len(parts) < 3 {
+	for key, res := range graph.EdgeResolutions {
+		callerKey, calleeKey, ok := callgraph.EdgeResolutionEndpoints(key, res)
+		if !ok {
 			continue
 		}
-		pairKey := fragmentEdgePairKey(parts[0], parts[1])
-		index[pairKey] = append(index[pairKey], newFragmentEdgeResolution(graph.EdgeResolutions[key]))
+		pairKey := fragmentEdgePairKey(callerKey, calleeKey)
+		index[pairKey] = append(index[pairKey], newFragmentEdgeResolution(res))
 	}
 	return index
 }
@@ -789,6 +798,29 @@ func chainIDForLine(fn *callgraph.FunctionDecl, line int) string {
 		}
 	}
 	return ""
+}
+
+func (ctx *exportBuildContext) chainIDForLine(callerKey string, fn *callgraph.FunctionDecl, line int) string {
+	if ctx == nil {
+		return chainIDForLine(fn, line)
+	}
+	if ctx.chainIDsByCallerLine == nil {
+		ctx.chainIDsByCallerLine = make(map[string]map[int]string)
+	}
+	lineIndex, ok := ctx.chainIDsByCallerLine[callerKey]
+	if !ok {
+		lineIndex = make(map[int]string)
+		if fn != nil {
+			for i := range fn.Calls {
+				call := &fn.Calls[i]
+				if call.Line > 0 && call.ChainID != "" {
+					lineIndex[call.Line] = call.ChainID
+				}
+			}
+		}
+		ctx.chainIDsByCallerLine[callerKey] = lineIndex
+	}
+	return lineIndex[line]
 }
 
 // findCallForCalleeAtLine finds callerKey's FunctionCall matching calleeKey,
@@ -842,8 +874,8 @@ func matchingCallsForCallee(ctx *exportBuildContext, callerKey string, callerDec
 	if callerDecl == nil {
 		return nil
 	}
-	calleeID, err := callgraph.ParseFunctionID(calleeKey)
-	if err != nil {
+	sigKey, ok := calleeSignatureKey(ctx, calleeKey)
+	if !ok {
 		// calleeKey isn't parseable (should not happen for real graph keys,
 		// which are always produced by FunctionID.String()); callMatchesCallee
 		// still honored an exact string match in this case, so fall back to a
@@ -857,8 +889,6 @@ func matchingCallsForCallee(ctx *exportBuildContext, callerKey string, callerDec
 		}
 		return matches
 	}
-	sigKey := callSignatureKey(calleeID.Package, calleeID.Type, callgraph.BaseFunctionName(calleeID.Name))
-
 	if ctx != nil {
 		index := ctx.callSignatureIndexForCaller(callerKey, callerDecl)
 		return index[sigKey]
@@ -872,6 +902,30 @@ func matchingCallsForCallee(ctx *exportBuildContext, callerKey string, callerDec
 		}
 	}
 	return matches
+}
+
+func calleeSignatureKey(ctx *exportBuildContext, calleeKey string) (string, bool) {
+	if ctx != nil {
+		if ctx.calleeSignatureKeys == nil {
+			ctx.calleeSignatureKeys = make(map[string]string)
+		}
+		if sigKey, ok := ctx.calleeSignatureKeys[calleeKey]; ok {
+			return sigKey, sigKey != ""
+		}
+		calleeID, err := callgraph.ParseFunctionID(calleeKey)
+		if err != nil {
+			ctx.calleeSignatureKeys[calleeKey] = ""
+			return "", false
+		}
+		sigKey := callSignatureKey(calleeID.Package, calleeID.Type, callgraph.BaseFunctionName(calleeID.Name))
+		ctx.calleeSignatureKeys[calleeKey] = sigKey
+		return sigKey, true
+	}
+	calleeID, err := callgraph.ParseFunctionID(calleeKey)
+	if err != nil {
+		return "", false
+	}
+	return callSignatureKey(calleeID.Package, calleeID.Type, callgraph.BaseFunctionName(calleeID.Name)), true
 }
 
 // callSignatureKey builds the (Package, Type, BaseFunctionName) grouping key

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -1,6 +1,8 @@
 package scan
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +13,96 @@ import (
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/pkg/graphfrag"
 )
+
+func TestExportGraphFragment_WritesDecodableNoEscapeJSON(t *testing.T) {
+	t.Parallel()
+
+	initID := callgraph.FunctionID{Package: "org.example", Type: "CipherFactory", Name: "<init>#0"}
+	helperID := callgraph.FunctionID{Package: "org.example", Type: "CipherFactory", Name: "helper#0"}
+	externalID := callgraph.FunctionID{Package: "net.crypto", Type: "Cipher", Name: "getInstance#1"}
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			initID.String(): {
+				ID:        initID,
+				FilePath:  "CipherFactory.java",
+				StartLine: 1,
+				EndLine:   3,
+				Calls: []callgraph.FunctionCall{
+					{Callee: helperID, FilePath: "CipherFactory.java", Line: 2},
+					{Callee: externalID, FilePath: "CipherFactory.java", Line: 3},
+				},
+			},
+			helperID.String(): {
+				ID:        helperID,
+				FilePath:  "CipherFactory.java",
+				StartLine: 5,
+				EndLine:   6,
+			},
+		},
+		Callers: map[string][]string{
+			helperID.String():   {initID.String()},
+			externalID.String(): {initID.String()},
+		},
+	}
+	path := filepath.Join(t.TempDir(), "fragment.json")
+
+	if err := ExportGraphFragment(path, "json", &engine.DepScanResult{
+		CallGraph:  graph,
+		RootModule: "org.example:cipher-factory",
+		Ecosystem:  "java",
+	}); err != nil {
+		t.Fatalf("ExportGraphFragment: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Contains(data, []byte("<init>")) {
+		t.Fatalf("export should preserve <init> without HTML escaping: %s", data)
+	}
+	if bytes.Contains(data, []byte(`\u003cinit\u003e`)) {
+		t.Fatalf("export HTML-escaped <init>: %s", data)
+	}
+	var decoded graphfrag.GraphFragmentExport
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, data)
+	}
+	if got, want := decoded.ScanMetadata.FunctionCount, 2; got != want {
+		t.Fatalf("function_count = %d, want %d", got, want)
+	}
+	if got, want := decoded.ScanMetadata.InternalEdges, 1; got != want {
+		t.Fatalf("internal_edge_count = %d, want %d", got, want)
+	}
+	if got, want := decoded.ScanMetadata.ExternalCalls, 1; got != want {
+		t.Fatalf("external_call_count = %d, want %d", got, want)
+	}
+	if got, want := len(decoded.CompactInternalEdges), 1; got != want {
+		t.Fatalf("compact internal edges len = %d, want %d", got, want)
+	}
+	if got := len(decoded.InternalEdges); got != 0 {
+		t.Fatalf("full internal edges len = %d, want 0 in compact export", got)
+	}
+	if got, want := decoded.Functions[0].Key, initID.String(); got != want {
+		t.Fatalf("function key = %q, want %q", got, want)
+	}
+	fragment := decoded.ToFragment(graphfrag.ComponentKey{Purl: "pkg:maven/org.example/cipher-factory", Version: "1.0.0"})
+	if got, want := len(fragment.InternalEdges), 1; got != want {
+		t.Fatalf("decoded fragment internal edges len = %d, want %d", got, want)
+	}
+	if got, want := fragment.InternalEdges[0].Caller, initID.String(); got != want {
+		t.Fatalf("decoded fragment caller = %q, want %q", got, want)
+	}
+	if got, want := fragment.InternalEdges[0].Callee, helperID.String(); got != want {
+		t.Fatalf("decoded fragment callee = %q, want %q", got, want)
+	}
+	if fragment.InternalEdges[0].EntryCall == nil {
+		t.Fatal("decoded fragment internal edge EntryCall is nil")
+	}
+	if got, want := fragment.InternalEdges[0].EntryCall.Line, 2; got != want {
+		t.Fatalf("decoded fragment entry_call line = %d, want %d", got, want)
+	}
+}
 
 func TestBuildGraphFragmentExport_SeparatesInternalAndExternalCalls(t *testing.T) {
 	t.Parallel()

--- a/internal/scan/fragment_reachability_test.go
+++ b/internal/scan/fragment_reachability_test.go
@@ -75,8 +75,8 @@ func TestBuildGraphFragmentExport13_DerivesSupportingCallsFromObjectLifecycle(t 
 		Ecosystem:  "java",
 	})
 
-	if payload.SchemaVersion != "graph-fragment-1.6" {
-		t.Fatalf("SchemaVersion = %q, want graph-fragment-1.6", payload.SchemaVersion)
+	if payload.SchemaVersion != graphfrag.SchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", payload.SchemaVersion, graphfrag.SchemaVersion)
 	}
 
 	// The terminal finding is the only crypto annotation; the lifecycle calls are

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -3,7 +3,12 @@
 
 package graphfrag
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
 
 // SchemaVersion is the current graph-fragment export schema version.
 //
@@ -29,7 +34,11 @@ import "encoding/json"
 // target in closure, without changing the fail-closed default for call sites
 // inference did not resolve. Additive: a 1.5 fragment decodes with an empty
 // resolved_receiver_type, which the stitcher treats exactly as before.
-const SchemaVersion = "graph-fragment-1.6"
+//
+// 1.7 adds internal_edges_compact plus internal_edge_strings. It carries the
+// same internal edge fields as internal_edges, but indexes repeated strings and
+// function keys to keep large dependency fragments small.
+const SchemaVersion = "graph-fragment-1.7"
 
 // GraphAlgoVersion identifies the callgraph-CONSTRUCTION algorithm version. It
 // is independent of the binary version (cf_version) and the wire schema
@@ -44,14 +53,97 @@ const GraphAlgoVersion = "graph-algo-1"
 // crypto-finder's public contract; the scanner (internal/scan) builds it from a
 // callgraph, and any consumer decodes it into a Fragment via DecodeFragment.
 type GraphFragmentExport struct {
-	SchemaVersion     string                          `json:"schema_version"`
-	ScanMetadata      GraphFragmentScanMetadata       `json:"scan_metadata"`
-	Functions         []GraphFragmentFunction         `json:"functions"`
-	InternalEdges     []GraphFragmentEdge             `json:"internal_edges,omitempty"`
-	ExternalCalls     []GraphFragmentExternal         `json:"external_calls,omitempty"`
-	CryptoAnnotations []GraphFragmentCryptoOp         `json:"crypto_annotations,omitempty"`
-	SupportingCalls   []GraphFragmentSupporting       `json:"supporting_calls,omitempty"`
-	CryptoEntryPoints []GraphFragmentCryptoEntryPoint `json:"crypto_entry_points,omitempty"`
+	SchemaVersion        string                          `json:"schema_version"`
+	ScanMetadata         GraphFragmentScanMetadata       `json:"scan_metadata"`
+	Functions            []GraphFragmentFunction         `json:"functions"`
+	InternalEdges        []GraphFragmentEdge             `json:"internal_edges,omitempty"`
+	InternalEdgeStrings  []string                        `json:"internal_edge_strings,omitempty"`
+	CompactInternalEdges []GraphFragmentCompactEdge      `json:"internal_edges_compact,omitempty"`
+	ExternalCalls        []GraphFragmentExternal         `json:"external_calls,omitempty"`
+	CryptoAnnotations    []GraphFragmentCryptoOp         `json:"crypto_annotations,omitempty"`
+	SupportingCalls      []GraphFragmentSupporting       `json:"supporting_calls,omitempty"`
+	CryptoEntryPoints    []GraphFragmentCryptoEntryPoint `json:"crypto_entry_points,omitempty"`
+}
+
+// GraphFragmentCompactEdge is the graph-fragment-1.7 compact form of
+// GraphFragmentEdge. JSON is a positional array:
+// [caller_fn, callee_fn, line, resolution_s, declared_type_s, method_s, arity,
+//
+//	receiver_var_s, assigned_var_s, chain_id_s, start_col, end_col,
+//	resolved_receiver_type_s, entry_call].
+//
+// Function indexes address GraphFragmentExport.Functions; string indexes
+// address GraphFragmentExport.InternalEdgeStrings.
+type GraphFragmentCompactEdge struct {
+	Caller, Callee                       int
+	Line                                 int
+	Resolution, DeclaredType, MethodName int
+	Arity                                int
+	ReceiverVar, AssignedVar, ChainID    int
+	StartCol, EndCol                     int
+	ResolvedReceiverType                 int
+	EntryCall                            *GraphFragmentCallSite
+}
+
+func (e GraphFragmentCompactEdge) MarshalJSON() ([]byte, error) {
+	values := []int{
+		e.Caller, e.Callee, e.Line, e.Resolution, e.DeclaredType, e.MethodName,
+		e.Arity, e.ReceiverVar, e.AssignedVar, e.ChainID, e.StartCol, e.EndCol,
+		e.ResolvedReceiverType,
+	}
+	last := len(values) - 1
+	for last >= 0 && values[last] == 0 {
+		last--
+	}
+	if e.EntryCall != nil {
+		last = len(values)
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	for i := 0; i <= last; i++ {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		if i == len(values) {
+			data, err := json.Marshal(e.EntryCall)
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(data)
+			continue
+		}
+		buf.WriteString(strconv.Itoa(values[i]))
+	}
+	buf.WriteByte(']')
+	return buf.Bytes(), nil
+}
+
+func (e *GraphFragmentCompactEdge) UnmarshalJSON(data []byte) error {
+	var values []json.RawMessage
+	if err := json.Unmarshal(data, &values); err != nil {
+		return err
+	}
+	ints := []*int{
+		&e.Caller, &e.Callee, &e.Line, &e.Resolution, &e.DeclaredType, &e.MethodName,
+		&e.Arity, &e.ReceiverVar, &e.AssignedVar, &e.ChainID, &e.StartCol, &e.EndCol,
+		&e.ResolvedReceiverType,
+	}
+	if len(values) > len(ints)+1 {
+		return fmt.Errorf("graphfrag: compact edge has %d fields, want at most %d", len(values), len(ints)+1)
+	}
+	for i := 0; i < len(values) && i < len(ints); i++ {
+		if err := json.Unmarshal(values[i], ints[i]); err != nil {
+			return fmt.Errorf("graphfrag: compact edge field %d: %w", i, err)
+		}
+	}
+	if len(values) == len(ints)+1 && len(values[len(ints)]) > 0 && string(values[len(ints)]) != "null" {
+		var call GraphFragmentCallSite
+		if err := json.Unmarshal(values[len(ints)], &call); err != nil {
+			return fmt.Errorf("graphfrag: compact edge entry_call: %w", err)
+		}
+		e.EntryCall = &call
+	}
+	return nil
 }
 
 // GraphFragmentScanMetadata summarizes the scan that produced a graph-fragment

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -85,6 +85,7 @@ type GraphFragmentCompactEdge struct {
 	EntryCall                            *GraphFragmentCallSite
 }
 
+// MarshalJSON encodes the compact edge as a positional JSON array.
 func (e GraphFragmentCompactEdge) MarshalJSON() ([]byte, error) {
 	values := []int{
 		e.Caller, e.Callee, e.Line, e.Resolution, e.DeclaredType, e.MethodName,
@@ -118,6 +119,7 @@ func (e GraphFragmentCompactEdge) MarshalJSON() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// UnmarshalJSON decodes the compact positional edge array.
 func (e *GraphFragmentCompactEdge) UnmarshalJSON(data []byte) error {
 	var values []json.RawMessage
 	if err := json.Unmarshal(data, &values); err != nil {

--- a/pkg/graphfrag/export_test.go
+++ b/pkg/graphfrag/export_test.go
@@ -187,13 +187,11 @@ func TestGraphFragmentCryptoOp_JSONRoundTrip(t *testing.T) {
 	}
 }
 
-// TestSchemaVersion_Is_1_6 verifies the schema version constant has been bumped.
-// 1.6 adds resolved_receiver_type on internal_edges/external_calls (the
-// concrete receiver type the producer's KB-contract/return-type inference
-// resolved for an interface-dispatch call site) — additive over 1.5.
-func TestSchemaVersion_Is_1_6(t *testing.T) {
+// TestSchemaVersion_Is_1_7 verifies the schema version constant has been bumped.
+// 1.7 adds compact internal edge encoding with the same data as internal_edges.
+func TestSchemaVersion_Is_1_7(t *testing.T) {
 	t.Parallel()
-	if SchemaVersion != "graph-fragment-1.6" {
-		t.Errorf("SchemaVersion = %q, want graph-fragment-1.6", SchemaVersion)
+	if SchemaVersion != "graph-fragment-1.7" {
+		t.Errorf("SchemaVersion = %q, want graph-fragment-1.7", SchemaVersion)
 	}
 }

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -23,8 +23,20 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 		GraphAlgoVersion: e.ScanMetadata.GraphAlgoVersion,
 	}
 
-	for i := range e.Functions {
-		fn := &e.Functions[i]
+	appendFragmentFunctions(&frag, e.Functions)
+	functionKeys := graphFragmentFunctionKeys(e.Functions)
+	appendCompactInternalEdges(&frag, functionKeys, e.InternalEdgeStrings, e.CompactInternalEdges)
+	appendInternalEdges(&frag, e.InternalEdges)
+	appendExternalCalls(&frag, e.ExternalCalls)
+	appendCryptoOperations(&frag, e.CryptoAnnotations)
+	appendSupportingCalls(&frag, e.SupportingCalls)
+	frag.CryptoEntryPoints = appendCryptoEntryPoints(frag.CryptoEntryPoints, e.CryptoEntryPoints)
+	return frag
+}
+
+func appendFragmentFunctions(frag *Fragment, functions []GraphFragmentFunction) {
+	for i := range functions {
+		fn := &functions[i]
 		frag.Functions = append(frag.Functions, Function{
 			Signature:          fn.Key,
 			FunctionName:       fn.FunctionName,
@@ -40,74 +52,91 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			Aliases:            append([]string(nil), fn.Aliases...),
 		})
 	}
-	functionKeys := make([]string, len(e.Functions))
-	for i := range e.Functions {
-		functionKeys[i] = e.Functions[i].Key
+}
+
+func graphFragmentFunctionKeys(functions []GraphFragmentFunction) []string {
+	keys := make([]string, len(functions))
+	for i := range functions {
+		keys[i] = functions[i].Key
 	}
-	for i := range e.CompactInternalEdges {
-		ie := &e.CompactInternalEdges[i]
-		edge := InternalEdge{
+	return keys
+}
+
+func appendCompactInternalEdges(
+	frag *Fragment,
+	functionKeys []string,
+	strings []string,
+	edges []GraphFragmentCompactEdge,
+) {
+	for i := range edges {
+		ie := &edges[i]
+		frag.InternalEdges = append(frag.InternalEdges, InternalEdge{
 			Caller:               functionKeyAt(functionKeys, ie.Caller),
 			Callee:               functionKeyAt(functionKeys, ie.Callee),
-			Resolution:           normalizeResolutionKind(stringAt(e.InternalEdgeStrings, ie.Resolution)),
-			DeclaredType:         stringAt(e.InternalEdgeStrings, ie.DeclaredType),
-			MethodName:           stringAt(e.InternalEdgeStrings, ie.MethodName),
+			Resolution:           normalizeResolutionKind(stringAt(strings, ie.Resolution)),
+			DeclaredType:         stringAt(strings, ie.DeclaredType),
+			MethodName:           stringAt(strings, ie.MethodName),
 			Arity:                ie.Arity,
 			CallSite:             ie.Line,
-			ReceiverVar:          stringAt(e.InternalEdgeStrings, ie.ReceiverVar),
-			AssignedVar:          stringAt(e.InternalEdgeStrings, ie.AssignedVar),
-			ChainID:              stringAt(e.InternalEdgeStrings, ie.ChainID),
+			ReceiverVar:          stringAt(strings, ie.ReceiverVar),
+			AssignedVar:          stringAt(strings, ie.AssignedVar),
+			ChainID:              stringAt(strings, ie.ChainID),
 			StartCol:             ie.StartCol,
 			EndCol:               ie.EndCol,
 			EntryCall:            toCallSite(ie.EntryCall),
-			ResolvedReceiverType: stringAt(e.InternalEdgeStrings, ie.ResolvedReceiverType),
-		}
-		frag.InternalEdges = append(frag.InternalEdges, edge)
+			ResolvedReceiverType: stringAt(strings, ie.ResolvedReceiverType),
+		})
 	}
-	for i := range e.InternalEdges {
-		ie := &e.InternalEdges[i]
-		edge := InternalEdge{
-			Caller:       ie.CallerKey,
-			Callee:       ie.CalleeKey,
-			Resolution:   normalizeResolutionKind(ie.Resolution),
-			DeclaredType: ie.DeclaredType,
-			MethodName:   ie.MethodName,
-			Arity:        ie.Arity,
-			CallSite:     ie.Line,
-			ReceiverVar:  ie.ReceiverVar,
-			AssignedVar:  ie.AssignedVar,
-			ChainID:      ie.ChainID,
-			StartCol:     ie.StartCol,
-			EndCol:       ie.EndCol,
-			EntryCall:    toCallSite(ie.EntryCall),
+}
 
+func appendInternalEdges(frag *Fragment, edges []GraphFragmentEdge) {
+	for i := range edges {
+		ie := &edges[i]
+		frag.InternalEdges = append(frag.InternalEdges, InternalEdge{
+			Caller:               ie.CallerKey,
+			Callee:               ie.CalleeKey,
+			Resolution:           normalizeResolutionKind(ie.Resolution),
+			DeclaredType:         ie.DeclaredType,
+			MethodName:           ie.MethodName,
+			Arity:                ie.Arity,
+			CallSite:             ie.Line,
+			ReceiverVar:          ie.ReceiverVar,
+			AssignedVar:          ie.AssignedVar,
+			ChainID:              ie.ChainID,
+			StartCol:             ie.StartCol,
+			EndCol:               ie.EndCol,
+			EntryCall:            toCallSite(ie.EntryCall),
 			ResolvedReceiverType: ie.ResolvedReceiverType,
-		}
-		frag.InternalEdges = append(frag.InternalEdges, edge)
+		})
 	}
-	for i := range e.ExternalCalls {
-		ec := &e.ExternalCalls[i]
-		frag.ExternalCalls = append(frag.ExternalCalls, ExternalCall{
-			Caller:          ec.CallerKey,
-			TargetSignature: ec.TargetKey,
-			Raw:             ec.Raw,
-			Resolution:      normalizeResolutionKind(ec.Resolution),
-			DeclaredType:    ec.DeclaredType,
-			MethodName:      ec.MethodName,
-			Arity:           ec.Arity,
-			CallSite:        ec.Line,
-			ReceiverVar:     ec.ReceiverVar,
-			AssignedVar:     ec.AssignedVar,
-			ChainID:         ec.ChainID,
-			StartCol:        ec.StartCol,
-			EndCol:          ec.EndCol,
-			EntryCall:       toCallSite(ec.EntryCall),
+}
 
+func appendExternalCalls(frag *Fragment, calls []GraphFragmentExternal) {
+	for i := range calls {
+		ec := &calls[i]
+		frag.ExternalCalls = append(frag.ExternalCalls, ExternalCall{
+			Caller:               ec.CallerKey,
+			TargetSignature:      ec.TargetKey,
+			Raw:                  ec.Raw,
+			Resolution:           normalizeResolutionKind(ec.Resolution),
+			DeclaredType:         ec.DeclaredType,
+			MethodName:           ec.MethodName,
+			Arity:                ec.Arity,
+			CallSite:             ec.Line,
+			ReceiverVar:          ec.ReceiverVar,
+			AssignedVar:          ec.AssignedVar,
+			ChainID:              ec.ChainID,
+			StartCol:             ec.StartCol,
+			EndCol:               ec.EndCol,
+			EntryCall:            toCallSite(ec.EntryCall),
 			ResolvedReceiverType: ec.ResolvedReceiverType,
 		})
 	}
-	for i := range e.CryptoAnnotations {
-		op := &e.CryptoAnnotations[i]
+}
+
+func appendCryptoOperations(frag *Fragment, ops []GraphFragmentCryptoOp) {
+	for i := range ops {
+		op := &ops[i]
 		frag.CryptoOperations = append(frag.CryptoOperations, CryptoOperation{
 			Function:          op.FunctionKey,
 			FindingID:         op.FindingID,
@@ -125,8 +154,11 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			SupportingCallIDs: append([]string(nil), op.SupportingCallIDs...),
 		})
 	}
-	for i := range e.SupportingCalls {
-		s := &e.SupportingCalls[i]
+}
+
+func appendSupportingCalls(frag *Fragment, calls []GraphFragmentSupporting) {
+	for i := range calls {
+		s := &calls[i]
 		frag.SupportingCalls = append(frag.SupportingCalls, SupportingCall{
 			Function:           s.FunctionKey,
 			SupportingID:       s.SupportingID,
@@ -143,8 +175,6 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			MatchedOperation:   toMatchedOp(s.MatchedOperation),
 		})
 	}
-	frag.CryptoEntryPoints = appendCryptoEntryPoints(frag.CryptoEntryPoints, e.CryptoEntryPoints)
-	return frag
 }
 
 func functionKeyAt(values []string, idx int) string {

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -25,8 +25,11 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 
 	appendFragmentFunctions(&frag, e.Functions)
 	functionKeys := graphFragmentFunctionKeys(e.Functions)
-	appendCompactInternalEdges(&frag, functionKeys, e.InternalEdgeStrings, e.CompactInternalEdges)
-	appendInternalEdges(&frag, e.InternalEdges)
+	if len(e.CompactInternalEdges) > 0 {
+		appendCompactInternalEdges(&frag, functionKeys, e.InternalEdgeStrings, e.CompactInternalEdges)
+	} else {
+		appendInternalEdges(&frag, e.InternalEdges)
+	}
 	appendExternalCalls(&frag, e.ExternalCalls)
 	appendCryptoOperations(&frag, e.CryptoAnnotations)
 	appendSupportingCalls(&frag, e.SupportingCalls)

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -40,6 +40,30 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 			Aliases:            append([]string(nil), fn.Aliases...),
 		})
 	}
+	functionKeys := make([]string, len(e.Functions))
+	for i := range e.Functions {
+		functionKeys[i] = e.Functions[i].Key
+	}
+	for i := range e.CompactInternalEdges {
+		ie := &e.CompactInternalEdges[i]
+		edge := InternalEdge{
+			Caller:               functionKeyAt(functionKeys, ie.Caller),
+			Callee:               functionKeyAt(functionKeys, ie.Callee),
+			Resolution:           normalizeResolutionKind(stringAt(e.InternalEdgeStrings, ie.Resolution)),
+			DeclaredType:         stringAt(e.InternalEdgeStrings, ie.DeclaredType),
+			MethodName:           stringAt(e.InternalEdgeStrings, ie.MethodName),
+			Arity:                ie.Arity,
+			CallSite:             ie.Line,
+			ReceiverVar:          stringAt(e.InternalEdgeStrings, ie.ReceiverVar),
+			AssignedVar:          stringAt(e.InternalEdgeStrings, ie.AssignedVar),
+			ChainID:              stringAt(e.InternalEdgeStrings, ie.ChainID),
+			StartCol:             ie.StartCol,
+			EndCol:               ie.EndCol,
+			EntryCall:            toCallSite(ie.EntryCall),
+			ResolvedReceiverType: stringAt(e.InternalEdgeStrings, ie.ResolvedReceiverType),
+		}
+		frag.InternalEdges = append(frag.InternalEdges, edge)
+	}
 	for i := range e.InternalEdges {
 		ie := &e.InternalEdges[i]
 		edge := InternalEdge{
@@ -121,6 +145,20 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 	}
 	frag.CryptoEntryPoints = appendCryptoEntryPoints(frag.CryptoEntryPoints, e.CryptoEntryPoints)
 	return frag
+}
+
+func functionKeyAt(values []string, idx int) string {
+	if idx < 0 || idx >= len(values) {
+		return ""
+	}
+	return values[idx]
+}
+
+func stringAt(values []string, idx int) string {
+	if idx < 0 || idx >= len(values) {
+		return ""
+	}
+	return values[idx]
 }
 
 func appendCryptoEntryPoints(dst []CryptoEntryPoint, src []GraphFragmentCryptoEntryPoint) []CryptoEntryPoint {

--- a/pkg/graphfrag/ingest_test.go
+++ b/pkg/graphfrag/ingest_test.go
@@ -329,3 +329,30 @@ func TestStitch_EndToEnd_BouncyCastleFalsePositiveKilled(t *testing.T) {
 		t.Fatalf("expected the over-broad get() edge to be recorded as suppressed name_only: %#v", res.Suppressed)
 	}
 }
+
+func TestDecodeFragment_PrefersCompactInternalEdgesWhenBothFormatsPresent(t *testing.T) {
+	t.Parallel()
+
+	export := GraphFragmentExport{
+		ScanMetadata: GraphFragmentScanMetadata{RootModule: "app"},
+		Functions: []GraphFragmentFunction{
+			{Key: "caller"},
+			{Key: "callee"},
+		},
+		InternalEdgeStrings: []string{"", "exact"},
+		CompactInternalEdges: []GraphFragmentCompactEdge{
+			{Caller: 0, Callee: 1, Line: 10, Resolution: 1},
+		},
+		InternalEdges: []GraphFragmentEdge{
+			{CallerKey: "caller", CalleeKey: "callee", Line: 10, Resolution: "exact"},
+		},
+	}
+
+	frag := export.ToFragment(ComponentKey{Purl: "pkg:maven/app", Version: "1.0.0"})
+	if len(frag.InternalEdges) != 1 {
+		t.Fatalf("InternalEdges len = %d, want 1", len(frag.InternalEdges))
+	}
+	if frag.InternalEdges[0].Caller != "caller" || frag.InternalEdges[0].Callee != "callee" {
+		t.Fatalf("InternalEdges[0] = %+v, want caller -> callee", frag.InternalEdges[0])
+	}
+}

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -123,6 +123,7 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 	}
 
 	functionsBySignature := indexFunctions(closure, fragments)
+	functionsByNode := indexFunctionsByNode(closure, fragments)
 	adjacency, suppressed := buildAdjacency(closure, deps, fragments, functionsBySignature)
 	opsByNode := indexCryptoOperations(closure, fragments)
 	supportingByNode := indexSupportingCalls(closure, fragments)
@@ -139,10 +140,10 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		// callgraph matches live byte-for-byte (the parity contract) and stays
 		// bounded on high-fan-in libraries (BouncyCastle, 18k functions) where the
 		// old all-simple-paths forward DFS hangs.
-		traceBackward(adjacency, opsByNode, supportingByNode, fragments, roots, &out)
+		traceBackward(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, roots, &out)
 		attachAnnotationSupportingCalls(closure, fragments, &out)
 		if opts.ForwardClosure {
-			out.forwardClosures = buildForwardClosures(adjacency, opsByNode, supportingByNode, fragments, forwardCapsFrom(opts))
+			out.forwardClosures = buildForwardClosures(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
 		}
 		return &out, nil
 	}
@@ -153,11 +154,11 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 	// fail-closed and parallel-edge tests; it is NOT under the live parity contract
 	// (that contract is the serving path above) and keeps its exact prior output.
 	for _, start := range roots {
-		trace(start, adjacency, opsByNode, supportingByNode, fragments, nil, nil, map[graphNode]bool{}, &out)
+		trace(start, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, nil, nil, map[graphNode]bool{}, &out)
 	}
 	attachAnnotationSupportingCalls(closure, fragments, &out)
 	if opts.ForwardClosure {
-		out.forwardClosures = buildForwardClosures(adjacency, opsByNode, supportingByNode, fragments, forwardCapsFrom(opts))
+		out.forwardClosures = buildForwardClosures(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
 	}
 	return &out, nil
 }
@@ -329,6 +330,18 @@ func indexFunctions(closure []ComponentKey, fragments map[ComponentKey]Fragment)
 		for i := range fragment.Functions {
 			node := graphNode{Component: key, Function: fragment.Functions[i].Signature}
 			out[fragment.Functions[i].Signature] = append(out[fragment.Functions[i].Signature], node)
+		}
+	}
+	return out
+}
+
+func indexFunctionsByNode(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[graphNode]Function {
+	out := make(map[graphNode]Function)
+	for _, key := range closure {
+		fragment := fragments[key]
+		for i := range fragment.Functions {
+			fn := fragment.Functions[i]
+			out[graphNode{Component: key, Function: fn.Signature}] = fn
 		}
 	}
 	return out
@@ -819,6 +832,7 @@ func traceBackward(
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	roots []graphNode,
 	out *Result,
 ) {
@@ -843,7 +857,7 @@ func traceBackward(
 			chains = []backwardChain{{nodes: []graphNode{opNode}, entryCalls: []*CallSite{nil}}}
 		}
 		for _, chain := range chains {
-			emitChain(opNode, chain, opsByNode, supportingByNode, fragments, supportingSeen, out)
+			emitChain(opNode, chain, opsByNode, supportingByNode, fragments, functionsByNode, supportingSeen, out)
 		}
 	}
 }
@@ -949,12 +963,13 @@ func emitChain(
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	supportingSeen map[graphNode]bool,
 	out *Result,
 ) {
 	frames := make([]CallFrame, len(chain.nodes))
 	for i, node := range chain.nodes {
-		frames[i] = buildFrame(node, chain.entryCalls[i], fragments)
+		frames[i] = buildFrame(node, chain.entryCalls[i], fragments, functionsByNode)
 	}
 
 	// Flush supporting calls in entry->op order so output ordering matches the old
@@ -986,7 +1001,12 @@ func emitChain(
 
 // buildFrame resolves one node into a CallFrame, stamping the resolved Function
 // identity from the fragment and the EntryCall of the edge that led to this frame.
-func buildFrame(node graphNode, entryCall *CallSite, fragments map[ComponentKey]Fragment) CallFrame {
+func buildFrame(
+	node graphNode,
+	entryCall *CallSite,
+	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
+) CallFrame {
 	frame := CallFrame{
 		Component: node.Component,
 		Signature: node.Function,
@@ -994,12 +1014,9 @@ func buildFrame(node graphNode, entryCall *CallSite, fragments map[ComponentKey]
 	}
 	if frag, ok := fragments[node.Component]; ok {
 		frame.Module = frag.Module
-		for i := range frag.Functions {
-			if frag.Functions[i].Signature == node.Function {
-				frame.Function = frag.Functions[i]
-				break
-			}
-		}
+	}
+	if fn, ok := functionsByNode[node]; ok {
+		frame.Function = fn
 	}
 	return frame
 }
@@ -1037,6 +1054,7 @@ func trace(
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	traversedEdgeEntryCall *CallSite,
 	path []CallFrame,
 	visiting map[graphNode]bool,
@@ -1048,7 +1066,7 @@ func trace(
 	visiting[current] = true
 	defer delete(visiting, current)
 
-	frame := buildFrame(current, traversedEdgeEntryCall, fragments)
+	frame := buildFrame(current, traversedEdgeEntryCall, fragments, functionsByNode)
 
 	path = append(path, frame)
 	flushSupportingCalls(current, &frame, supportingByNode, out)
@@ -1069,7 +1087,7 @@ func trace(
 	}
 	for _, edge := range adjacency[current] {
 		// Carry the EntryCall from this edge to the next frame.
-		trace(edge.target, adjacency, opsByNode, supportingByNode, fragments, edge.entryCall, path, visiting, out)
+		trace(edge.target, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, edge.entryCall, path, visiting, out)
 	}
 }
 
@@ -1119,6 +1137,7 @@ func buildForwardClosures(
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	caps forwardCaps,
 ) map[graphNode]*forwardClosure {
 	memo := make(map[graphNode]*forwardClosure, len(opsByNode))
@@ -1126,7 +1145,7 @@ func buildForwardClosures(
 		if _, ok := memo[anchor]; ok {
 			continue
 		}
-		memo[anchor] = forwardBFS(anchor, adjacency, opsByNode, supportingByNode, fragments, caps)
+		memo[anchor] = forwardBFS(anchor, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, caps)
 	}
 	return memo
 }
@@ -1145,10 +1164,11 @@ func forwardBFS(
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	caps forwardCaps,
 ) *forwardClosure {
 	fc := &forwardClosure{
-		anchor:   buildFrame(anchor, nil, fragments),
+		anchor:   buildFrame(anchor, nil, fragments, functionsByNode),
 		maxDepth: caps.maxDepth,
 	}
 
@@ -1156,6 +1176,7 @@ func forwardBFS(
 		fc:               fc,
 		caps:             caps,
 		fragments:        fragments,
+		functionsByNode:  functionsByNode,
 		opsByNode:        opsByNode,
 		supportingByNode: supportingByNode,
 		visited:          map[graphNode]bool{anchor: true},
@@ -1203,6 +1224,7 @@ type forwardBFSState struct {
 	fc               *forwardClosure
 	caps             forwardCaps
 	fragments        map[ComponentKey]Fragment
+	functionsByNode  map[graphNode]Function
 	opsByNode        map[graphNode][]CryptoOperation
 	supportingByNode map[graphNode][]SupportingCall
 	visited          map[graphNode]bool
@@ -1231,7 +1253,7 @@ func (s *forwardBFSState) visitEdge(cur graphNode, d int, edge adjacencyEdge) (g
 		}
 		s.visited[target] = true
 		s.depth[target] = d + 1
-		s.fc.nodes = append(s.fc.nodes, buildForwardNode(target, d+1, s.fragments, s.opsByNode, s.supportingByNode))
+		s.fc.nodes = append(s.fc.nodes, buildForwardNode(target, d+1, s.fragments, s.functionsByNode, s.opsByNode, s.supportingByNode))
 		s.edgeSeen[key] = true
 		s.fc.edges = append(s.fc.edges, forwardEdge{from: cur, to: target, entryCall: edge.entryCall})
 		return target, true
@@ -1259,13 +1281,14 @@ func buildForwardNode(
 	node graphNode,
 	depth int,
 	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 ) forwardNode {
 	category := firstSupportingCategory(supportingByNode[node])
 	return forwardNode{
 		node:               node,
-		frame:              buildFrame(node, nil, fragments),
+		frame:              buildFrame(node, nil, fragments, functionsByNode),
 		depth:              depth,
 		cryptoRelevant:     len(opsByNode[node]) > 0 || category != "",
 		supportingCategory: category,


### PR DESCRIPTION
## Summary

- Stream large JSON report/export paths instead of buffering whole encoded payloads before writing.
- Add compact graph-fragment internal edge encoding while preserving edge data for ingest/reconstruction.
- Stream-build callgraph finding graphs and optimize hot lookup paths used during large scans.
- Prune dependency callgraph inputs to packages that can sit on a user-to-crypto dependency path when the resolver graph proves it; fall back conservatively when it cannot.
- Populate Maven dependency graph metadata best-effort with a bounded `dependency:tree` call so Java scans can use the same pruning path.
- Drop no-finding dependency reports from memory after caching and use a safer Java default for dependency scan workers.

## Benchmarks

bcprov-jdk15on 1.70 mining-faithful scan, with both graph fragment and callgraph exports:

| Metric | Result |
|---|---:|
| Elapsed | 129.457s |
| Max RSS | ~3.69 GiB |
| Fragment output | ~209 MB |
| Callgraph output | ~656 MB |
| Findings | 1,748 |
| Functions | 19,230 |
| Internal edges | 3,907,909 |
| Crypto entry points | 2,156 |

## Dependency scanning changes

`--scan-dependencies` is not recursive-exponential: dependencies are canonicalized and scanned once. The remaining expensive path is the combined callgraph build. This PR reduces that cost by using resolver graph proof to avoid parsing dependencies that cannot be on any root-to-crypto-dependency path, while preserving the old all-deps behavior when the graph is missing or incomplete.

For Maven, graph extraction is best-effort and bounded. If `dependency:tree` is slow, missing, or incomplete, the scan keeps the conservative pre-existing behavior.

Important data-quality guard: the dependency callgraph is still built even when dependency source scans produce zero direct findings, because API-boundary synthesis and dependency bridge paths can require the graph.

## Validation

- [x] `git diff --check`
- [x] `make lint`
- [x] `GOCACHE=/private/tmp/crypto-finder-bcprov-bench/cache go test ./internal/engine -run 'TestDependency(ScanWorkers|Scanner_(CollectPackageSets|ScanSingleDep|ScanDependenciesParallel|ScanWithDependencies_NoDepsAndErrors))|TestMavenResolver'`
- [x] `GOCACHE=/private/tmp/crypto-finder-bcprov-bench/cache go test ./internal/dependency ./internal/cli ./internal/scan ./pkg/...`
- [x] Fresh-cache smoke: `client-encryption-java` with `--scan-dependencies --dep-ecosystem java --dep-workers=1 --no-cache --no-remote-rules`, isolated `HOME=/private/tmp/crypto-finder-client-java-smoke/run2/home`; exit 0, 47s, 84 assets, fragment exported.

## Notes

Full `go test ./...` was not run locally because the broader suite includes Docker/testcontainers-backed Postgres tests that are not suitable for this sandboxed worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph-fragment exports now use a newer schema and include a compact internal-edge format for smaller output files.
  * Maven dependency scanning now captures dependency graph data when available.
  * Scan tooling now supports disabling findings caching entirely.

* **Bug Fixes**
  * JSON exports now stream directly to files, reducing memory use and improving reliability on large outputs.
  * Exported JSON preserves special characters without HTML escaping.

* **Performance**
  * Dependency and graph export handling is more efficient for large projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->