### PR TITLE
fix: exclude empty rule files from language filtering and explain scanner exit codes

### DIFF
--- a/internal/engine/rule_filter.go
+++ b/internal/engine/rule_filter.go
@@ -24,18 +24,25 @@ type ruleFile struct {
 	} `yaml:"rules"`
 }
 
-// ruleLanguages parses a rule YAML file and returns the set of languages it targets.
-func ruleLanguages(path string) []string {
+// ruleLanguages parses a rule YAML file and returns the set of languages it
+// targets. The second return is true when the file parsed successfully but
+// contains zero rules: such a file can never match anything, so callers must
+// exclude it rather than treat it as "unknown language".
+func ruleLanguages(path string) ([]string, bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Debug().Err(err).Str("path", path).Msg("Failed to read rule file for language extraction")
-		return nil
+		return nil, false
 	}
 
 	var rf ruleFile
 	if err := yaml.Unmarshal(data, &rf); err != nil {
 		log.Debug().Err(err).Str("path", path).Msg("Failed to parse rule file for language extraction")
-		return nil
+		return nil, false
+	}
+
+	if len(rf.Rules) == 0 {
+		return nil, true
 	}
 
 	seen := make(map[string]bool)
@@ -49,7 +56,7 @@ func ruleLanguages(path string) []string {
 			}
 		}
 	}
-	return langs
+	return langs, false
 }
 
 // filterRulesByLanguages filters rule paths to only include rules whose YAML
@@ -70,7 +77,12 @@ func filterRulesByLanguages(allRules, languages []string) []string {
 
 	filtered := make([]string, 0, len(candidateRules))
 	for _, rulePath := range candidateRules {
-		ruleLangs := ruleLanguages(rulePath)
+		ruleLangs, empty := ruleLanguages(rulePath)
+		if empty {
+			// Zero rules in the file — it can never match anything, and if it
+			// survives as the sole config, opengrep fails with exit code 7.
+			continue
+		}
 		if len(ruleLangs) == 0 {
 			// Can't determine language — include to be safe
 			filtered = append(filtered, rulePath)

--- a/internal/engine/rule_filter_test.go
+++ b/internal/engine/rule_filter_test.go
@@ -27,7 +27,10 @@ func TestRuleLanguages(t *testing.T) {
     languages: [Go, go, PYTHON]
 `)
 
-	langs := ruleLanguages(good)
+	langs, empty := ruleLanguages(good)
+	if empty {
+		t.Fatalf("expected non-empty rule file")
+	}
 	if len(langs) != 2 {
 		t.Fatalf("ruleLanguages len = %d, want 2", len(langs))
 	}
@@ -35,13 +38,18 @@ func TestRuleLanguages(t *testing.T) {
 		t.Fatalf("expected normalized go language in %v", langs)
 	}
 
-	if got := ruleLanguages(filepath.Join(dir, "missing.yaml")); got != nil {
-		t.Fatalf("expected nil for missing file, got %v", got)
+	if got, empty := ruleLanguages(filepath.Join(dir, "missing.yaml")); got != nil || empty {
+		t.Fatalf("expected nil/non-empty for missing file, got %v empty=%v", got, empty)
 	}
 
 	invalid := writeRuleFile(t, dir, "invalid.yaml", `: not-yaml`)
-	if got := ruleLanguages(invalid); got != nil {
-		t.Fatalf("expected nil for invalid yaml, got %v", got)
+	if got, empty := ruleLanguages(invalid); got != nil || empty {
+		t.Fatalf("expected nil/non-empty for invalid yaml, got %v empty=%v", got, empty)
+	}
+
+	emptyFile := writeRuleFile(t, dir, "empty.yaml", `rules: []`)
+	if _, empty := ruleLanguages(emptyFile); !empty {
+		t.Fatalf("expected empty=true for zero-rule file")
 	}
 }
 
@@ -82,6 +90,34 @@ func TestFilterRulesByLanguages(t *testing.T) {
 	fallback := filterRulesByLanguages([]string{pyRule}, []string{"go"})
 	if len(fallback) != 1 || fallback[0] != pyRule {
 		t.Fatalf("expected fallback to all rules, got %#v", fallback)
+	}
+}
+
+// A rule file with zero rules (`rules: []`) must never survive language
+// filtering. When it was the sole survivor, opengrep received a config with
+// no rules and failed the whole scan with exit code 7.
+func TestFilterRulesByLanguages_ExcludesEmptyRuleFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pyRule := writeRuleFile(t, dir, "python.yaml", `rules:
+  - id: py-rule
+    languages: [python]
+`)
+	emptyRule := writeRuleFile(t, dir, "empty.yaml", `rules: []
+`)
+
+	// No detected language matches any real rule: the empty file must not be
+	// the lone survivor — the zero-match fallback to all rules must trigger.
+	fallback := filterRulesByLanguages([]string{pyRule, emptyRule}, []string{"c++"})
+	if len(fallback) != 2 {
+		t.Fatalf("expected fallback to all rules, got %#v", fallback)
+	}
+
+	// With a matching language, the empty file is still excluded.
+	filtered := filterRulesByLanguages([]string{pyRule, emptyRule}, []string{"python"})
+	if len(filtered) != 1 || filtered[0] != pyRule {
+		t.Fatalf("expected only python rule, got %#v", filtered)
 	}
 }
 

--- a/internal/scanner/opengrep/scanner.go
+++ b/internal/scanner/opengrep/scanner.go
@@ -158,10 +158,10 @@ func (s *Scanner) Scan(ctx context.Context, target string, rulePaths []string, t
 	// Execute opengrep
 	output, stderr, err := s.execute(ctx, args)
 	if err != nil {
-		cmdStr := fmt.Sprintf("%s %s", s.executablePath, strings.Join(args, " "))
 		log.Debug().
-			Str("command", cmdStr).
-			Str("stderr", stderr).
+			Strs("configs", rulePaths).
+			Str("target", target).
+			Str("stderr", semgrep.SanitizeScannerStderr(stderr)).
 			Msg("opengrep command failed")
 
 		return nil, err
@@ -335,7 +335,7 @@ func (s *Scanner) execute(ctx context.Context, args []string) (stdout []byte, st
 			}
 		}
 
-		err = semgrep.HandleSemgrepCompatibleErrors(stdout, duration, exitCode, ScannerName)
+		err = semgrep.HandleSemgrepCompatibleErrors(stdout, stderr, duration, exitCode, ScannerName)
 		if err != nil {
 			return nil, stderr, err
 		}

--- a/internal/scanner/semgrep/parser.go
+++ b/internal/scanner/semgrep/parser.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/internal/failure"
@@ -174,7 +175,11 @@ func SanitizeScannerStderr(stderr string) string {
 	}
 	out := strings.Join(lines, " | ")
 	if len(out) > maxStderrTail {
-		out = "…" + out[len(out)-maxStderrTail:]
+		cut := len(out) - maxStderrTail
+		for cut < len(out) && !utf8.RuneStart(out[cut]) {
+			cut++
+		}
+		out = "…" + out[cut:]
 	}
 	return out
 }

--- a/internal/scanner/semgrep/parser.go
+++ b/internal/scanner/semgrep/parser.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -133,9 +134,54 @@ func LogSemgrepCompatibleErrors(errors []entities.SemgrepError) bool {
 	return true
 }
 
+// exitCodeMeanings maps documented semgrep/opengrep exit codes to a
+// human-readable cause (https://semgrep.dev/docs/cli-reference#exit-codes).
+// Exit code 7 also fires when the effective rule configuration contains zero
+// rules, which opengrep treats as an invalid configuration.
+var exitCodeMeanings = map[int]string{
+	2:  "scanner failed unexpectedly",
+	3:  "invalid syntax in scanned code",
+	4:  "invalid pattern in rule schema",
+	5:  "rule configuration is not valid YAML",
+	7:  "rule configuration contains no valid rules",
+	8:  "unsupported language specified",
+	13: "invalid API key",
+}
+
+func exitCodeMeaning(exitCode int) string {
+	if meaning, ok := exitCodeMeanings[exitCode]; ok {
+		return meaning
+	}
+	return "unknown error"
+}
+
+// ansiEscapeRE matches ANSI terminal escape sequences (colors, cursor moves).
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+// maxStderrTail bounds how much scanner stderr is attached to logs and errors.
+const maxStderrTail = 500
+
+// SanitizeScannerStderr strips ANSI escape sequences and blank lines from
+// scanner stderr and keeps only the tail, so it can be attached to logs and
+// error details without flooding the console with banner art.
+func SanitizeScannerStderr(stderr string) string {
+	clean := ansiEscapeRE.ReplaceAllString(stderr, "")
+	var lines []string
+	for line := range strings.SplitSeq(clean, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	out := strings.Join(lines, " | ")
+	if len(out) > maxStderrTail {
+		out = "…" + out[len(out)-maxStderrTail:]
+	}
+	return out
+}
+
 // HandleSemgrepCompatibleErrors displays semgrep compatible errors in a user-friendly format.
 // Returns true if there were any errors logged.
-func HandleSemgrepCompatibleErrors(stdout []byte, duration time.Duration, exitCode int, scannerName string) error {
+func HandleSemgrepCompatibleErrors(stdout []byte, stderr string, duration time.Duration, exitCode int, scannerName string) error {
 	parsedOutput, err := ParseSemgrepCompatibleOutput(stdout)
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to parse %s output", scannerName)
@@ -172,16 +218,28 @@ func HandleSemgrepCompatibleErrors(stdout []byte, duration time.Duration, exitCo
 		)
 	}
 
-	log.Error().
+	meaning := exitCodeMeaning(exitCode)
+	stderrTail := SanitizeScannerStderr(stderr)
+	logEvent := log.Error().
 		Int("exit_code", exitCode).
-		Dur("duration", duration).
-		Msgf("%s failed with no error details", scannerName)
+		Dur("duration", duration)
+	if stderrTail != "" {
+		logEvent = logEvent.Str("stderr", stderrTail)
+	}
+	logEvent.Msgf("%s failed: %s", scannerName, meaning)
+
+	opts := []failure.Option{
+		failure.WithDetail("scanner", scannerName),
+		failure.WithDetail("exit_code", fmt.Sprintf("%d", exitCode)),
+	}
+	if stderrTail != "" {
+		opts = append(opts, failure.WithDetail("stderr", stderrTail))
+	}
 	return failure.New(
 		failure.CodeScannerExecutionFailed,
 		failure.StageScan,
-		fmt.Sprintf("%s execution failed with exit code %d", scannerName, exitCode),
-		failure.WithDetail("scanner", scannerName),
-		failure.WithDetail("exit_code", fmt.Sprintf("%d", exitCode)),
+		fmt.Sprintf("%s execution failed with exit code %d (%s)", scannerName, exitCode, meaning),
+		opts...,
 	)
 }
 

--- a/internal/scanner/semgrep/parser_test.go
+++ b/internal/scanner/semgrep/parser_test.go
@@ -18,9 +18,13 @@ package semgrep
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/internal/failure"
 )
 
 func TestParseSemgrepCompatibleOutput_WithArrayTypeError(t *testing.T) {
@@ -209,5 +213,50 @@ func TestUnmarshalSemgrepError(t *testing.T) {
 
 	if err.Spans[0].File != "/test/file.c" {
 		t.Errorf("Expected file '/test/file.c', got '%s'", err.Spans[0].File)
+	}
+}
+
+func TestSanitizeScannerStderr(t *testing.T) {
+	t.Parallel()
+
+	raw := "\n┌──────────────┐\n│ Opengrep CLI │\n└──────────────┘\n\n\x1b[32m✔\x1b[39m \x1b[1mOpengrep OSS\x1b[0m\n\n\x1b[1m  Loading rules from local config...\x1b[0m\n"
+	got := SanitizeScannerStderr(raw)
+
+	if strings.Contains(got, "\x1b") {
+		t.Errorf("expected ANSI escapes stripped, got %q", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("expected single line, got %q", got)
+	}
+	if !strings.Contains(got, "Loading rules from local config...") {
+		t.Errorf("expected stderr content preserved, got %q", got)
+	}
+
+	long := strings.Repeat("x", maxStderrTail+100)
+	if got := SanitizeScannerStderr(long); len(got) > maxStderrTail+len("…") {
+		t.Errorf("expected stderr capped at %d chars, got %d", maxStderrTail, len(got))
+	}
+}
+
+func TestHandleSemgrepCompatibleErrors_ExitCodeMeaning(t *testing.T) {
+	t.Parallel()
+
+	// Valid JSON with no errors and exit code 7: the failure message must
+	// explain the exit code instead of only echoing the number.
+	stdout := []byte(`{"results":[],"errors":[],"paths":{"scanned":[]}}`)
+	err := HandleSemgrepCompatibleErrors(stdout, "banner noise", time.Second, 7, "opengrep")
+	if err == nil {
+		t.Fatal("expected error for exit code 7")
+	}
+	if !strings.Contains(err.Error(), "rule configuration contains no valid rules") {
+		t.Errorf("expected exit code meaning in error, got %q", err.Error())
+	}
+
+	var f *failure.Error
+	if !errors.As(err, &f) {
+		t.Fatalf("expected *failure.Error, got %T", err)
+	}
+	if f.Details["stderr"] != "banner noise" {
+		t.Errorf("expected stderr detail, got %q", f.Details["stderr"])
 	}
 }

--- a/internal/scanner/semgrep/parser_test.go
+++ b/internal/scanner/semgrep/parser_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/internal/failure"
@@ -235,6 +236,13 @@ func TestSanitizeScannerStderr(t *testing.T) {
 	long := strings.Repeat("x", maxStderrTail+100)
 	if got := SanitizeScannerStderr(long); len(got) > maxStderrTail+len("…") {
 		t.Errorf("expected stderr capped at %d chars, got %d", maxStderrTail, len(got))
+	}
+
+	// Truncation must not split a multi-byte rune: force the cut point to
+	// land mid-rune and check the result is still valid UTF-8.
+	multibyte := strings.Repeat("─", maxStderrTail)
+	if got := SanitizeScannerStderr(multibyte); !utf8.ValidString(got) {
+		t.Errorf("expected valid UTF-8 after truncation, got %q", got)
 	}
 }
 

--- a/internal/scanner/semgrep/scanner.go
+++ b/internal/scanner/semgrep/scanner.go
@@ -265,7 +265,7 @@ func (s *Scanner) execute(ctx context.Context, args []string) (stdout []byte, st
 			}
 		}
 
-		err = HandleSemgrepCompatibleErrors(stdout, duration, exitCode, ScannerName)
+		err = HandleSemgrepCompatibleErrors(stdout, stderr, duration, exitCode, ScannerName)
 		if err != nil {
 			return nil, stderr, err
 		}

--- a/internal/scanner/semgrep/scanner.go
+++ b/internal/scanner/semgrep/scanner.go
@@ -126,10 +126,10 @@ func (s *Scanner) Scan(ctx context.Context, target string, rulePaths []string, t
 	// Execute semgrep
 	output, stderr, err := s.execute(ctx, args)
 	if err != nil {
-		cmdStr := fmt.Sprintf("%s %s", s.executablePath, strings.Join(args, " "))
 		log.Debug().
-			Str("command", cmdStr).
-			Str("stderr", stderr).
+			Strs("configs", rulePaths).
+			Str("target", target).
+			Str("stderr", SanitizeScannerStderr(stderr)).
 			Msg("semgrep command failed")
 
 		return nil, err


### PR DESCRIPTION
## Problem

Scanning a C++/CMake project hit a hard scan failure: `opengrep execution failed with exit code 7`, with no useful diagnostics.

Root cause chain:
1. The DCA ruleset ships one rule file containing `rules: []` (`python/boto3/algorithm/other/kms/rules.yaml`).
2. The language filter treats a file whose languages can't be determined as "include to be safe" — a zero-rule file has no languages, so it always survives filtering.
3. The ruleset has no rules for `c++`/`cmake`/`shell`, so the empty file became the **sole** filtered config, which also blocked the zero-match fallback (filtered=1, not 0).
4. Opengrep invoked with a config containing zero rules exits with code 7, failing the whole scan.

Reproducible with any C++ project: `crypto-finder scan --languages c++ <dir>`.

## Fix

- `ruleLanguages` now reports when a file parsed successfully but contains zero rules; `filterRulesByLanguages` excludes such files (they can never match anything). With the empty file excluded, the existing zero-match fallback to all rules triggers and the scan completes with a clear warning.
- The "rules present but no `languages` field" include-to-be-safe path is unchanged and covered by existing tests.

## Diagnostics improvements

- Documented semgrep/opengrep exit codes are mapped to human-readable causes and included in the failure message: `opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`.
- Scanner stderr is sanitized (ANSI escapes stripped, single line, tail capped at 500 bytes on rune boundaries) before being attached to logs and error details.
- The failure debug log now records rule configs + target instead of dumping the full command line with its 28 `--exclude` flags.

## Coverage note

Even with this fix, C++ scans currently find nothing: the C rules are tagged `languages: [c]` and opengrep never applies them to `.cpp` targets. Tracked in scanoss/crypto_rules#116 (tag C rules with `[c, cpp]`).

## Testing

- New regression tests: `TestFilterRulesByLanguages_ExcludesEmptyRuleFiles`, `TestSanitizeScannerStderr`, `TestHandleSemgrepCompatibleErrors_ExitCodeMeaning`.
- Full `internal/engine` and `internal/scanner/...` suites pass.
- End-to-end: minimal C++ project reproduces the customer failure on main and completes with exit 0 on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty rule files are now excluded from scanner configurations when applicable.
  * Scanner failures provide clearer exit-code explanations and sanitized error details.
  * Error output is safely shortened while preserving readable content and valid characters.

* **Diagnostics**
  * Scan failure logs now include relevant rule configuration, target, and sanitized error output instead of the full command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->