### PR TITLE
Call graph performance: fix constructor dispatch fan-out, parallelize parsing, optimize hot paths

### DIFF
--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -299,6 +299,9 @@ func (b *Builder) buildCallerIndex(graph *CallGraph) {
 		methodsByQualifiedArity: indexMethodsByQualifiedArity(graph),
 		subclassByTypeName:      indexSubclassByTypeName(graph),
 		knownClassTypes:         indexKnownClassTypes(graph),
+		interfaceDispatchMemo:   make(map[string][]interfaceDispatchAlias),
+		abstractDispatchMemo:    make(map[string][]interfaceDispatchAlias),
+		callerSeen:              make(map[string]map[string]struct{}),
 	}
 
 	for callerKey, fn := range graph.Functions {
@@ -311,11 +314,59 @@ func (b *Builder) buildCallerIndex(graph *CallGraph) {
 // dispatchIndexes bundles the lookup tables buildCallerIndex needs to expand
 // one call site into all of its dispatch aliases (overloads, interface/abstract
 // virtual dispatch, Python subclass dispatch, fluent fallback).
+//
+// interfaceDispatchMemo/abstractDispatchMemo cache expansion results per callee
+// target: both expansions depend only on the target and the (immutable during
+// buildCallerIndex) graph/index state, while popular targets are re-expanded
+// once per call site — on dispatch-heavy corpora such as bcprov the same
+// interface method is expanded thousands of times. A nil slice is a valid
+// cached value, so presence is tracked with the two-value map lookup.
+//
+// callerSeen mirrors graph.Callers as callee → set-of-callers so the hot path
+// can dedup in O(1) instead of addCaller's linear scan over fan-in slices.
+// Only buildCallerIndex uses it; later passes call addCaller at low volume.
 type dispatchIndexes struct {
 	methodsByName           map[string][]*FunctionDecl
 	methodsByQualifiedArity map[string][]string
 	subclassByTypeName      map[string][]*FunctionDecl
 	knownClassTypes         map[string]bool
+	interfaceDispatchMemo   map[string][]interfaceDispatchAlias
+	abstractDispatchMemo    map[string][]interfaceDispatchAlias
+	callerSeen              map[string]map[string]struct{}
+}
+
+// addCallerIndexed is addCaller's O(1) equivalent for the buildCallerIndex hot
+// path, backed by the dispatchIndexes.callerSeen set. Semantics are identical:
+// append callerKey to callers[calleeKey] unless already present.
+func (idx dispatchIndexes) addCallerIndexed(callers map[string][]string, calleeKey, callerKey string) {
+	set := idx.callerSeen[calleeKey]
+	if set == nil {
+		set = make(map[string]struct{}, 4)
+		idx.callerSeen[calleeKey] = set
+	}
+	if _, dup := set[callerKey]; dup {
+		return
+	}
+	set[callerKey] = struct{}{}
+	callers[calleeKey] = append(callers[calleeKey], callerKey)
+}
+
+func (idx dispatchIndexes) expandInterfaceDispatchMemoized(b *Builder, calleeKey string, graph *CallGraph) []interfaceDispatchAlias {
+	if aliases, ok := idx.interfaceDispatchMemo[calleeKey]; ok {
+		return aliases
+	}
+	aliases := b.expandInterfaceDispatch(calleeKey, graph, idx.methodsByName)
+	idx.interfaceDispatchMemo[calleeKey] = aliases
+	return aliases
+}
+
+func (idx dispatchIndexes) expandAbstractClassDispatchMemoized(b *Builder, callee FunctionID, calleeKey string, graph *CallGraph) []interfaceDispatchAlias {
+	if aliases, ok := idx.abstractDispatchMemo[calleeKey]; ok {
+		return aliases
+	}
+	aliases := b.expandAbstractClassDispatch(callee, graph, idx.methodsByName, idx.knownClassTypes)
+	idx.abstractDispatchMemo[calleeKey] = aliases
+	return aliases
 }
 
 // indexCallDispatch records the direct edge for one call site plus every
@@ -324,36 +375,36 @@ type dispatchIndexes struct {
 // classification.
 func (b *Builder) indexCallDispatch(graph *CallGraph, callerKey string, call FunctionCall, idx dispatchIndexes) {
 	calleeKey := call.Callee.String()
-	addCaller(graph.Callers, calleeKey, callerKey)
+	idx.addCallerIndexed(graph.Callers, calleeKey, callerKey)
 	recordEdgeResolution(graph, callerKey, calleeKey, EdgeKindExact, "", call.Line)
 
 	overloadTargets := b.expandOverloadCandidates(call.Callee, idx.methodsByQualifiedArity)
 	resolvedTargets := make([]string, 1, 1+len(overloadTargets))
 	resolvedTargets[0] = calleeKey
 	for _, target := range overloadTargets {
-		addCaller(graph.Callers, target, callerKey)
+		idx.addCallerIndexed(graph.Callers, target, callerKey)
 		recordEdgeResolution(graph, callerKey, target, EdgeKindExact, "", call.Line)
 		resolvedTargets = append(resolvedTargets, target)
 	}
 
 	for _, target := range resolvedTargets {
-		for _, alias := range b.expandInterfaceDispatch(target, graph, idx.methodsByName) {
-			addCaller(graph.Callers, alias.CalleeKey, callerKey)
+		for _, alias := range idx.expandInterfaceDispatchMemoized(b, target, graph) {
+			idx.addCallerIndexed(graph.Callers, alias.CalleeKey, callerKey)
 			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
 		}
 		for _, alias := range b.expandPythonSubclassDispatch(target, graph, idx.subclassByTypeName) {
-			addCaller(graph.Callers, alias.CalleeKey, callerKey)
+			idx.addCallerIndexed(graph.Callers, alias.CalleeKey, callerKey)
 			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindPythonSubclassDispatch, alias.DeclaredType, call.Line)
 		}
 	}
 
-	for _, alias := range b.expandAbstractClassDispatch(call.Callee, graph, idx.methodsByName, idx.knownClassTypes) {
-		addCaller(graph.Callers, alias.CalleeKey, callerKey)
+	for _, alias := range idx.expandAbstractClassDispatchMemoized(b, call.Callee, calleeKey, graph) {
+		idx.addCallerIndexed(graph.Callers, alias.CalleeKey, callerKey)
 		recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
 	}
 
 	for _, alias := range b.expandFluentFallback(call, graph, idx.methodsByName) {
-		addCaller(graph.Callers, alias, callerKey)
+		idx.addCallerIndexed(graph.Callers, alias, callerKey)
 		recordEdgeResolution(graph, callerKey, alias, EdgeKindNameOnly, "", call.Line)
 	}
 }

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -729,6 +729,15 @@ func (b *Builder) expandAbstractClassDispatch(
 	if callee.Type == "" {
 		return nil
 	}
+	// Constructors and static initializers never dispatch virtually: `new Foo()`
+	// invokes exactly Foo.<init>, regardless of hierarchy. Without this guard, a
+	// constructor call whose exact declaration is missing from the graph (implicit
+	// default constructor, unparsed overload) fans out to EVERY same-arity
+	// constructor in the namespace root — on the bcprov corpus that synthesized
+	// 6.58M of the graph's 7.16M edges, all semantically impossible.
+	if base := BaseFunctionName(callee.Name); base == "<init>" || base == "<clinit>" {
+		return nil
+	}
 	calleeKey := callee.String()
 	if _, declared := graph.Functions[calleeKey]; declared {
 		return nil

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -34,6 +37,14 @@ type Parser interface {
 	SubPackagePath(parentPath, dirName string) string
 	// PackageSeparator returns the separator used in package paths ("/" for Go, "." for Java).
 	PackageSeparator() string
+}
+
+// ParserCloner is implemented by parsers that can produce an independent
+// instance of themselves for concurrent use. tree-sitter parsers are not
+// reentrant, so parallel source parsing requires one parser per worker; a
+// parser that does not implement this interface is used serially.
+type ParserCloner interface {
+	CloneParser() Parser
 }
 
 // PackageDir associates a filesystem directory with its package/module path.
@@ -186,9 +197,94 @@ func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) 
 }
 
 // analyzePackage parses all source files in a package directory,
-// recursing into subdirectories to handle sub-packages.
+// recursing into subdirectories to handle sub-packages. When the parser
+// supports cloning and more than one CPU is available, directories are parsed
+// concurrently; results are merged in the exact serial traversal order so the
+// collision handling in addAnalyses behaves identically either way.
 func (b *Builder) analyzePackage(pkg PackageDir, graph *CallGraph) error {
-	return b.analyzeDir(pkg.Dir, pkg.ImportPath, graph)
+	cloner, ok := b.parser.(ParserCloner)
+	workers := runtime.GOMAXPROCS(0)
+	if !ok || workers <= 1 {
+		return b.analyzeDir(pkg.Dir, pkg.ImportPath, graph)
+	}
+	return b.analyzePackageParallel(pkg, graph, cloner, workers)
+}
+
+// parseDirWork is one directory to parse: the unit of parallelism.
+type parseDirWork struct {
+	dir        string
+	importPath string
+}
+
+// collectParseDirs reproduces analyzeDir's pre-order traversal (directory
+// first, then its subdirectories in os.ReadDir order) without parsing, so
+// analyzePackageParallel can merge parse results in exactly the order the
+// serial path would have produced them.
+func (b *Builder) collectParseDirs(dir, importPath string, skipDirs map[string]bool) []parseDirWork {
+	work := []parseDirWork{{dir: dir, importPath: importPath}}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		log.Debug().Err(readErr).Str("dir", dir).Msg("Failed to read directory during call graph traversal")
+		return work
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || skipDirs[name] {
+			continue
+		}
+		subDir := filepath.Join(dir, name)
+		subImportPath := b.parser.SubPackagePath(importPath, name)
+		work = append(work, b.collectParseDirs(subDir, subImportPath, skipDirs)...)
+	}
+	return work
+}
+
+// analyzePackageParallel fans directory parsing out over a pool of workers,
+// each owning its own cloned parser instance, then merges the results in
+// serial traversal order. Mirrors the serial path's error contract: a failure
+// on the package's root directory aborts the package with that error (nothing
+// merged), while subdirectory failures are logged and skipped.
+func (b *Builder) analyzePackageParallel(pkg PackageDir, graph *CallGraph, cloner ParserCloner, workers int) error {
+	work := b.collectParseDirs(pkg.Dir, pkg.ImportPath, b.parser.SkipDirs())
+	if workers > len(work) {
+		workers = len(work)
+	}
+
+	results := make([][]*FileAnalysis, len(work))
+	errs := make([]error, len(work))
+	var next atomic.Int64
+	next.Store(-1)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			parser := cloner.CloneParser()
+			for {
+				i := int(next.Add(1))
+				if i >= len(work) {
+					return
+				}
+				results[i], errs[i] = parser.ParseDirectory(work[i].dir, work[i].importPath)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if errs[0] != nil {
+		return errs[0]
+	}
+	for i := range work {
+		if errs[i] != nil {
+			log.Debug().Err(errs[i]).Str("dir", work[i].dir).Msg("Failed to analyze subdirectory")
+			continue
+		}
+		b.addAnalyses(graph, results[i])
+	}
+	return nil
 }
 
 func (b *Builder) analyzeDir(dir, importPath string, graph *CallGraph) error {

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -103,10 +103,9 @@ func (b *Builder) PackageSeparator() string {
 func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) (*CallGraph, error) {
 	buildStart := time.Now()
 	graph := &CallGraph{
-		Functions:             make(map[string]*FunctionDecl),
-		Callers:               make(map[string][]string),
-		EdgeResolutions:       make(map[string]EdgeResolution),
-		EdgeResolutionsByPair: make(map[string][]EdgeResolution),
+		Functions:       make(map[string]*FunctionDecl),
+		Callers:         make(map[string][]string),
+		EdgeResolutions: make(map[string]EdgeResolution),
 	}
 
 	// Phase 1: Parse source files only for packages that need full analysis
@@ -529,39 +528,10 @@ func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind Ed
 		calleeKey:    calleeKey,
 	}
 	key := EdgeResolutionKey(callerKey, calleeKey, resolution)
-	if existing, ok := graph.EdgeResolutions[key]; ok {
-		if edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
-			return
-		}
-		graph.EdgeResolutions[key] = resolution
-		upsertEdgeResolutionByPair(graph, callerKey, calleeKey, resolution)
+	if existing, ok := graph.EdgeResolutions[key]; ok && edgeKindRank(existing.Kind) >= edgeKindRank(kind) {
 		return
 	}
 	graph.EdgeResolutions[key] = resolution
-	upsertEdgeResolutionByPair(graph, callerKey, calleeKey, resolution)
-}
-
-func upsertEdgeResolutionByPair(graph *CallGraph, callerKey, calleeKey string, resolution EdgeResolution) {
-	if graph.EdgeResolutionsByPair == nil {
-		graph.EdgeResolutionsByPair = make(map[string][]EdgeResolution)
-	}
-	pairKey := EdgeResolutionPairKey(callerKey, calleeKey)
-	values := graph.EdgeResolutionsByPair[pairKey]
-	for i := range values {
-		if sameEdgeResolutionVariant(values[i], resolution) {
-			values[i] = resolution
-			graph.EdgeResolutionsByPair[pairKey] = values
-			return
-		}
-	}
-	graph.EdgeResolutionsByPair[pairKey] = append(values, resolution)
-}
-
-func sameEdgeResolutionVariant(a, b EdgeResolution) bool {
-	return a.CallSite == b.CallSite &&
-		a.DeclaredType == b.DeclaredType &&
-		a.MethodName == b.MethodName &&
-		a.Arity == b.Arity
 }
 
 func indexMethodsByName(graph *CallGraph) map[string][]*FunctionDecl {
@@ -1996,7 +1966,6 @@ func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, li
 	}
 	res.ResolvedReceiverType = resolvedType
 	graph.EdgeResolutions[key] = res
-	upsertEdgeResolutionByPair(graph, callerKey, targetKey, res)
 	receiverIdx[resolvedReceiverIndexKey(callerKey, targetKey)] = resolvedReceiverEntry{resolvedType: resolvedType, line: line}
 }
 

--- a/internal/callgraph/constructor_dispatch_test.go
+++ b/internal/callgraph/constructor_dispatch_test.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+
+package callgraph
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestBuilder_DoesNotDispatchExpandConstructors guards the constructor
+// exclusion in expandAbstractClassDispatch: `new Foo(x)` invokes exactly
+// Foo.<init> and can never dispatch virtually, so a constructor call whose
+// exact declaration is missing from the graph (implicit default constructor,
+// unparsed overload) must NOT fan out to other classes' same-arity
+// constructors. On the bcprov corpus this fan-out synthesized 6.58M of the
+// graph's 7.16M edge resolutions before the guard existed.
+func TestBuilder_DoesNotDispatchExpandConstructors(t *testing.T) {
+	root := t.TempDir()
+
+	// class Widget { Widget(int size) {...} }  — parsed, so knownClassTypes
+	// contains Widget, but only the #1-arity ctor below is declared; the
+	// call site invokes an UNDECLARED Widget ctor via a second file's shape.
+	widgetCtor := FunctionDecl{
+		ID:         FunctionID{Package: "com.example", Type: "Widget", Name: "<init>#1"},
+		FilePath:   filepath.Join(root, "Widget.java"),
+		StartLine:  3,
+		EndLine:    5,
+		OwnerType:  "class",
+		OwnerName:  "Widget",
+		Parameters: []FunctionParameter{{Type: "int"}},
+	}
+
+	// class Gadget { Gadget(int size) {...} } — an unrelated class whose
+	// same-arity constructor must NOT become a dispatch target.
+	gadgetCtor := FunctionDecl{
+		ID:         FunctionID{Package: "com.example", Type: "Gadget", Name: "<init>#1"},
+		FilePath:   filepath.Join(root, "Gadget.java"),
+		StartLine:  3,
+		EndLine:    5,
+		OwnerType:  "class",
+		OwnerName:  "Gadget",
+		Parameters: []FunctionParameter{{Type: "int"}},
+	}
+
+	// class App { void run() { new Widget(cfg); } } — the callee resolves to a
+	// Widget constructor signature that has no declaration in the graph
+	// (different arity spelling), the exact shape that used to trigger the
+	// namespace-wide constructor fan-out.
+	appRun := FunctionDecl{
+		ID:        FunctionID{Package: "com.example", Type: "App", Name: "run#0"},
+		FilePath:  filepath.Join(root, "App.java"),
+		StartLine: 10,
+		EndLine:   14,
+		OwnerType: "class",
+		OwnerName: "App",
+		Calls: []FunctionCall{
+			{
+				Callee:    FunctionID{Package: "com.example", Type: "Widget", Name: "<init>#2"},
+				Raw:       "new Widget",
+				FilePath:  filepath.Join(root, "App.java"),
+				Line:      12,
+				Arguments: []string{"cfg", "flags"},
+			},
+		},
+	}
+
+	parser := &stubParser{
+		sep: ".",
+		analyses: map[string][]*FileAnalysis{
+			root: {
+				{Functions: []FunctionDecl{widgetCtor, gadgetCtor, appRun}},
+			},
+		},
+	}
+
+	graph, err := NewBuilder(parser).BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "com.example"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	appRunKey := appRun.ID.String()
+
+	// The direct (exact) edge to the invoked constructor signature must survive.
+	directCalleeKey := FunctionID{Package: "com.example", Type: "Widget", Name: "<init>#2"}.String()
+	if !sliceContainsAbstractDispatchKey(graph.Callers[directCalleeKey], appRunKey) {
+		t.Fatalf("Callers[%s] = %v, want to include %s (direct constructor call edge)",
+			directCalleeKey, graph.Callers[directCalleeKey], appRunKey)
+	}
+
+	// No dispatch fan-out: neither the unrelated Gadget ctor nor the sibling
+	// Widget ctor overload may gain App.run as a synthesized caller.
+	for _, calleeKey := range []string{gadgetCtor.ID.String(), widgetCtor.ID.String()} {
+		if sliceContainsAbstractDispatchKey(graph.Callers[calleeKey], appRunKey) {
+			t.Fatalf("Callers[%s] = %v, must not include %s (constructor dispatch fan-out)",
+				calleeKey, graph.Callers[calleeKey], appRunKey)
+		}
+	}
+
+	// And no interface_dispatch edge resolutions may exist for <init> callees.
+	for _, res := range graph.EdgeResolutions {
+		if res.Kind == EdgeKindInterfaceDispatch && res.MethodName == "<init>" {
+			t.Fatalf("found interface_dispatch edge resolution for a constructor: %+v", res)
+		}
+	}
+}

--- a/internal/callgraph/go_parser.go
+++ b/internal/callgraph/go_parser.go
@@ -36,6 +36,12 @@ func NewGoParser(opts ...ParserOption) *GoParser {
 	return &GoParser{parser: parser, includeTests: cfg.includeTests}
 }
 
+// CloneParser returns an independent GoParser with the same configuration,
+// for concurrent use (tree-sitter parsers are not reentrant).
+func (p *GoParser) CloneParser() Parser {
+	return NewGoParser(WithIncludeTests(p.includeTests))
+}
+
 // ParseFile extracts function declarations, imports, and calls from a single Go file.
 // packagePath is the Go import path for the package containing this file.
 func (p *GoParser) ParseFile(filePath, packagePath string) (*FileAnalysis, error) {

--- a/internal/callgraph/java_parser.go
+++ b/internal/callgraph/java_parser.go
@@ -56,6 +56,12 @@ func NewJavaParser(opts ...ParserOption) *JavaParser {
 	return &JavaParser{parser: p, includeTests: cfg.includeTests}
 }
 
+// CloneParser returns an independent JavaParser with the same configuration,
+// for concurrent use (tree-sitter parsers are not reentrant).
+func (p *JavaParser) CloneParser() Parser {
+	return NewJavaParser(WithIncludeTests(p.includeTests))
+}
+
 // SkipDirs returns directory names to skip during Java source traversal.
 func (p *JavaParser) SkipDirs() map[string]bool {
 	skip := map[string]bool{"META-INF": true, "target": true}

--- a/internal/callgraph/parallel_parse_test.go
+++ b/internal/callgraph/parallel_parse_test.go
@@ -24,9 +24,11 @@ type serialOnlyParser struct {
 func (s *serialOnlyParser) ParseDirectory(dir, packagePath string) ([]*FileAnalysis, error) {
 	return s.inner.ParseDirectory(dir, packagePath)
 }
-func (s *serialOnlyParser) SkipDirs() map[string]bool               { return s.inner.SkipDirs() }
-func (s *serialOnlyParser) SubPackagePath(parent, dir string) string { return s.inner.SubPackagePath(parent, dir) }
-func (s *serialOnlyParser) PackageSeparator() string                 { return s.inner.PackageSeparator() }
+func (s *serialOnlyParser) SkipDirs() map[string]bool { return s.inner.SkipDirs() }
+func (s *serialOnlyParser) SubPackagePath(parent, dir string) string {
+	return s.inner.SubPackagePath(parent, dir)
+}
+func (s *serialOnlyParser) PackageSeparator() string { return s.inner.PackageSeparator() }
 
 // TestBuilder_ParallelParseMatchesSerial builds the same multi-directory Java
 // tree through the serial path and the parallel path and requires the two

--- a/internal/callgraph/parallel_parse_test.go
+++ b/internal/callgraph/parallel_parse_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+
+package callgraph
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// serialOnlyParser hides the underlying parser's CloneParser method so the
+// builder takes the serial path, letting the test compare serial vs parallel
+// output for the same corpus.
+type serialOnlyParser struct {
+	inner Parser
+}
+
+func (s *serialOnlyParser) ParseDirectory(dir, packagePath string) ([]*FileAnalysis, error) {
+	return s.inner.ParseDirectory(dir, packagePath)
+}
+func (s *serialOnlyParser) SkipDirs() map[string]bool               { return s.inner.SkipDirs() }
+func (s *serialOnlyParser) SubPackagePath(parent, dir string) string { return s.inner.SubPackagePath(parent, dir) }
+func (s *serialOnlyParser) PackageSeparator() string                 { return s.inner.PackageSeparator() }
+
+// TestBuilder_ParallelParseMatchesSerial builds the same multi-directory Java
+// tree through the serial path and the parallel path and requires the two
+// graphs to be canonically identical. Guards the ordering contract of
+// analyzePackageParallel: results must merge in serial pre-order so
+// addAnalyses collision handling behaves the same.
+func TestBuilder_ParallelParseMatchesSerial(t *testing.T) {
+	root := t.TempDir()
+
+	writeJava := func(rel, class, callee string) {
+		dir := filepath.Join(root, filepath.Dir(rel))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		src := fmt.Sprintf(`package com.example.%s;
+
+public class %s {
+    public void run(byte[] data) {
+        %s helper = new %s();
+        helper.process(data);
+    }
+    public void process(byte[] data) {
+        helper2.transform(data);
+    }
+}
+`, filepath.Base(filepath.Dir(rel)), class, callee, callee)
+		if err := os.WriteFile(filepath.Join(root, rel), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Several classes spread over nested directories so the parallel path has
+	// real fan-out, including same-name methods across packages to exercise
+	// dispatch expansion identically on both paths.
+	for i := 0; i < 6; i++ {
+		pkg := fmt.Sprintf("mod%d", i)
+		writeJava(filepath.Join(pkg, fmt.Sprintf("Alpha%d.java", i)), fmt.Sprintf("Alpha%d", i), fmt.Sprintf("Beta%d", i))
+		writeJava(filepath.Join(pkg, "deep", fmt.Sprintf("Beta%d.java", i)), fmt.Sprintf("Beta%d", i), fmt.Sprintf("Alpha%d", i))
+	}
+
+	serialGraph, err := NewBuilder(&serialOnlyParser{inner: NewJavaParser()}).
+		BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "com.example"}}, nil)
+	if err != nil {
+		t.Fatalf("serial BuildFromDirectories: %v", err)
+	}
+
+	parallelGraph, err := NewBuilder(NewJavaParser()).
+		BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "com.example"}}, nil)
+	if err != nil {
+		t.Fatalf("parallel BuildFromDirectories: %v", err)
+	}
+
+	if len(parallelGraph.Functions) == 0 {
+		t.Fatal("parallel graph is empty; fixture did not parse")
+	}
+	serialDump := canonicalGraphDump(serialGraph)
+	parallelDump := canonicalGraphDump(parallelGraph)
+	if serialDump != parallelDump {
+		t.Fatalf("parallel parse produced a different graph than serial parse:\nserial:\n%s\nparallel:\n%s", serialDump, parallelDump)
+	}
+}

--- a/internal/callgraph/python_parser.go
+++ b/internal/callgraph/python_parser.go
@@ -37,6 +37,12 @@ func NewPythonParser(opts ...ParserOption) *PythonParser {
 	return &PythonParser{parser: p, includeTests: cfg.includeTests}
 }
 
+// CloneParser returns an independent PythonParser with the same configuration,
+// for concurrent use (tree-sitter parsers are not reentrant).
+func (p *PythonParser) CloneParser() Parser {
+	return NewPythonParser(WithIncludeTests(p.includeTests))
+}
+
 // SkipDirs returns directory names to skip during Python source traversal.
 func (p *PythonParser) SkipDirs() map[string]bool {
 	skip := map[string]bool{

--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -27,6 +27,12 @@ func NewRustParser(opts ...ParserOption) *RustParser {
 	return &RustParser{parser: p, includeTests: cfg.includeTests}
 }
 
+// CloneParser returns an independent RustParser with the same configuration,
+// for concurrent use (tree-sitter parsers are not reentrant).
+func (p *RustParser) CloneParser() Parser {
+	return NewRustParser(WithIncludeTests(p.includeTests))
+}
+
 // SkipDirs returns directory names to skip during Rust source traversal.
 func (p *RustParser) SkipDirs() map[string]bool {
 	skip := map[string]bool{"target": true, "benches": true, "examples": true}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -143,9 +143,9 @@ type FunctionID struct {
 // This includes the arity suffix (e.g., "javax.crypto.(Cipher).getInstance#1").
 func (f FunctionID) String() string {
 	if f.Type != "" {
-		return fmt.Sprintf("%s.(%s).%s", f.Package, f.Type, f.Name)
+		return f.Package + ".(" + f.Type + ")." + f.Name
 	}
-	return fmt.Sprintf("%s.%s", f.Package, f.Name)
+	return f.Package + "." + f.Name
 }
 
 // InferredReturn carries the result of static return-type inference for a function.

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -304,12 +304,10 @@ type CallGraph struct {
 	// was resolved. Keyed by EdgeResolutionKey(callerKey, calleeKey, resolution).
 	// An edge with no entry is an exact, directly-resolved source call. Consumers
 	// use this to refuse to present over-broad name/arity dispatch guesses as
-	// typed reachability proof.
+	// typed reachability proof. Values carry their caller/callee endpoints
+	// (EdgeResolutionEndpoints), so per-pair views are one O(E) pass away —
+	// see internal/scan's indexFragmentEdgeResolutions.
 	EdgeResolutions map[string]EdgeResolution
-	// EdgeResolutionsByPair mirrors EdgeResolutions by caller/callee pair so
-	// export paths can avoid rebuilding that index for very large dispatch
-	// graphs.
-	EdgeResolutionsByPair map[string][]EdgeResolution
 }
 
 // EdgeKind classifies how confidently a caller->callee edge was resolved.
@@ -386,12 +384,6 @@ func EdgeResolutionKey(callerKey, calleeKey string, resolution EdgeResolution) s
 // variants for one caller->callee pair.
 func EdgeResolutionKeyPrefix(callerKey, calleeKey string) string {
 	return callerKey + "\x00" + calleeKey + "\x00"
-}
-
-// EdgeResolutionPairKey is the stable key shared by all resolution variants
-// for one caller->callee pair.
-func EdgeResolutionPairKey(callerKey, calleeKey string) string {
-	return callerKey + "\x00" + calleeKey
 }
 
 // EdgeResolutionEndpoints returns the caller/callee pair for a stored edge

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -729,17 +729,6 @@ func indexFragmentEdgeResolutions(graph *callgraph.CallGraph) map[string][]fragm
 	if graph == nil || len(graph.EdgeResolutions) == 0 {
 		return nil
 	}
-	if len(graph.EdgeResolutionsByPair) > 0 {
-		index := make(map[string][]fragmentEdgeResolution, len(graph.EdgeResolutionsByPair))
-		for pairKey, resolutions := range graph.EdgeResolutionsByPair {
-			values := make([]fragmentEdgeResolution, 0, len(resolutions))
-			for i := range resolutions {
-				values = append(values, newFragmentEdgeResolution(resolutions[i]))
-			}
-			index[pairKey] = values
-		}
-		return index
-	}
 	index := make(map[string][]fragmentEdgeResolution)
 	for key, res := range graph.EdgeResolutions {
 		callerKey, calleeKey, ok := callgraph.EdgeResolutionEndpoints(key, res)
@@ -748,6 +737,25 @@ func indexFragmentEdgeResolutions(graph *callgraph.CallGraph) map[string][]fragm
 		}
 		pairKey := fragmentEdgePairKey(callerKey, calleeKey)
 		index[pairKey] = append(index[pairKey], newFragmentEdgeResolution(res))
+	}
+	// Deterministic per-pair variant order: EdgeResolutions is a map, so
+	// insertion order above is random. Downstream emission sorts its final
+	// edge lists, but a stable index keeps intermediate behavior (e.g. which
+	// variant a line-match picks first) reproducible run to run.
+	for pairKey := range index {
+		values := index[pairKey]
+		sort.Slice(values, func(i, j int) bool {
+			if values[i].CallSite != values[j].CallSite {
+				return values[i].CallSite < values[j].CallSite
+			}
+			if values[i].DeclaredType != values[j].DeclaredType {
+				return values[i].DeclaredType < values[j].DeclaredType
+			}
+			if values[i].MethodName != values[j].MethodName {
+				return values[i].MethodName < values[j].MethodName
+			}
+			return values[i].Arity < values[j].Arity
+		})
 	}
 	return index
 }

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -754,7 +754,10 @@ func indexFragmentEdgeResolutions(graph *callgraph.CallGraph) map[string][]fragm
 			if values[i].MethodName != values[j].MethodName {
 				return values[i].MethodName < values[j].MethodName
 			}
-			return values[i].Arity < values[j].Arity
+			if values[i].Arity != values[j].Arity {
+				return values[i].Arity < values[j].Arity
+			}
+			return values[i].Kind < values[j].Kind
 		})
 	}
 	return index


### PR DESCRIPTION
## Summary

Four changes to the call graph build, benchmarked on the BouncyCastle corpus (bc-java core+prov, 3,104 files, ~29k functions). Combined result:

| Metric | Before | After |
|---|---|---|
| Build + canonical dump wall time | 144s | **13.3s** |
| Peak RSS | ~13 GB | **~1.07 GB** |
| Edge resolutions | 7,157,372 | 576,778 |

### 1. Fix: exclude constructors from abstract-class dispatch expansion (`09ccf3e`)

Constructors never dispatch virtually — `new Foo()` invokes exactly `Foo.<init>` — but constructor call sites whose exact declaration was missing from the graph (implicit default constructors, unparsed overloads) fell through to `expandAbstractClassDispatch`'s name+arity fan-out and were linked to **every** same-arity constructor in the namespace root. On the bcprov corpus those fabricated edges were 92% of all edge resolutions, and they polluted `graph.Callers`, so exported call chains and `crypto_entry_points` claimed reachability through callers that never existed.

This is both the main correctness fix and the main perf win: 144s → 32s, ~13 GB → 1.35 GB.

### 2. Perf: parallelize source parsing across directories (`c968062`)

After the fix above, single-threaded tree-sitter parsing dominated the profile (82% of wall time). Parsers aren't reentrant, so each worker gets its own instance via a new `ParserCloner` interface (implemented by all four language parsers). `analyzePackage` collects the directory work list up front, fans `ParseDirectory` out over `GOMAXPROCS` workers, and merges results in exact serial order so collision handling behaves identically. Parsers without `ParserCloner` (e.g. test stubs) keep the serial path. Parse 23.7s → 8.3s; total build 29s → 13.3s on 4 cores.

### 3. Perf: memoize dispatch expansion + O(1) caller dedup (`743f491`)

Memoizes `expandInterfaceDispatch`/`expandAbstractClassDispatch` per callee target in `buildCallerIndex` (they were recomputed, including a candidate sort, for every call site of the same target), replaces `addCaller`'s linear fan-in scan with a set-backed dedup in the hot path, and builds `FunctionID.String()` by concatenation instead of `fmt.Sprintf`.

### 4. Perf: drop `EdgeResolutionsByPair` mirror map (`a1b0c1b`)

The mirror duplicated every `EdgeResolution` to spare the fragment exporter one O(E) index rebuild — a trade that stopped paying once the edge count shrank ~12x. Its single consumer now builds the per-pair view in one pass, with deterministic (sorted) variant order instead of map-iteration order. Peak RSS 1.31 GB → 1.07 GB.

## Verification

- **Equivalence proofs via canonical graph dumps (sha256):** the constructor fix hashes identically to the baseline after filtering `<init>`/`<clinit>` lines (every non-constructor edge and caller relationship is byte-for-byte unchanged; all 30,602 direct exact constructor edges retained). Each of the three perf commits hashes identical to its predecessor — output-neutral by construction.
- **New tests:** `constructor_dispatch_test.go` locks the constructor-dispatch behavior; `parallel_parse_test.go` (`TestBuilder_ParallelParseMatchesSerial`) locks serial/parallel equivalence, clean under `-race`.
- Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ap9qk3R7dimqBsqhVyAU6i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ap9qk3R7dimqBsqhVyAU6i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added concurrent directory parsing to speed up call-graph generation while preserving consistent results.
  * Improved call-graph indexing and deduplication for faster processing of complex dispatch patterns.

* **Bug Fixes**
  * Prevented constructors and static initializers from being incorrectly expanded through virtual dispatch.
  * Ensured edge-resolution results are consistently ordered for stable scan output.

* **Tests**
  * Added coverage confirming parallel and serial parsing produce equivalent call graphs.
  * Added regression coverage for constructor dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->