### PR TITLE
feat(graphfrag): export ambiguous forward calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)
 - C callgraph parsing now extracts include paths, function declarations, call sites, assignment targets, and 1-based half-open call columns for reachability analysis. (#67)
 - JavaScript and TypeScript callgraph parsing and CLI ecosystem routing now cover ES module and CommonJS imports, imported/direct calls, lifecycle receiver and assignment fields, fluent-chain IDs, and source columns. (#66)
 - **Method-role and parameter-role classification** (`method_role`, `role_provenance`, `parameter_roles` — callgraph schema `6.3` → `6.4`): contracts now support `role: operation` (alongside the existing `factory`/`config`/`output`, now enum-validated at load time) and a per-parameter `parameters:` sub-schema (`operation-determining`/`metadata-contributing`/`none`, with `contributes: {property, derivation}` for `argument_value`/`argument_bit_length`/`argument_type`). Structural (call-edge-derived) supporting calls now carry a KB-derived `category` too, not just definition-based ones. See `internal/callgraph/contracts/`, `internal/scan/export.go`, `internal/scan/fragment_export.go`, `pkg/graphfrag/stitch.go`, `pkg/graphfrag/callgraph_export.go`. (#108)

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -471,36 +471,36 @@ func (idx dispatchIndexes) expandAbstractClassDispatchMemoized(b *Builder, calle
 func (b *Builder) indexCallDispatch(graph *CallGraph, callerKey string, call FunctionCall, idx dispatchIndexes) {
 	calleeKey := call.Callee.String()
 	idx.addCallerIndexed(graph.Callers, calleeKey, callerKey)
-	recordEdgeResolution(graph, callerKey, calleeKey, EdgeKindExact, "", call.Line)
+	recordEdgeResolution(graph, callerKey, calleeKey, EdgeKindExact, "", call.Line, call.StartCol, call.EndCol)
 
 	overloadTargets := b.expandOverloadCandidates(call.Callee, idx.methodsByQualifiedArity)
 	resolvedTargets := make([]string, 1, 1+len(overloadTargets))
 	resolvedTargets[0] = calleeKey
 	for _, target := range overloadTargets {
 		idx.addCallerIndexed(graph.Callers, target, callerKey)
-		recordEdgeResolution(graph, callerKey, target, EdgeKindExact, "", call.Line)
+		recordEdgeResolution(graph, callerKey, target, EdgeKindExact, "", call.Line, call.StartCol, call.EndCol)
 		resolvedTargets = append(resolvedTargets, target)
 	}
 
 	for _, target := range resolvedTargets {
 		for _, alias := range idx.expandInterfaceDispatchMemoized(b, target, graph) {
 			idx.addCallerIndexed(graph.Callers, alias.CalleeKey, callerKey)
-			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
+			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line, call.StartCol, call.EndCol)
 		}
 		for _, alias := range b.expandPythonSubclassDispatch(target, graph, idx.subclassByTypeName) {
 			idx.addCallerIndexed(graph.Callers, alias.CalleeKey, callerKey)
-			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindPythonSubclassDispatch, alias.DeclaredType, call.Line)
+			recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindPythonSubclassDispatch, alias.DeclaredType, call.Line, call.StartCol, call.EndCol)
 		}
 	}
 
 	for _, alias := range idx.expandAbstractClassDispatchMemoized(b, call.Callee, calleeKey, graph) {
 		idx.addCallerIndexed(graph.Callers, alias.CalleeKey, callerKey)
-		recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line)
+		recordEdgeResolution(graph, callerKey, alias.CalleeKey, EdgeKindInterfaceDispatch, alias.DeclaredType, call.Line, call.StartCol, call.EndCol)
 	}
 
 	for _, alias := range b.expandFluentFallback(call, graph, idx.methodsByName) {
 		idx.addCallerIndexed(graph.Callers, alias, callerKey)
-		recordEdgeResolution(graph, callerKey, alias, EdgeKindNameOnly, "", call.Line)
+		recordEdgeResolution(graph, callerKey, alias, EdgeKindNameOnly, "", call.Line, call.StartCol, call.EndCol)
 	}
 }
 
@@ -509,7 +509,7 @@ func (b *Builder) indexCallDispatch(graph *CallGraph, callerKey string, call Fun
 // paths (a direct exact call must never be downgraded to a dispatch guess).
 // MethodName and Arity are derived from the callee key so dispatch siblings of
 // one call site share a stable grouping identity downstream.
-func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind EdgeKind, declaredType string, callSite int) {
+func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind EdgeKind, declaredType string, callSite, startCol, endCol int) {
 	if graph.EdgeResolutions == nil {
 		graph.EdgeResolutions = make(map[string]EdgeResolution)
 	}
@@ -524,6 +524,8 @@ func recordEdgeResolution(graph *CallGraph, callerKey, calleeKey string, kind Ed
 		MethodName:   method,
 		Arity:        arity,
 		CallSite:     callSite,
+		StartCol:     startCol,
+		EndCol:       endCol,
 		callerKey:    callerKey,
 		calleeKey:    calleeKey,
 	}
@@ -1119,7 +1121,7 @@ func resolveChainLinkCallees(graph *CallGraph, callerKey string, fn *FunctionDec
 			// FunctionCall.Callee diverge and the exported edge carries a synthesized
 			// key with no object identity.
 			addCaller(graph.Callers, newKey, callerKey, oldKey)
-			recordEdgeResolution(graph, callerKey, newKey, EdgeKindExact, "", call.Line)
+			recordEdgeResolution(graph, callerKey, newKey, EdgeKindExact, "", call.Line, call.StartCol, call.EndCol)
 			resolved++
 		}
 		currentType = unconditionalContractReturn(ctrs)
@@ -1172,6 +1174,8 @@ func unconditionalContractReturn(ctrs []contracts.Contract) string {
 type dispatchAmbiguousGroupKey struct {
 	Caller     string
 	CallSite   int
+	StartCol   int
+	EndCol     int
 	MethodName string
 	Arity      int
 }
@@ -1381,10 +1385,10 @@ func groupAmbiguousDispatchEdges(graph *CallGraph) map[dispatchAmbiguousGroupKey
 		for i := range entries {
 			entry := entries[i]
 			res := entry.resolution
-			if !containsDispatchCallSite(candidate.sites, res.CallSite, res.MethodName, res.Arity) {
+			if !containsDispatchCallSite(candidate.sites, res.CallSite, res.StartCol, res.EndCol, res.MethodName, res.Arity) {
 				continue
 			}
-			gk := compactDispatchGroupKey{CallerID: candidate.id, CallSite: res.CallSite, MethodName: res.MethodName, Arity: res.Arity}
+			gk := compactDispatchGroupKey{CallerID: candidate.id, CallSite: res.CallSite, StartCol: res.StartCol, EndCol: res.EndCol, MethodName: res.MethodName, Arity: res.Arity}
 			compactGroups[gk] = append(compactGroups[gk], entry)
 		}
 	}
@@ -1397,6 +1401,8 @@ func groupAmbiguousDispatchEdges(graph *CallGraph) map[dispatchAmbiguousGroupKey
 		groups[dispatchAmbiguousGroupKey{
 			Caller:     callersByID[gk.CallerID],
 			CallSite:   gk.CallSite,
+			StartCol:   gk.StartCol,
+			EndCol:     gk.EndCol,
 			MethodName: gk.MethodName,
 			Arity:      gk.Arity,
 		}] = entries
@@ -1406,7 +1412,8 @@ func groupAmbiguousDispatchEdges(graph *CallGraph) map[dispatchAmbiguousGroupKey
 
 func interfaceDispatchEdgesByCaller(graph *CallGraph) map[string][]edgeResolutionEntry {
 	edgesByCaller := make(map[string][]edgeResolutionEntry)
-	for key, res := range graph.EdgeResolutions {
+	for key := range graph.EdgeResolutions {
+		res := graph.EdgeResolutions[key]
 		if res.Kind != EdgeKindInterfaceDispatch {
 			continue
 		}
@@ -1425,6 +1432,8 @@ func interfaceDispatchEdgesByCaller(graph *CallGraph) map[string][]edgeResolutio
 
 type dispatchCallSiteKey struct {
 	CallSite   int
+	StartCol   int
+	EndCol     int
 	MethodName string
 	Arity      int
 }
@@ -1432,6 +1441,8 @@ type dispatchCallSiteKey struct {
 type compactDispatchGroupKey struct {
 	CallerID   int
 	CallSite   int
+	StartCol   int
+	EndCol     int
 	MethodName string
 	Arity      int
 }
@@ -1466,17 +1477,17 @@ func passthroughCandidateSites(fn *FunctionDecl) []dispatchCallSiteKey {
 			continue
 		}
 		method, arity := methodBaseArity(call.Callee.Name)
-		site := dispatchCallSiteKey{CallSite: call.Line, MethodName: method, Arity: arity}
-		if !containsDispatchCallSite(sites, site.CallSite, site.MethodName, site.Arity) {
+		site := dispatchCallSiteKey{CallSite: call.Line, StartCol: call.StartCol, EndCol: call.EndCol, MethodName: method, Arity: arity}
+		if !containsDispatchCallSite(sites, site.CallSite, site.StartCol, site.EndCol, site.MethodName, site.Arity) {
 			sites = append(sites, site)
 		}
 	}
 	return sites
 }
 
-func containsDispatchCallSite(sites []dispatchCallSiteKey, callSite int, methodName string, arity int) bool {
+func containsDispatchCallSite(sites []dispatchCallSiteKey, callSite, startCol, endCol int, methodName string, arity int) bool {
 	for i := range sites {
-		if sites[i].CallSite == callSite && sites[i].MethodName == methodName && sites[i].Arity == arity {
+		if sites[i].CallSite == callSite && sites[i].StartCol == startCol && sites[i].EndCol == endCol && sites[i].MethodName == methodName && sites[i].Arity == arity {
 			return true
 		}
 	}
@@ -1532,6 +1543,12 @@ func sortedAmbiguousGroupKeys(groups map[dispatchAmbiguousGroupKey][]edgeResolut
 		}
 		if a.CallSite != b.CallSite {
 			return a.CallSite < b.CallSite
+		}
+		if a.StartCol != b.StartCol {
+			return a.StartCol < b.StartCol
+		}
+		if a.EndCol != b.EndCol {
+			return a.EndCol < b.EndCol
 		}
 		if a.MethodName != b.MethodName {
 			return a.MethodName < b.MethodName
@@ -1629,7 +1646,7 @@ func findCallAtSite(fn *FunctionDecl, gk dispatchAmbiguousGroupKey) (FunctionCal
 	var found *FunctionCall
 	for i := range fn.Calls {
 		c := &fn.Calls[i]
-		if c.Line != gk.CallSite {
+		if c.Line != gk.CallSite || (gk.StartCol > 0 && (c.StartCol != gk.StartCol || c.EndCol != gk.EndCol)) {
 			continue
 		}
 		method, arity := methodBaseArity(c.Callee.Name)
@@ -1724,12 +1741,12 @@ func resolvePassthroughForCaller(
 	// is a no-op (addCaller dedupes, the resolution map overwrites), but
 	// counting it as progress keeps the fixpoint spinning to
 	// passthroughMaxIterations instead of terminating.
-	if _, _, exists := lookupResolvedReceiverType(receiverIdx, callerKey, targetKey); exists {
+	if _, _, _, _, exists := lookupResolvedReceiverType(receiverIdx, callerKey, targetKey); exists {
 		return 0
 	}
 	addCaller(graph.Callers, targetKey, callerKey)
-	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", call.Line)
-	stampResolvedReceiverType(graph, callerKey, targetKey, call.Line, argType, receiverIdx)
+	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", call.Line, call.StartCol, call.EndCol)
+	stampResolvedReceiverType(graph, callerKey, targetKey, call.Line, call.StartCol, call.EndCol, argType, receiverIdx)
 	return 1
 }
 
@@ -1746,7 +1763,7 @@ func resolvePassthroughForThisReceiver(
 	candidateOwners map[string]string,
 	receiverIdx resolvedReceiverIndex,
 ) int {
-	resolvedType, line, ok := lookupResolvedReceiverType(receiverIdx, callerKey, gk.Caller)
+	resolvedType, line, startCol, endCol, ok := lookupResolvedReceiverType(receiverIdx, callerKey, gk.Caller)
 	if !ok {
 		return 0
 	}
@@ -1756,12 +1773,12 @@ func resolvePassthroughForThisReceiver(
 	}
 	// Same no-progress gate as resolvePassthroughForCaller: a bypass edge
 	// stamped in a prior iteration must not count as fixpoint progress.
-	if _, _, exists := lookupResolvedReceiverType(receiverIdx, callerKey, targetKey); exists {
+	if _, _, _, _, exists := lookupResolvedReceiverType(receiverIdx, callerKey, targetKey); exists {
 		return 0
 	}
 	addCaller(graph.Callers, targetKey, callerKey)
-	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", line)
-	stampResolvedReceiverType(graph, callerKey, targetKey, line, resolvedType, receiverIdx)
+	recordEdgeResolution(graph, callerKey, targetKey, EdgeKindExact, "", line, startCol, endCol)
+	stampResolvedReceiverType(graph, callerKey, targetKey, line, startCol, endCol, resolvedType, receiverIdx)
 	return 1
 }
 
@@ -1781,6 +1798,8 @@ type resolvedReceiverIndex map[string]resolvedReceiverEntry
 type resolvedReceiverEntry struct {
 	resolvedType string
 	line         int
+	startCol     int
+	endCol       int
 }
 
 // resolvedReceiverIndexKey builds the lookup key shared by
@@ -1797,7 +1816,8 @@ func resolvedReceiverIndexKey(callerKey, calleeKey string) string {
 // changes.
 func newResolvedReceiverIndex(graph *CallGraph) resolvedReceiverIndex {
 	idx := make(resolvedReceiverIndex, len(graph.EdgeResolutions))
-	for key, res := range graph.EdgeResolutions {
+	for key := range graph.EdgeResolutions {
+		res := graph.EdgeResolutions[key]
 		if res.ResolvedReceiverType == "" {
 			continue
 		}
@@ -1808,6 +1828,8 @@ func newResolvedReceiverIndex(graph *CallGraph) resolvedReceiverIndex {
 		idx[resolvedReceiverIndexKey(callerKey, calleeKey)] = resolvedReceiverEntry{
 			resolvedType: res.ResolvedReceiverType,
 			line:         res.CallSite,
+			startCol:     res.StartCol,
+			endCol:       res.EndCol,
 		}
 	}
 	return idx
@@ -1817,12 +1839,12 @@ func newResolvedReceiverIndex(graph *CallGraph) resolvedReceiverIndex {
 // (stamped by a previous resolveParameterPassthroughDispatch iteration) in the
 // index instead of scanning graph.EdgeResolutions. Returns the resolved type
 // and the call-site line to attribute the extended bypass edge to.
-func lookupResolvedReceiverType(receiverIdx resolvedReceiverIndex, callerKey, calleeKey string) (resolvedType string, line int, ok bool) {
+func lookupResolvedReceiverType(receiverIdx resolvedReceiverIndex, callerKey, calleeKey string) (resolvedType string, line, startCol, endCol int, ok bool) {
 	entry, found := receiverIdx[resolvedReceiverIndexKey(callerKey, calleeKey)]
 	if !found {
-		return "", 0, false
+		return "", 0, 0, 0, false
 	}
-	return entry.resolvedType, entry.line, true
+	return entry.resolvedType, entry.line, entry.startCol, entry.endCol, true
 }
 
 // resolveCandidateOwner matches a resolved concrete argument type against the
@@ -1950,7 +1972,7 @@ func concreteTypeFromSourceNode(graph *CallGraph, src SourceNode) string {
 // stampResolvedReceiverType writes ResolvedReceiverType onto the just-recorded
 // exact EdgeResolution for callerKey->targetKey at line, so the fragment
 // exporter can carry it through as graph-fragment resolved_receiver_type.
-func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, line int, resolvedType string, receiverIdx resolvedReceiverIndex) {
+func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, line, startCol, endCol int, resolvedType string, receiverIdx resolvedReceiverIndex) {
 	// Mirror recordEdgeResolution's method/arity derivation exactly so the key
 	// matches the entry it just wrote (EdgeResolutionKey folds MethodName/Arity
 	// into the map key, so an approximate key would silently miss).
@@ -1959,14 +1981,14 @@ func stampResolvedReceiverType(graph *CallGraph, callerKey, targetKey string, li
 		method = BaseFunctionName(calleeID.Name)
 		arity = functionArity(calleeID.Name)
 	}
-	key := EdgeResolutionKey(callerKey, targetKey, EdgeResolution{MethodName: method, Arity: arity, CallSite: line})
+	key := EdgeResolutionKey(callerKey, targetKey, EdgeResolution{MethodName: method, Arity: arity, CallSite: line, StartCol: startCol, EndCol: endCol})
 	res, ok := graph.EdgeResolutions[key]
 	if !ok {
 		return
 	}
 	res.ResolvedReceiverType = resolvedType
 	graph.EdgeResolutions[key] = res
-	receiverIdx[resolvedReceiverIndexKey(callerKey, targetKey)] = resolvedReceiverEntry{resolvedType: resolvedType, line: line}
+	receiverIdx[resolvedReceiverIndexKey(callerKey, targetKey)] = resolvedReceiverEntry{resolvedType: resolvedType, line: line, startCol: startCol, endCol: endCol}
 }
 
 // buildTypePackageIndex maps simple type names to their packages.

--- a/internal/callgraph/edge_resolution_test.go
+++ b/internal/callgraph/edge_resolution_test.go
@@ -99,3 +99,41 @@ func TestBuildCallerIndex_ClassifiesEdgeResolution(t *testing.T) {
 		t.Fatalf("impl edge call site = %d, want 3 (the call expression line)", implRes.CallSite)
 	}
 }
+
+func TestBuildCallerIndex_PreservesSameLineCallColumns(t *testing.T) {
+	root := t.TempDir()
+	caller := FunctionDecl{
+		ID:       FunctionID{Package: "app", Type: "Controller", Name: "handle#0"},
+		FilePath: filepath.Join(root, "Controller.java"),
+		Calls: []FunctionCall{
+			{Callee: FunctionID{Package: "com.dep", Type: "Sink", Name: "run#0"}, Line: 3, StartCol: 4, EndCol: 14},
+			{Callee: FunctionID{Package: "com.dep", Type: "Sink", Name: "run#0"}, Line: 3, StartCol: 20, EndCol: 30},
+		},
+	}
+	iface := FunctionDecl{
+		ID: FunctionID{Package: "com.dep", Type: "Sink", Name: "run#0"}, OwnerType: "interface", OwnerName: "Sink",
+	}
+	impl := FunctionDecl{
+		ID: FunctionID{Package: "com.dep.impl", Type: "SinkImpl", Name: "run#0"}, OwnerType: "class", OwnerName: "SinkImpl",
+	}
+	parser := &stubParser{sep: ".", analyses: map[string][]*FileAnalysis{root: {{Functions: []FunctionDecl{caller, iface, impl}}}}}
+
+	graph, err := NewBuilder(parser).BuildFromDirectories([]PackageDir{{Dir: root, ImportPath: "app"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	for _, cols := range [][2]int{{4, 14}, {20, 30}} {
+		key := EdgeResolutionKey(caller.ID.String(), impl.ID.String(), EdgeResolution{
+			DeclaredType: "com.dep.Sink", MethodName: "run", Arity: 0, CallSite: 3,
+			StartCol: cols[0], EndCol: cols[1],
+		})
+		resolution, ok := graph.EdgeResolutions[key]
+		if !ok {
+			t.Fatalf("missing same-line dispatch resolution at columns %d:%d", cols[0], cols[1])
+		}
+		if resolution.StartCol != cols[0] || resolution.EndCol != cols[1] {
+			t.Fatalf("resolution columns = %d:%d, want %d:%d", resolution.StartCol, resolution.EndCol, cols[0], cols[1])
+		}
+	}
+}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -356,6 +356,8 @@ type EdgeResolution struct {
 	MethodName   string // base method name (no arity decoration)
 	Arity        int
 	CallSite     int // source line of the call expression
+	StartCol     int // 1-based, inclusive; 0 when the parser is not column-aware
+	EndCol       int // 1-based, exclusive; 0 when unknown
 	callerKey    string
 	calleeKey    string
 
@@ -375,6 +377,8 @@ type EdgeResolution struct {
 func EdgeResolutionKey(callerKey, calleeKey string, resolution EdgeResolution) string {
 	return EdgeResolutionKeyPrefix(callerKey, calleeKey) +
 		strconv.Itoa(resolution.CallSite) + "\x00" +
+		strconv.Itoa(resolution.StartCol) + "\x00" +
+		strconv.Itoa(resolution.EndCol) + "\x00" +
 		resolution.DeclaredType + "\x00" +
 		resolution.MethodName + "\x00" +
 		strconv.Itoa(resolution.Arity)

--- a/internal/cli/dependency_intelligence_acceptance_integration_test.go
+++ b/internal/cli/dependency_intelligence_acceptance_integration_test.go
@@ -441,11 +441,71 @@ func assertForwardContract(t *testing.T, tc acceptanceCase, result *acceptanceRe
 			"ambiguity remains candidate identities with parameter-type evidence",
 		)
 		assertSuppressedAmbiguity(t, result.stitch)
+		assertSerializedAmbiguity(t, result.stitched)
 	case "python":
 		assert.Equal(t, "dependency_intelligence_python.helper(bytes, bytes, int): bytes", helper.EntryCall.CanonicalSignature)
 		assert.Equal(t, "bytes", helper.EntryCall.ReturnType)
 		assert.Equal(t, []string{"bytes", "bytes", "int"}, helper.EntryCall.ParameterTypes)
 	}
+}
+
+func assertSerializedAmbiguity(t *testing.T, export graphfrag.CallgraphExport) {
+	t.Helper()
+	raw, err := json.Marshal(export)
+	require.NoError(t, err)
+	var payload struct {
+		FindingGraphs []struct {
+			ForwardCalls *struct {
+				Anchor struct {
+					FunctionName string `json:"function_name"`
+				} `json:"anchor"`
+				Truncated      bool `json:"truncated"`
+				AmbiguousCalls []struct {
+					GroupID      string `json:"group_id"`
+					Reason       string `json:"reason"`
+					Completeness string `json:"completeness"`
+					CallSite     struct {
+						MethodName string `json:"method_name"`
+						Line       int    `json:"line"`
+						StartCol   int    `json:"start_col"`
+						EndCol     int    `json:"end_col"`
+					} `json:"call_site"`
+					Candidates []struct {
+						CandidateID        string   `json:"candidate_id"`
+						CanonicalSignature string   `json:"canonical_signature"`
+						ParameterTypes     []string `json:"parameter_types"`
+						EntryCall          any      `json:"entry_call"`
+					} `json:"candidates"`
+				} `json:"ambiguous_calls"`
+			} `json:"forward_calls"`
+		} `json:"finding_graphs"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload), "serialized callgraph JSON")
+	for _, finding := range payload.FindingGraphs {
+		if finding.ForwardCalls == nil || !strings.HasSuffix(finding.ForwardCalls.Anchor.FunctionName, ".run") {
+			continue
+		}
+		for _, group := range finding.ForwardCalls.AmbiguousCalls {
+			if group.CallSite.MethodName != "apply" {
+				continue
+			}
+			assert.NotEmpty(t, group.GroupID)
+			assert.Equal(t, graphfrag.SuppressReasonAmbiguousDispatch, group.Reason)
+			assert.Equal(t, graphfrag.AmbiguityComplete, group.Completeness)
+			assert.NotZero(t, group.CallSite.Line)
+			assert.NotZero(t, group.CallSite.StartCol)
+			assert.Greater(t, group.CallSite.EndCol, group.CallSite.StartCol)
+			require.Len(t, group.Candidates, 2)
+			for _, candidate := range group.Candidates {
+				assert.NotEmpty(t, candidate.CandidateID)
+				assert.NotEmpty(t, candidate.CanonicalSignature)
+				assert.Equal(t, []string{"byte[]"}, candidate.ParameterTypes)
+				assert.NotNil(t, candidate.EntryCall)
+			}
+			return
+		}
+	}
+	assert.Fail(t, "serialized JSON lacks ambiguous apply dispatch", "payload: %s", raw)
 }
 
 func assertSuppressedAmbiguity(t *testing.T, result *graphfrag.Result) {

--- a/internal/scan/export_inferred_return_test.go
+++ b/internal/scan/export_inferred_return_test.go
@@ -69,8 +69,8 @@ func TestExportSchema_Is52(t *testing.T) {
 		t.Fatalf("invalid json: %v", err)
 	}
 
-	if payload.SchemaVersion != "6.5" {
-		t.Fatalf("schema_version = %q, want 6.5", payload.SchemaVersion)
+	if payload.SchemaVersion != callGraphSchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, callGraphSchemaVersion)
 	}
 }
 
@@ -361,8 +361,8 @@ func TestExportSchemaVersionIs53(t *testing.T) {
 		t.Fatalf("invalid json: %v", err)
 	}
 
-	if payload.SchemaVersion != "6.5" {
-		t.Fatalf("schema_version = %q, want 6.5", payload.SchemaVersion)
+	if payload.SchemaVersion != callGraphSchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, callGraphSchemaVersion)
 	}
 }
 

--- a/internal/scan/export_reachability_test.go
+++ b/internal/scan/export_reachability_test.go
@@ -90,8 +90,8 @@ func TestBuildCallGraphExportV6_CryptoEntryPointsAndSourceNodes(t *testing.T) {
 		Ecosystem: "java",
 	})
 
-	if payload.SchemaVersion != "6.5" {
-		t.Fatalf("SchemaVersion = %q, want 6.5", payload.SchemaVersion)
+	if payload.SchemaVersion != callGraphSchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", payload.SchemaVersion, callGraphSchemaVersion)
 	}
 	raw, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -428,27 +428,68 @@ func buildResolvedFragmentEdges(
 		}
 		resolutions := resolveFragmentEdges(ctx, callerKey, calleeKey)
 		for i := range resolutions {
-			res := resolutions[i]
-			line := fragmentEdgeLine(ctx, callerKey, callerDecl, calleeKey, res)
-			call := findCallForCalleeAtLine(ctx, callerKey, callerDecl, calleeKey, line)
-			if _, ok := graph.Functions[calleeKey]; ok {
-				edge := buildFragmentInternalEdge(ctx, callerDecl, call, callerKey, calleeKey, line, res)
-				if edge.ChainID == "" {
-					edge.ChainID = ctx.chainIDForLine(callerKey, callerDecl, line)
-				}
-				if err := emitInternal(edge); err != nil {
-					return nil, err
-				}
-				continue
+			external, err := buildResolvedFragmentEdge(ctx, callerKey, callerDecl, calleeKey, resolutions[i], emitInternal)
+			if err != nil {
+				return nil, err
 			}
-			external := buildFragmentExternalCall(ctx, callerDecl, call, callerKey, calleeKey, line, res)
-			if external.ChainID == "" {
-				external.ChainID = ctx.chainIDForLine(callerKey, callerDecl, line)
+			if external != nil {
+				externalCalls = append(externalCalls, *external)
 			}
-			externalCalls = append(externalCalls, external)
 		}
 	}
 	return externalCalls, nil
+}
+
+func buildResolvedFragmentEdge(
+	ctx *exportBuildContext,
+	callerKey string,
+	callerDecl *callgraph.FunctionDecl,
+	calleeKey string,
+	res fragmentEdgeResolution,
+	emitInternal func(graphfrag.GraphFragmentEdge) error,
+) (*graphfrag.GraphFragmentExternal, error) {
+	line := fragmentEdgeLine(ctx, callerKey, callerDecl, calleeKey, res)
+	call := findCallForCalleeAtLine(ctx, callerKey, callerDecl, calleeKey, line)
+	if call == nil {
+		call = findDispatchCallAtLine(callerDecl, line, res.StartCol, res.EndCol, res.MethodName, res.Arity)
+	}
+	if _, ok := ctx.graph.Functions[calleeKey]; ok {
+		edge := buildFragmentInternalEdge(ctx, callerDecl, call, callerKey, calleeKey, line, res)
+		if edge.ChainID == "" {
+			edge.ChainID = ctx.chainIDForLine(callerKey, callerDecl, line)
+		}
+		if err := emitInternal(edge); err != nil {
+			return nil, fmt.Errorf("scan: emit fragment edge: %w", err)
+		}
+		return nil, nil
+	}
+	external := buildFragmentExternalCall(ctx, callerDecl, call, callerKey, calleeKey, line, res)
+	if external.ChainID == "" {
+		external.ChainID = ctx.chainIDForLine(callerKey, callerDecl, line)
+	}
+	return &external, nil
+}
+
+// findDispatchCallAtLine recovers the source invocation for a dispatch-expanded
+// target whose concrete declaring type differs from the interface call recorded
+// by the parser. It fails closed when the line contains more than one matching
+// method+arity call.
+func findDispatchCallAtLine(fn *callgraph.FunctionDecl, line, startCol, endCol int, method string, arity int) *callgraph.FunctionCall {
+	if fn == nil || line <= 0 || method == "" {
+		return nil
+	}
+	var match *callgraph.FunctionCall
+	for i := range fn.Calls {
+		call := &fn.Calls[i]
+		if call.Line != line || (startCol > 0 && (call.StartCol != startCol || call.EndCol != endCol)) || callgraph.BaseFunctionName(call.Callee.Name) != method || len(call.Arguments) != arity {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = call
+	}
+	return match
 }
 
 // buildFragmentCallSiteEntryCall constructs the GraphFragmentCallSite for a
@@ -534,13 +575,17 @@ func buildFragmentInternalEdge(
 		Arity:                res.Arity,
 		EntryCall:            buildFragmentCallSiteEntryCall(ctx, call),
 		ResolvedReceiverType: res.ResolvedReceiverType,
+		StartCol:             res.StartCol,
+		EndCol:               res.EndCol,
 	}
 	if call != nil {
 		edge.ReceiverVar = call.ReceiverVar
 		edge.AssignedVar = call.AssignedVar
 		edge.ChainID = call.ChainID
-		edge.StartCol = call.StartCol
-		edge.EndCol = call.EndCol
+		if call.StartCol > 0 && call.EndCol > call.StartCol {
+			edge.StartCol = call.StartCol
+			edge.EndCol = call.EndCol
+		}
 	}
 	return edge
 }
@@ -564,6 +609,8 @@ func buildFragmentExternalCall(
 		Arity:                res.Arity,
 		EntryCall:            buildFragmentCallSiteEntryCall(ctx, call),
 		ResolvedReceiverType: res.ResolvedReceiverType,
+		StartCol:             res.StartCol,
+		EndCol:               res.EndCol,
 	}
 	external.TargetFunctionName = fragmentTargetFunctionName(ctx, callerKey, callerDecl, calleeKey, &external)
 	if call != nil {
@@ -571,8 +618,10 @@ func buildFragmentExternalCall(
 		external.ReceiverVar = call.ReceiverVar
 		external.AssignedVar = call.AssignedVar
 		external.ChainID = call.ChainID
-		external.StartCol = call.StartCol
-		external.EndCol = call.EndCol
+		if call.StartCol > 0 && call.EndCol > call.StartCol {
+			external.StartCol = call.StartCol
+			external.EndCol = call.EndCol
+		}
 	}
 	return external
 }
@@ -650,6 +699,12 @@ func fragmentEdgeLess(a, b graphfrag.GraphFragmentEdge) bool {
 	if a.Line != b.Line {
 		return a.Line < b.Line
 	}
+	if a.StartCol != b.StartCol {
+		return a.StartCol < b.StartCol
+	}
+	if a.EndCol != b.EndCol {
+		return a.EndCol < b.EndCol
+	}
 	if a.Resolution != b.Resolution {
 		return a.Resolution < b.Resolution
 	}
@@ -666,6 +721,8 @@ func fragmentEdgeSameKey(a, b graphfrag.GraphFragmentEdge) bool {
 	return a.CallerKey == b.CallerKey &&
 		a.CalleeKey == b.CalleeKey &&
 		a.Line == b.Line &&
+		a.StartCol == b.StartCol &&
+		a.EndCol == b.EndCol &&
 		a.Resolution == b.Resolution &&
 		a.DeclaredType == b.DeclaredType &&
 		a.MethodName == b.MethodName &&
@@ -681,6 +738,12 @@ func fragmentExternalLess(a, b graphfrag.GraphFragmentExternal) bool {
 	}
 	if a.Line != b.Line {
 		return a.Line < b.Line
+	}
+	if a.StartCol != b.StartCol {
+		return a.StartCol < b.StartCol
+	}
+	if a.EndCol != b.EndCol {
+		return a.EndCol < b.EndCol
 	}
 	if a.Resolution != b.Resolution {
 		return a.Resolution < b.Resolution
@@ -698,6 +761,8 @@ func fragmentExternalSameKey(a, b graphfrag.GraphFragmentExternal) bool {
 	return a.CallerKey == b.CallerKey &&
 		a.TargetKey == b.TargetKey &&
 		a.Line == b.Line &&
+		a.StartCol == b.StartCol &&
+		a.EndCol == b.EndCol &&
 		a.Resolution == b.Resolution &&
 		a.DeclaredType == b.DeclaredType &&
 		a.MethodName == b.MethodName &&
@@ -728,7 +793,8 @@ func indexFragmentEdgeResolutions(graph *callgraph.CallGraph) map[string][]fragm
 		return nil
 	}
 	index := make(map[string][]fragmentEdgeResolution)
-	for key, res := range graph.EdgeResolutions {
+	for key := range graph.EdgeResolutions {
+		res := graph.EdgeResolutions[key]
 		callerKey, calleeKey, ok := callgraph.EdgeResolutionEndpoints(key, res)
 		if !ok {
 			continue
@@ -742,23 +808,31 @@ func indexFragmentEdgeResolutions(graph *callgraph.CallGraph) map[string][]fragm
 	// variant a line-match picks first) reproducible run to run.
 	for pairKey := range index {
 		values := index[pairKey]
-		sort.Slice(values, func(i, j int) bool {
-			if values[i].CallSite != values[j].CallSite {
-				return values[i].CallSite < values[j].CallSite
-			}
-			if values[i].DeclaredType != values[j].DeclaredType {
-				return values[i].DeclaredType < values[j].DeclaredType
-			}
-			if values[i].MethodName != values[j].MethodName {
-				return values[i].MethodName < values[j].MethodName
-			}
-			if values[i].Arity != values[j].Arity {
-				return values[i].Arity < values[j].Arity
-			}
-			return values[i].Kind < values[j].Kind
-		})
+		sort.Slice(values, func(i, j int) bool { return fragmentEdgeResolutionLess(values[i], values[j]) })
 	}
 	return index
+}
+
+func fragmentEdgeResolutionLess(a, b fragmentEdgeResolution) bool {
+	if a.CallSite != b.CallSite {
+		return a.CallSite < b.CallSite
+	}
+	if a.StartCol != b.StartCol {
+		return a.StartCol < b.StartCol
+	}
+	if a.EndCol != b.EndCol {
+		return a.EndCol < b.EndCol
+	}
+	if a.DeclaredType != b.DeclaredType {
+		return a.DeclaredType < b.DeclaredType
+	}
+	if a.MethodName != b.MethodName {
+		return a.MethodName < b.MethodName
+	}
+	if a.Arity != b.Arity {
+		return a.Arity < b.Arity
+	}
+	return a.Kind < b.Kind
 }
 
 func fragmentEdgePairKey(callerKey, calleeKey string) string {

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -865,3 +865,23 @@ func TestFlattenGraphFragmentEntryPoints_PopulatesParameterRoles(t *testing.T) {
 		t.Fatalf("ParameterRoles[0] = %#v, want index=0 metadata-contributing keySize/argument_bit_length", pr)
 	}
 }
+
+func TestSortedFragmentEdges_PreserveSameLineColumnIdentity(t *testing.T) {
+	t.Parallel()
+
+	internal := sortedFragmentEdges([]graphfrag.GraphFragmentEdge{
+		{CallerKey: "caller", CalleeKey: "callee", Line: 7, StartCol: 20, EndCol: 30, Resolution: string(graphfrag.ResolutionInterfaceDispatch)},
+		{CallerKey: "caller", CalleeKey: "callee", Line: 7, StartCol: 4, EndCol: 14, Resolution: string(graphfrag.ResolutionInterfaceDispatch)},
+	})
+	if len(internal) != 2 || internal[0].StartCol != 4 || internal[1].StartCol != 20 {
+		t.Fatalf("internal same-line identities lost or unstable: %+v", internal)
+	}
+
+	external := sortedFragmentExternalCalls([]graphfrag.GraphFragmentExternal{
+		{CallerKey: "caller", TargetKey: "callee", Line: 7, StartCol: 20, EndCol: 30, Resolution: string(graphfrag.ResolutionInterfaceDispatch)},
+		{CallerKey: "caller", TargetKey: "callee", Line: 7, StartCol: 4, EndCol: 14, Resolution: string(graphfrag.ResolutionInterfaceDispatch)},
+	})
+	if len(external) != 2 || external[0].StartCol != 4 || external[1].StartCol != 20 {
+		t.Fatalf("external same-line identities lost or unstable: %+v", external)
+	}
+}

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -339,8 +339,8 @@ func TestExportCallGraph(t *testing.T) {
 		if err := json.Unmarshal(data, &payload); err != nil {
 			t.Fatalf("invalid json output: %v", err)
 		}
-		if payload.SchemaVersion != "6.5" {
-			t.Fatalf("schema_version = %q, want 6.5", payload.SchemaVersion)
+		if payload.SchemaVersion != callGraphSchemaVersion {
+			t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, callGraphSchemaVersion)
 		}
 		if len(payload.FindingGraphs) != 1 {
 			t.Fatalf("finding_graphs count = %d, want 1", len(payload.FindingGraphs))
@@ -1959,8 +1959,8 @@ func TestExportCallGraph_CryptoEntryPointsBuiltFromChains(t *testing.T) {
 		t.Fatalf("json: %v", err)
 	}
 
-	if payload.SchemaVersion != "6.5" {
-		t.Fatalf("schema_version = %q, want 6.5", payload.SchemaVersion)
+	if payload.SchemaVersion != callGraphSchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, callGraphSchemaVersion)
 	}
 
 	if len(payload.CryptoEntryPoints) == 0 {

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -28,7 +28,7 @@ import (
 // the graph-fragment stitch path (ToCallgraphExport), so the two can never drift
 // — a consumer that serves stitched output stamps the SAME version a live
 // `--scan-dependencies --export-callgraph` run produces.
-const CallgraphSchemaVersion = "6.5"
+const CallgraphSchemaVersion = "6.6"
 
 // ScanMeta carries the top-level metadata stamped onto a CallgraphExport.
 type ScanMeta struct {
@@ -85,11 +85,56 @@ type ExportFindingGraph struct {
 // echoes the depth CAP applied (the budget), not the deepest node reached;
 // Truncated is true whenever any cap (depth/node/edge) cut the walk short.
 type ExportForwardClosure struct {
-	Anchor    ExportForwardAnchor `json:"anchor"`
-	MaxDepth  int                 `json:"max_depth"`
-	Truncated bool                `json:"truncated"`
-	Nodes     []ExportForwardNode `json:"nodes,omitempty"`
-	Edges     []ExportForwardEdge `json:"edges,omitempty"`
+	Anchor         ExportForwardAnchor          `json:"anchor"`
+	MaxDepth       int                          `json:"max_depth"`
+	Truncated      bool                         `json:"truncated"`
+	Nodes          []ExportForwardNode          `json:"nodes,omitempty"`
+	Edges          []ExportForwardEdge          `json:"edges,omitempty"`
+	AmbiguousCalls []ExportAmbiguousForwardCall `json:"ambiguous_calls,omitempty"`
+}
+
+const (
+	// AmbiguityComplete marks ambiguity evidence with complete call-site and candidate identities.
+	AmbiguityComplete = "complete"
+	// AmbiguityPartial marks ambiguity evidence that degraded because identity data was unavailable.
+	AmbiguityPartial = "partial"
+)
+
+// ExportAmbiguousForwardCall is one fail-closed interface-dispatch call site.
+// Its candidates are evidence, never traversed forward edges.
+type ExportAmbiguousForwardCall struct {
+	GroupID      string                            `json:"group_id"`
+	Reason       string                            `json:"reason"`
+	Completeness string                            `json:"completeness"`
+	CallSite     ExportAmbiguousCallSite           `json:"call_site"`
+	Candidates   []ExportAmbiguousForwardCandidate `json:"candidates"`
+}
+
+// ExportAmbiguousCallSite identifies the source invocation shared by every
+// candidate in an ambiguous dispatch group.
+type ExportAmbiguousCallSite struct {
+	CallerFunctionKey        string `json:"caller_function_key"`
+	CallerFunctionName       string `json:"caller_function_name,omitempty"`
+	CallerCanonicalSignature string `json:"caller_canonical_signature,omitempty"`
+	Line                     int    `json:"line,omitempty"`
+	StartCol                 int    `json:"start_col,omitempty"`
+	EndCol                   int    `json:"end_col,omitempty"`
+	MethodName               string `json:"method_name"`
+	Arity                    int    `json:"arity"`
+}
+
+// ExportAmbiguousForwardCandidate is one possible target for an ambiguous
+// dispatch. EntryCall carries the candidate-aligned argument/provenance data.
+type ExportAmbiguousForwardCandidate struct {
+	CandidateID        string                `json:"candidate_id"`
+	FunctionKey        string                `json:"function_key"`
+	FunctionName       string                `json:"function_name,omitempty"`
+	CanonicalSignature string                `json:"canonical_signature,omitempty"`
+	DeclaringType      string                `json:"declaring_type,omitempty"`
+	ReturnType         string                `json:"return_type,omitempty"`
+	ParameterTypes     []string              `json:"parameter_types"`
+	DependencyInfo     *ExportDependencyInfo `json:"dependency_info,omitempty"`
+	EntryCall          *ExportEntryCall      `json:"entry_call,omitempty"`
 }
 
 // ExportForwardAnchor is the lean identity of the forward closure's root: the
@@ -630,8 +675,98 @@ func projectForwardClosure(fc *forwardClosure, root ComponentKey) *ExportForward
 		return li < lj
 	})
 	out.Edges = edges
+	out.AmbiguousCalls = projectAmbiguousCalls(fc.ambiguous, root)
 
 	return out
+}
+
+func projectAmbiguousCalls(groups []SuppressedEdge, root ComponentKey) []ExportAmbiguousForwardCall {
+	out := make([]ExportAmbiguousForwardCall, 0, len(groups))
+	for i := range groups {
+		group := &groups[i]
+		groupID := ambiguityID("group", group.Caller.Component.String(), group.Caller.Signature,
+			strconv.Itoa(group.CallSite), strconv.Itoa(group.StartCol), strconv.Itoa(group.EndCol), group.MethodName, strconv.Itoa(group.Arity))
+		exported := ExportAmbiguousForwardCall{
+			GroupID: groupID,
+			Reason:  group.Reason,
+			CallSite: ExportAmbiguousCallSite{
+				CallerFunctionKey:        group.Caller.Signature,
+				CallerFunctionName:       group.Caller.Function.FunctionName,
+				CallerCanonicalSignature: group.Caller.Function.CanonicalSignature,
+				Line:                     group.CallSite,
+				StartCol:                 group.StartCol,
+				EndCol:                   group.EndCol,
+				MethodName:               group.MethodName,
+				Arity:                    group.Arity,
+			},
+		}
+		frames := append([]CallFrame(nil), group.CandidateFrames...)
+		sort.Slice(frames, func(i, j int) bool {
+			a, b := frames[i], frames[j]
+			if a.Function.CanonicalSignature != b.Function.CanonicalSignature {
+				return a.Function.CanonicalSignature < b.Function.CanonicalSignature
+			}
+			if a.Signature != b.Signature {
+				return a.Signature < b.Signature
+			}
+			return a.Component.String() < b.Component.String()
+		})
+		for j := range frames {
+			frame := &frames[j]
+			parameterTypes := append([]string(nil), frame.Function.ParameterTypes...)
+			if parameterTypes == nil {
+				parameterTypes = []string{}
+			}
+			candidate := ExportAmbiguousForwardCandidate{
+				CandidateID:        ambiguityID("candidate", groupID, frame.Component.String(), frame.Signature, frame.Function.CanonicalSignature),
+				FunctionKey:        frame.Signature,
+				FunctionName:       frame.Function.FunctionName,
+				CanonicalSignature: frame.Function.CanonicalSignature,
+				DeclaringType:      frame.Function.DeclaringType,
+				ReturnType:         frame.Function.ReturnType,
+				ParameterTypes:     parameterTypes,
+				EntryCall:          exportEntryCall(frame.EntryCall, frame.Function),
+			}
+			if frame.Component != root {
+				candidate.DependencyInfo = &ExportDependencyInfo{Module: moduleFromFrame(frame), Version: frame.Component.Version}
+			}
+			exported.Candidates = append(exported.Candidates, candidate)
+		}
+		exported.Completeness = ambiguityCompleteness(exported)
+		out = append(out, exported)
+	}
+	return out
+}
+
+func ambiguityCompleteness(group ExportAmbiguousForwardCall) string {
+	if !completeAmbiguousCallSite(group.CallSite) || len(group.Candidates) < 2 {
+		return AmbiguityPartial
+	}
+	for i := range group.Candidates {
+		if !completeAmbiguousCandidate(&group.Candidates[i], group.CallSite.Arity) {
+			return AmbiguityPartial
+		}
+	}
+	return AmbiguityComplete
+}
+
+func completeAmbiguousCallSite(callSite ExportAmbiguousCallSite) bool {
+	return callSite.CallerFunctionKey != "" && callSite.CallerCanonicalSignature != "" &&
+		callSite.Line > 0 && callSite.StartCol > 0 && callSite.EndCol > callSite.StartCol &&
+		callSite.MethodName != ""
+}
+
+func completeAmbiguousCandidate(candidate *ExportAmbiguousForwardCandidate, arity int) bool {
+	if candidate.FunctionKey == "" || candidate.CanonicalSignature == "" || candidate.DeclaringType == "" ||
+		candidate.ReturnType == "" || candidate.EntryCall == nil || len(candidate.EntryCall.Parameters) != arity {
+		return false
+	}
+	return len(candidate.ParameterTypes) == arity
+}
+
+func ambiguityID(kind string, parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return kind + "-" + hex.EncodeToString(h[:8])
 }
 
 // chainSupportingCallIDs returns the terminal crypto operation's supporting-call

--- a/pkg/graphfrag/callgraph_export_forward_test.go
+++ b/pkg/graphfrag/callgraph_export_forward_test.go
@@ -109,6 +109,117 @@ func TestToCallgraphExportForwardCallsEmitted(t *testing.T) {
 	}
 }
 
+func TestToCallgraphExportForwardCallsExposeAmbiguousDispatch(t *testing.T) {
+	t.Parallel()
+
+	root := ComponentKey{Purl: "pkg:maven/com.acme/app", Version: "1.0.0"}
+	entryCall := &CallSite{Line: 23, Parameters: []Parameter{{
+		ParameterIndex:     0,
+		ArgumentExpression: "payload",
+		SourceNodes:        []SourceNode{{Type: "PARAMETER", Name: "payload"}},
+	}}}
+	fragment := Fragment{
+		Component: root,
+		Module:    "com.acme:app",
+		Functions: []Function{
+			{Signature: "anchor", FunctionName: "com.acme.App.anchor", DeclaringType: "App", CanonicalSignature: "com.acme.App.anchor(byte[]): void", ReturnType: "void", ParameterTypes: []string{"byte[]"}, FilePath: "App.java"},
+			{Signature: "dispatch", FunctionName: "com.acme.App.dispatch", DeclaringType: "App", CanonicalSignature: "com.acme.App.dispatch(Processor, byte[]): byte[]", ReturnType: "byte[]", ParameterTypes: []string{"Processor", "byte[]"}, FilePath: "App.java"},
+			{Signature: "impl-a", FunctionName: "com.acme.FirstProcessor.apply", DeclaringType: "FirstProcessor", CanonicalSignature: "com.acme.FirstProcessor.apply(byte[]): byte[]", ReturnType: "byte[]", ParameterTypes: []string{"byte[]"}, FilePath: "App.java"},
+			{Signature: "impl-b", FunctionName: "com.acme.SecondProcessor.apply", DeclaringType: "SecondProcessor", CanonicalSignature: "com.acme.SecondProcessor.apply(byte[]): byte[]", ReturnType: "byte[]", ParameterTypes: []string{"byte[]"}, FilePath: "App.java"},
+		},
+		InternalEdges: []InternalEdge{
+			{Caller: "anchor", Callee: "dispatch", Resolution: ResolutionExact, EntryCall: &CallSite{Line: 11}},
+			{Caller: "dispatch", Callee: "impl-b", Resolution: ResolutionInterfaceDispatch, MethodName: "apply", Arity: 1, CallSite: 23, StartCol: 9, EndCol: 33, EntryCall: entryCall},
+			{Caller: "dispatch", Callee: "impl-a", Resolution: ResolutionInterfaceDispatch, MethodName: "apply", Arity: 1, CallSite: 23, StartCol: 9, EndCol: 33, EntryCall: entryCall},
+			{Caller: "dispatch", Callee: "impl-b", Resolution: ResolutionInterfaceDispatch, MethodName: "apply", Arity: 1, CallSite: 23, StartCol: 38, EndCol: 62, EntryCall: entryCall},
+			{Caller: "dispatch", Callee: "impl-a", Resolution: ResolutionInterfaceDispatch, MethodName: "apply", Arity: 1, CallSite: 23, StartCol: 38, EndCol: 62, EntryCall: entryCall},
+		},
+		CryptoOperations: []CryptoOperation{{Function: "anchor", FindingID: "f1", RuleID: "r1", Symbol: "Cipher.run"}},
+	}
+
+	export := stitchForExport(t, root, DependencyGraph{}, map[ComponentKey]Fragment{root: fragment}, StitchOptions{
+		ForwardClosure:  true,
+		MaxForwardDepth: 2,
+	})
+	forward := export.FindingGraphs[0].ForwardCalls
+	if forward == nil {
+		t.Fatal("forward_calls missing")
+	}
+	if forward.Truncated {
+		t.Fatal("truncated = true, ambiguity must remain distinct from budget truncation")
+	}
+	for _, node := range forward.Nodes {
+		if node.FunctionKey == "impl-a" || node.FunctionKey == "impl-b" {
+			t.Fatalf("ambiguous candidate leaked into forward nodes: %#v", forward.Nodes)
+		}
+	}
+	if len(forward.AmbiguousCalls) != 2 {
+		t.Fatalf("ambiguous_calls = %#v, want two same-line groups", forward.AmbiguousCalls)
+	}
+	group := forward.AmbiguousCalls[0]
+	if group.GroupID == forward.AmbiguousCalls[1].GroupID {
+		t.Fatalf("same-line call sites share group_id %q", group.GroupID)
+	}
+	if group.GroupID == "" || group.Reason != SuppressReasonAmbiguousDispatch || group.Completeness != AmbiguityComplete {
+		t.Fatalf("ambiguous group = %#v", group)
+	}
+	if group.CallSite.CallerFunctionKey != "dispatch" || group.CallSite.Line != 23 || group.CallSite.StartCol != 9 || group.CallSite.EndCol != 33 || group.CallSite.MethodName != "apply" || group.CallSite.Arity != 1 {
+		t.Errorf("call_site = %#v", group.CallSite)
+	}
+	if len(group.Candidates) != 2 {
+		t.Fatalf("candidates = %#v, want two", group.Candidates)
+	}
+	if group.Candidates[0].CanonicalSignature != "com.acme.FirstProcessor.apply(byte[]): byte[]" ||
+		group.Candidates[1].CanonicalSignature != "com.acme.SecondProcessor.apply(byte[]): byte[]" {
+		t.Errorf("candidate order/identity = %#v", group.Candidates)
+	}
+	for _, candidate := range group.Candidates {
+		if candidate.CandidateID == "" || candidate.DeclaringType == "" || candidate.ReturnType != "byte[]" || len(candidate.ParameterTypes) != 1 {
+			t.Errorf("incomplete candidate = %#v", candidate)
+		}
+		if candidate.EntryCall == nil || len(candidate.EntryCall.Parameters) != 1 || len(candidate.EntryCall.Parameters[0].SourceNodes) != 1 {
+			t.Errorf("candidate evidence missing = %#v", candidate)
+		}
+	}
+	raw, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"ambiguous_calls"`)) {
+		t.Fatalf("serialized export lacks ambiguous_calls: %s", raw)
+	}
+}
+
+func TestToCallgraphExportForwardCallsMarksLegacyAmbiguityPartial(t *testing.T) {
+	t.Parallel()
+
+	root := ComponentKey{Purl: "pkg:generic/app", Version: "1"}
+	fragment := Fragment{
+		Component: root,
+		Functions: []Function{
+			{Signature: "anchor", FunctionName: "app.anchor"},
+			{Signature: "impl-a", FunctionName: "app.First.apply"},
+			{Signature: "impl-b", FunctionName: "app.Second.apply"},
+		},
+		InternalEdges: []InternalEdge{
+			{Caller: "anchor", Callee: "impl-a", Resolution: ResolutionInterfaceDispatch, MethodName: "apply", Arity: 0, CallSite: 7},
+			{Caller: "anchor", Callee: "impl-b", Resolution: ResolutionInterfaceDispatch, MethodName: "apply", Arity: 0, CallSite: 7},
+		},
+		CryptoOperations: []CryptoOperation{{Function: "anchor", FindingID: "f1", RuleID: "r1"}},
+	}
+
+	export := stitchForExport(t, root, DependencyGraph{}, map[ComponentKey]Fragment{root: fragment}, StitchOptions{ForwardClosure: true})
+	group := export.FindingGraphs[0].ForwardCalls.AmbiguousCalls[0]
+	if group.Completeness != AmbiguityPartial {
+		t.Fatalf("completeness = %q, want %q", group.Completeness, AmbiguityPartial)
+	}
+	for _, candidate := range group.Candidates {
+		if candidate.CandidateID == "" || candidate.ParameterTypes == nil {
+			t.Errorf("legacy candidate does not degrade explicitly: %#v", candidate)
+		}
+	}
+}
+
 // TestToCallgraphExportForwardCallsSharedAnchor asserts findings sharing one
 // anchor inline the same projected forward_calls content.
 func TestToCallgraphExportForwardCallsSharedAnchor(t *testing.T) {

--- a/pkg/graphfrag/callgraph_export_test.go
+++ b/pkg/graphfrag/callgraph_export_test.go
@@ -588,15 +588,14 @@ func TestToCallgraphExport_RootFindingIDUnprefixed(t *testing.T) {
 	}
 }
 
-// TestCallgraphSchemaVersion_Is65 pins the canonical callgraph schema version
-// at 6.5 — the contract change that represents operation methods as
-// supporting calls instead of operation-only crypto_entry_points. The bump
+// TestCallgraphSchemaVersion_Is66 pins the canonical callgraph schema version
+// at 6.6 — the contract change that serializes ambiguous forward dispatch. The bump
 // is unconditional: it advances regardless of whether any given export
 // actually emits the new fields (see package doc on CallgraphSchemaVersion).
-func TestCallgraphSchemaVersion_Is65(t *testing.T) {
+func TestCallgraphSchemaVersion_Is66(t *testing.T) {
 	t.Parallel()
 
-	if CallgraphSchemaVersion != "6.5" {
-		t.Fatalf("CallgraphSchemaVersion = %q, want %q", CallgraphSchemaVersion, "6.5")
+	if CallgraphSchemaVersion != "6.6" {
+		t.Fatalf("CallgraphSchemaVersion = %q, want %q", CallgraphSchemaVersion, "6.6")
 	}
 }

--- a/pkg/graphfrag/encode.go
+++ b/pkg/graphfrag/encode.go
@@ -34,6 +34,7 @@ func EncodeFragment(frag Fragment) ([]byte, error) {
 		fn := &frag.Functions[i]
 		out.Functions = append(out.Functions, GraphFragmentFunction{
 			Key:                fn.Signature,
+			Type:               fn.DeclaringType,
 			FunctionName:       fn.FunctionName,
 			CanonicalSignature: fn.CanonicalSignature,
 			FilePath:           fn.FilePath,

--- a/pkg/graphfrag/encode_test.go
+++ b/pkg/graphfrag/encode_test.go
@@ -16,7 +16,8 @@ func TestEncodeFragment_RoundTripsStructuralIdentity(t *testing.T) {
 		Module: "com.app",
 		Functions: []Function{{
 			Signature: "com.app.(Svc).run#0", FunctionName: "com.app.Svc.run",
-			FilePath: "Svc.java", StartLine: 4, EndLine: 11,
+			DeclaringType: "Svc",
+			FilePath:      "Svc.java", StartLine: 4, EndLine: 11,
 		}},
 		ExternalCalls: []ExternalCall{{
 			Caller: "com.app.(Svc).run#0", TargetSignature: "org.bc.(Gen).init#1",
@@ -46,6 +47,9 @@ func TestEncodeFragment_RoundTripsStructuralIdentity(t *testing.T) {
 
 	if len(got.Functions) != 1 || got.Functions[0].StartLine != 4 || got.Functions[0].EndLine != 11 {
 		t.Fatalf("function line range lost: %+v", got.Functions)
+	}
+	if got.Functions[0].DeclaringType != "Svc" {
+		t.Fatalf("function declaring type lost: %q, want Svc", got.Functions[0].DeclaringType)
 	}
 	if len(got.ExternalCalls) != 1 {
 		t.Fatalf("external calls len = %d, want 1", len(got.ExternalCalls))

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -43,6 +43,7 @@ func appendFragmentFunctions(frag *Fragment, functions []GraphFragmentFunction) 
 		frag.Functions = append(frag.Functions, Function{
 			Signature:          fn.Key,
 			FunctionName:       fn.FunctionName,
+			DeclaringType:      fn.Type,
 			CanonicalSignature: fn.CanonicalSignature,
 			ReturnType:         fn.ReturnType,
 			ParameterTypes:     fn.ParameterTypes,

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -80,6 +80,9 @@ type Function struct {
 	Signature string
 	// FunctionName is the fully-qualified human-readable function name (e.g. "org.bridge.Bridge.bridge").
 	FunctionName string
+	// DeclaringType is the parser-provided enclosing type. Empty for module-level
+	// functions and legacy fragments; it is never inferred from FunctionName.
+	DeclaringType string
 	// CanonicalSignature is the canonical function signature (1.2+).
 	CanonicalSignature string
 	// ReturnType is the declared return type (1.2+).
@@ -565,8 +568,16 @@ type SuppressedEdge struct {
 	Caller     CallFrame
 	MethodName string
 	Arity      int
+	CallSite   int
+	StartCol   int
+	EndCol     int
 	Reason     string
 	Candidates []ComponentKey
+
+	// CandidateFrames carries the full target identity and per-candidate call
+	// evidence for grouped ambiguous dispatches. Candidates remains the compact
+	// component summary used by existing callers.
+	CandidateFrames []CallFrame
 }
 
 // CallFrame is one frame in a stitched path.

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -84,8 +84,9 @@ type forwardClosure struct {
 	anchor    CallFrame     // resolved anchor identity (depth 0); reuses buildFrame output
 	nodes     []forwardNode // forward-reachable nodes, depth >= 1, deduped by graphNode
 	edges     []forwardEdge // directed traversed edges (endpoints always in {anchor} ∪ nodes)
-	maxDepth  int           // the depth CAP applied (== resolved MaxForwardDepth)
-	truncated bool          // any cap hit (depth/node/edge) -> true; never silent
+	ambiguous []SuppressedEdge
+	maxDepth  int  // the depth CAP applied (== resolved MaxForwardDepth)
+	truncated bool // any cap hit (depth/node/edge) -> true; never silent
 }
 
 // forwardNode is one forward-reachable node (depth >= 1) in a forwardClosure.
@@ -124,7 +125,7 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 
 	functionsBySignature := indexFunctions(closure, fragments)
 	functionsByNode := indexFunctionsByNode(closure, fragments)
-	adjacency, suppressed := buildAdjacency(closure, deps, fragments, functionsBySignature)
+	adjacency, suppressed := buildAdjacency(closure, deps, fragments, functionsBySignature, functionsByNode)
 	opsByNode := indexCryptoOperations(closure, fragments)
 	supportingByNode := indexSupportingCalls(closure, fragments)
 
@@ -143,7 +144,7 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		traceBackward(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, roots, &out)
 		attachAnnotationSupportingCalls(closure, fragments, &out)
 		if opts.ForwardClosure {
-			out.forwardClosures = buildForwardClosures(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
+			out.forwardClosures = buildForwardClosures(adjacency, suppressed, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
 		}
 		return &out, nil
 	}
@@ -158,7 +159,7 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 	}
 	attachAnnotationSupportingCalls(closure, fragments, &out)
 	if opts.ForwardClosure {
-		out.forwardClosures = buildForwardClosures(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
+		out.forwardClosures = buildForwardClosures(adjacency, suppressed, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
 	}
 	return &out, nil
 }
@@ -355,6 +356,8 @@ type dispatchGroupKey struct {
 	Component  ComponentKey
 	Caller     string
 	CallSite   int
+	StartCol   int
+	EndCol     int
 	MethodName string
 	Arity      int
 }
@@ -371,6 +374,8 @@ type callEdge struct {
 	method               string
 	arity                int
 	callSite             int
+	startCol             int
+	endCol               int
 	internal             bool
 	entryCall            *CallSite
 	resolvedReceiverType string
@@ -393,6 +398,7 @@ func buildAdjacency(
 	deps DependencyGraph,
 	fragments map[ComponentKey]Fragment,
 	functionsBySignature map[string][]graphNode,
+	functionsByNode map[graphNode]Function,
 ) (map[graphNode][]adjacencyEdge, []SuppressedEdge) {
 	out := make(map[graphNode][]adjacencyEdge)
 	var suppressed []SuppressedEdge
@@ -405,7 +411,7 @@ func buildAdjacency(
 		resolve := callEdgeResolver(key, componentSigs, componentSet(deps[key]), functionsBySignature)
 
 		dispatchGroups := applyImmediateEdgePolicy(key, edges, resolve, out, &suppressed)
-		applyDispatchGroups(key, dispatchGroups, resolve, ownerTypes, out, &suppressed)
+		applyDispatchGroups(key, dispatchGroups, resolve, ownerTypes, fragments, functionsByNode, out, &suppressed)
 	}
 	return out, suppressed
 }
@@ -469,7 +475,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 		e := &fragment.InternalEdges[i]
 		edges = append(edges, callEdge{
 			caller: e.Caller, target: e.Callee, resolution: e.Resolution,
-			method: e.MethodName, arity: e.Arity, callSite: e.CallSite, internal: true, entryCall: e.EntryCall,
+			method: e.MethodName, arity: e.Arity, callSite: e.CallSite, startCol: e.StartCol, endCol: e.EndCol, internal: true, entryCall: e.EntryCall,
 			resolvedReceiverType: e.ResolvedReceiverType,
 		})
 	}
@@ -477,7 +483,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 		c := &fragment.ExternalCalls[i]
 		edges = append(edges, callEdge{
 			caller: c.Caller, target: c.TargetSignature, resolution: c.Resolution,
-			method: c.MethodName, arity: c.Arity, callSite: c.CallSite, internal: false, entryCall: c.EntryCall,
+			method: c.MethodName, arity: c.Arity, callSite: c.CallSite, startCol: c.StartCol, endCol: c.EndCol, internal: false, entryCall: c.EntryCall,
 			resolvedReceiverType: c.ResolvedReceiverType,
 		})
 	}
@@ -532,20 +538,21 @@ func applyImmediateEdgePolicy(
 	// ambiguity (>1 impl in closure) is detected across all sibling edges,
 	// including siblings that cross the internal/external boundary.
 	dispatchGroups := make(map[dispatchGroupKey][]callEdge)
-	for _, e := range edges {
+	for i := range edges {
+		e := &edges[i]
 		caller := graphNode{Component: key, Function: e.caller}
 		switch e.resolution {
 		case ResolutionExact:
-			appendAdjacencyEdges(adjacency, caller, resolve(e), e.entryCall)
+			appendAdjacencyEdges(adjacency, caller, resolve(*e), e.entryCall)
 		case ResolutionInterfaceDispatch:
-			gk := dispatchKey(key, e)
-			dispatchGroups[gk] = append(dispatchGroups[gk], e)
+			gk := dispatchKey(key, *e)
+			dispatchGroups[gk] = append(dispatchGroups[gk], *e)
 		case ResolutionNameOnly:
-			*suppressed = append(*suppressed, suppressedEdge(key, e, SuppressReasonNameOnly, candidateComponents(resolve(e))))
+			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonNameOnly, candidateComponents(resolve(*e))))
 		case ResolutionUnknown:
-			*suppressed = append(*suppressed, suppressedEdge(key, e, SuppressReasonUnknown, candidateComponents(resolve(e))))
+			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonUnknown, candidateComponents(resolve(*e))))
 		default: // Future unhandled kind: fail closed.
-			*suppressed = append(*suppressed, suppressedEdge(key, e, SuppressReasonUnknown, candidateComponents(resolve(e))))
+			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonUnknown, candidateComponents(resolve(*e))))
 		}
 	}
 	return dispatchGroups
@@ -556,6 +563,8 @@ func dispatchKey(key ComponentKey, e callEdge) dispatchGroupKey {
 		Component:  key,
 		Caller:     e.caller,
 		CallSite:   e.callSite,
+		StartCol:   e.startCol,
+		EndCol:     e.endCol,
 		MethodName: e.method,
 		Arity:      e.arity,
 	}
@@ -566,6 +575,8 @@ func applyDispatchGroups(
 	groups map[dispatchGroupKey][]callEdge,
 	resolve edgeResolver,
 	ownerTypes map[graphNode]string,
+	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
 	adjacency map[graphNode][]adjacencyEdge,
 	suppressed *[]SuppressedEdge,
 ) {
@@ -581,7 +592,7 @@ func applyDispatchGroups(
 				adjacency[caller] = append(adjacency[caller], resolved)
 				continue
 			}
-			*suppressed = append(*suppressed, ambiguousDispatchEdge(key, gk, candidateComponentsFromEdges(targets)))
+			*suppressed = append(*suppressed, ambiguousDispatchEdge(key, gk, targets, fragments, functionsByNode))
 			// len(targets) == 0: no implementation in closure -> unreachable,
 			// nothing to traverse and nothing to record.
 		}
@@ -643,7 +654,8 @@ func simpleTypeName(typeName string) string {
 }
 
 func firstResolvedReceiverType(group []callEdge) string {
-	for _, e := range group {
+	for i := range group {
+		e := &group[i]
 		if e.resolvedReceiverType != "" {
 			return e.resolvedReceiverType
 		}
@@ -665,8 +677,9 @@ func appendAdjacencyEdges(
 func distinctTargetEdges(edges []callEdge, resolve edgeResolver) []adjacencyEdge {
 	distinct := map[graphNode]bool{}
 	var targets []adjacencyEdge
-	for _, e := range edges {
-		for _, t := range resolve(e) {
+	for i := range edges {
+		e := &edges[i]
+		for _, t := range resolve(*e) {
 			if distinct[t] {
 				continue
 			}
@@ -677,13 +690,28 @@ func distinctTargetEdges(edges []callEdge, resolve edgeResolver) []adjacencyEdge
 	return targets
 }
 
-func ambiguousDispatchEdge(key ComponentKey, gk dispatchGroupKey, candidates []ComponentKey) SuppressedEdge {
+func ambiguousDispatchEdge(
+	key ComponentKey,
+	gk dispatchGroupKey,
+	targets []adjacencyEdge,
+	fragments map[ComponentKey]Fragment,
+	functionsByNode map[graphNode]Function,
+) SuppressedEdge {
+	targets = sortedAdjacencyEdges(targets)
+	frames := make([]CallFrame, 0, len(targets))
+	for _, target := range targets {
+		frames = append(frames, buildFrame(target.target, target.entryCall, fragments, functionsByNode))
+	}
 	return SuppressedEdge{
-		Caller:     CallFrame{Component: key, Signature: gk.Caller},
-		MethodName: gk.MethodName,
-		Arity:      gk.Arity,
-		Reason:     SuppressReasonAmbiguousDispatch,
-		Candidates: candidates,
+		Caller:          buildFrame(graphNode{Component: key, Function: gk.Caller}, nil, fragments, functionsByNode),
+		MethodName:      gk.MethodName,
+		Arity:           gk.Arity,
+		CallSite:        gk.CallSite,
+		StartCol:        gk.StartCol,
+		EndCol:          gk.EndCol,
+		Reason:          SuppressReasonAmbiguousDispatch,
+		Candidates:      candidateComponentsFromEdges(targets),
+		CandidateFrames: frames,
 	}
 }
 
@@ -725,6 +753,12 @@ func sortedDispatchKeys(groups map[dispatchGroupKey][]callEdge) []dispatchGroupK
 		}
 		if a.CallSite != b.CallSite {
 			return a.CallSite < b.CallSite
+		}
+		if a.StartCol != b.StartCol {
+			return a.StartCol < b.StartCol
+		}
+		if a.EndCol != b.EndCol {
+			return a.EndCol < b.EndCol
 		}
 		if a.MethodName != b.MethodName {
 			return a.MethodName < b.MethodName
@@ -1133,6 +1167,7 @@ func sortedAdjacencyEdges(edges []adjacencyEdge) []adjacencyEdge {
 // package).
 func buildForwardClosures(
 	adjacency map[graphNode][]adjacencyEdge,
+	suppressed []SuppressedEdge,
 	opsByNode map[graphNode][]CryptoOperation,
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
@@ -1144,9 +1179,46 @@ func buildForwardClosures(
 		if _, ok := memo[anchor]; ok {
 			continue
 		}
-		memo[anchor] = forwardBFS(anchor, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, caps)
+		fc := forwardBFS(anchor, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, caps)
+		fc.ambiguous = reachableAmbiguities(anchor, fc.nodes, suppressed)
+		memo[anchor] = fc
 	}
 	return memo
+}
+
+func reachableAmbiguities(anchor graphNode, nodes []forwardNode, suppressed []SuppressedEdge) []SuppressedEdge {
+	reachable := map[graphNode]bool{anchor: true}
+	for i := range nodes {
+		reachable[nodes[i].node] = true
+	}
+	var out []SuppressedEdge
+	for i := range suppressed {
+		edge := suppressed[i]
+		caller := graphNode{Component: edge.Caller.Component, Function: edge.Caller.Signature}
+		if edge.Reason == SuppressReasonAmbiguousDispatch && reachable[caller] {
+			out = append(out, edge)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.Caller.Signature != b.Caller.Signature {
+			return a.Caller.Signature < b.Caller.Signature
+		}
+		if a.CallSite != b.CallSite {
+			return a.CallSite < b.CallSite
+		}
+		if a.StartCol != b.StartCol {
+			return a.StartCol < b.StartCol
+		}
+		if a.EndCol != b.EndCol {
+			return a.EndCol < b.EndCol
+		}
+		if a.MethodName != b.MethodName {
+			return a.MethodName < b.MethodName
+		}
+		return a.Arity < b.Arity
+	})
+	return out
 }
 
 // forwardBFS computes the rooted forward reachability graph from anchor: a

--- a/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
+++ b/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
@@ -45,6 +45,7 @@ class Acceptance {
         AESEngine engine = new AESEngine();
         helper(data, key, 16);
         engine.processBlock(data, 0, data, 0);
+        dispatch(null, data);
         return data;
     }
 


### PR DESCRIPTION
Closes #122

## Summary
- add schema 6.6 ambiguous forward-call candidate groups with stable IDs and complete/partial evidence
- preserve source call-site columns and declaring types through callgraph/fragment conversion
- keep ambiguous candidates out of forward reachability while serializing them losslessly

## Validation
- `go test -race ./internal/callgraph ./internal/scan ./pkg/graphfrag ./internal/cli -count=1`
- `make test`
- `make lint`

Review scope is intentionally one cohesive public-schema change across producer, fragment, stitcher, and export layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Call graph exports now use schema version 6.6.
  * Forward-call results include detailed, deterministic records for ambiguous dispatches, including call-site locations, candidate identities, completeness, and available entry-call evidence.
  * Graph fragments now preserve declaring type information for functions.
* **Bug Fixes**
  * Call-site column ranges are preserved, preventing distinct same-line calls from being merged or misidentified.
  * Export ordering and deduplication are now more consistent and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->