### PR TITLE
feat(contracts): add Azure Key Vault Secrets contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)
 - C callgraph parsing now extracts include paths, function declarations, call sites, assignment targets, and 1-based half-open call columns for reachability analysis. (#67)
 - JavaScript and TypeScript callgraph parsing and CLI ecosystem routing now cover ES module and CommonJS imports, imported/direct calls, lifecycle receiver and assignment fields, fluent-chain IDs, and source columns. (#66)

--- a/internal/callgraph/contracts/python/azure-keyvault-secrets.yaml
+++ b/internal/callgraph/contracts/python/azure-keyvault-secrets.yaml
@@ -1,0 +1,84 @@
+schema_version: "2"
+ecosystem: python
+library:
+  name: azure-keyvault-secrets
+  coordinates:
+    - azure-keyvault-secrets
+  version_range: ">=4.0"
+  description: "Azure Key Vault Secrets client result contracts"
+
+contracts:
+  - method: azure.keyvault.secrets.SecretClient.<init>
+    arity: 2
+    return: { type: azure.keyvault.secrets.SecretClient, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.secrets.SecretClient.set_secret
+    arity: 2
+    return: { type: azure.keyvault.secrets.KeyVaultSecret, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.SecretClient.get_secret
+    arity: 1
+    return: { type: azure.keyvault.secrets.KeyVaultSecret, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.SecretClient.get_deleted_secret
+    arity: 1
+    return: { type: azure.keyvault.secrets.DeletedSecret, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.SecretClient.backup_secret
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.SecretClient.restore_secret_backup
+    arity: 1
+    return: { type: azure.keyvault.secrets.SecretProperties, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.aio.SecretClient.<init>
+    arity: 2
+    return: { type: azure.keyvault.secrets.aio.SecretClient, confidence: high }
+    role: factory
+
+  - method: azure.keyvault.secrets.aio.SecretClient.set_secret
+    arity: 2
+    return: { type: azure.keyvault.secrets.KeyVaultSecret, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.aio.SecretClient.get_secret
+    arity: 1
+    return: { type: azure.keyvault.secrets.KeyVaultSecret, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.aio.SecretClient.get_deleted_secret
+    arity: 1
+    return: { type: azure.keyvault.secrets.DeletedSecret, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.aio.SecretClient.backup_secret
+    arity: 1
+    return: { type: builtins.bytes, confidence: high }
+    role: output
+
+  - method: azure.keyvault.secrets.aio.SecretClient.restore_secret_backup
+    arity: 1
+    return: { type: azure.keyvault.secrets.SecretProperties, confidence: high }
+    role: output
+
+hierarchy:
+  azure.keyvault.secrets.SecretClient:
+    - builtins.object
+  azure.keyvault.secrets.aio.SecretClient:
+    - builtins.object
+  azure.keyvault.secrets.KeyVaultSecret:
+    - builtins.object
+  azure.keyvault.secrets.DeletedSecret:
+    - builtins.object
+  azure.keyvault.secrets.SecretProperties:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -449,6 +449,53 @@ func TestLoadEmbedded_Python_AzureKeyVaultKeys(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_Python_AzureKeyVaultSecrets(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantRole   string
+	}{
+		{"azure.keyvault.secrets.SecretClient.<init>", 2, "azure.keyvault.secrets.SecretClient", "factory"},
+		{"azure.keyvault.secrets.SecretClient.set_secret", 2, "azure.keyvault.secrets.KeyVaultSecret", "output"},
+		{"azure.keyvault.secrets.SecretClient.get_secret", 1, "azure.keyvault.secrets.KeyVaultSecret", "output"},
+		{"azure.keyvault.secrets.SecretClient.get_deleted_secret", 1, "azure.keyvault.secrets.DeletedSecret", "output"},
+		{"azure.keyvault.secrets.SecretClient.backup_secret", 1, "builtins.bytes", "output"},
+		{"azure.keyvault.secrets.SecretClient.restore_secret_backup", 1, "azure.keyvault.secrets.SecretProperties", "output"},
+		{"azure.keyvault.secrets.aio.SecretClient.<init>", 2, "azure.keyvault.secrets.aio.SecretClient", "factory"},
+		{"azure.keyvault.secrets.aio.SecretClient.set_secret", 2, "azure.keyvault.secrets.KeyVaultSecret", "output"},
+		{"azure.keyvault.secrets.aio.SecretClient.get_secret", 1, "azure.keyvault.secrets.KeyVaultSecret", "output"},
+		{"azure.keyvault.secrets.aio.SecretClient.get_deleted_secret", 1, "azure.keyvault.secrets.DeletedSecret", "output"},
+		{"azure.keyvault.secrets.aio.SecretClient.backup_secret", 1, "builtins.bytes", "output"},
+		{"azure.keyvault.secrets.aio.SecretClient.restore_secret_backup", 1, "azure.keyvault.secrets.SecretProperties", "output"},
+	}
+
+	for _, tt := range tests {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) == 0 {
+			t.Errorf("%s#%d: no contracts found", tt.method, tt.arity)
+			continue
+		}
+		c := got[0]
+		if c.Return.Type != tt.wantReturn {
+			t.Errorf("%s#%d return type = %q, want %q", tt.method, tt.arity, c.Return.Type, tt.wantReturn)
+		}
+		if c.Role != tt.wantRole {
+			t.Errorf("%s#%d role = %q, want %q", tt.method, tt.arity, c.Role, tt.wantRole)
+		}
+		if c.SourceLibrary != "azure-keyvault-secrets" {
+			t.Errorf("%s#%d source library = %q, want azure-keyvault-secrets", tt.method, tt.arity, c.SourceLibrary)
+		}
+		if c.Return.Confidence != "high" {
+			t.Errorf("%s#%d confidence = %q, want high", tt.method, tt.arity, c.Return.Confidence)
+		}
+	}
+}
+
 // TestLoadEmbedded_Python_AllLibrariesHaveValidReturnTypes asserts that every
 // contract in the merged Python KB has a non-empty return type and "high"
 // confidence (the only author-facing confidence level per crypto-kb-author skill).


### PR DESCRIPTION
Part of #56

Triggered by scanoss/crypto_rules#115.

## Summary

- add schema-v2 Azure Key Vault Secrets contracts for every sync and async API detected by the triggering rules PR
- resolve both `SecretClient` receiver types and preserve documented result types and lifecycle roles
- add focused embedded-KB assertions and an Unreleased changelog entry

## API audit

Primary sources: Microsoft documentation for the [sync `SecretClient`](https://learn.microsoft.com/en-us/python/api/azure-keyvault-secrets/azure.keyvault.secrets.secretclient?view=azure-python) and [async `SecretClient`](https://learn.microsoft.com/en-us/python/api/azure-keyvault-secrets/azure.keyvault.secrets.aio.secretclient?view=azure-python).

| API | Disposition |
|---|---|
| sync and async `SecretClient.<init>` | contracted, receiver factories needed for callgraph resolution |
| sync and async `set_secret` | contracted |
| sync and async `get_secret` | contracted |
| sync and async `get_deleted_secret` | contracted |
| sync and async `backup_secret` | contracted |
| sync and async `restore_secret_backup` | contracted |
| sync and async list APIs | skipped-non-crypto, documented results exclude secret values |
| sync delete/recover pollers; async `delete_secret`/`recover_deleted_secret`; sync and async purge/update-properties APIs | skipped-non-crypto, lifecycle/property operations are outside the triggering rules |
| sync and async `close`, `send_request` | skipped-non-crypto |

The detected one-shot SDK methods use the established `output` role used by existing boto3 KMS and Azure Key Vault Keys contracts. `operation` remains reserved for cryptographic execution methods such as block processing and finalization.

## Test plan

- [x] `go test ./internal/callgraph/contracts/... -count=1`
- [x] `go test ./internal/callgraph/... -count=1`
- [x] `go test ./... -count=1`
- [x] `make lint`
