### PR TITLE
feat(callgraph): wire Rust contract resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ internal/callgraph/contracts/
 │   └── jdk-crypto.yaml    # JDK JCA/JCE contracts (shipped in v1)
 ├── go/                    # future: stdlib + x/crypto + ...
 ├── python/                # pyca-cryptography, pycryptodome, pycryptodomex, paramiko
-└── rust/                  # future: ring + rustcrypto + ...
+└── rust/                  # schema-v2 Rust callgraph contracts
 ```
 
 **One YAML file = one library version**. Adding a new library is a new YAML, not a code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)
 - C callgraph parsing now extracts include paths, function declarations, call sites, assignment targets, and 1-based half-open call columns for reachability analysis. (#67)

--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -20,9 +20,14 @@ var javaFS embed.FS
 //go:embed python/*.yaml
 var pythonFS embed.FS
 
+//go:embed rust/*.yaml
+var rustFS embed.FS
+
 const (
 	// ecosystemPython is the ecosystem identifier for the Python contract KB.
 	ecosystemPython = "python"
+	// ecosystemRust is the ecosystem identifier for the Rust contract KB.
+	ecosystemRust = "rust"
 )
 
 // Library holds the metadata for a single library KB source.
@@ -456,6 +461,8 @@ func embedFSFor(ecosystem string) (fs.FS, string) {
 		return &javaFS, "java"
 	case ecosystemPython:
 		return &pythonFS, ecosystemPython
+	case ecosystemRust:
+		return &rustFS, ecosystemRust
 	default:
 		return nil, ""
 	}

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -677,6 +677,16 @@ func TestLoadEmbedded_NonexistentEcosystem_ReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_Rust(t *testing.T) {
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(\"rust\"): %v", err)
+	}
+	if kb.Ecosystem != "rust" {
+		t.Fatalf("Ecosystem = %q, want rust", kb.Ecosystem)
+	}
+}
+
 // TestContractsFor_ReturnsCorrectSlice
 // kb.ContractsFor("javax.crypto.Cipher.unwrap", 3) returns 3 conditional entries.
 func TestContractsFor_ReturnsCorrectSlice(t *testing.T) {

--- a/internal/callgraph/contracts/rust/bootstrap.yaml
+++ b/internal/callgraph/contracts/rust/bootstrap.yaml
@@ -1,0 +1,9 @@
+schema_version: "2"
+ecosystem: rust
+# ponytail: go:embed needs one YAML match; remove this file when the first Rust library KB lands.
+library:
+  name: rust-bootstrap
+  description: "Bootstrap for embedded Rust callgraph contracts"
+
+contracts: []
+hierarchy: {}

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -31,6 +31,8 @@ func NewTypeResolverForEcosystem(ecosystem string, javaRuntime javaruntime.Confi
 		return NewJavaBytecodeTypeResolver(javaRuntime)
 	case "python":
 		return NewPythonContractTypeResolverFromEmbedded()
+	case "rust":
+		return NewRustContractTypeResolverFromEmbedded()
 	default:
 		return nil
 	}

--- a/internal/callgraph/rust_type_resolver.go
+++ b/internal/callgraph/rust_type_resolver.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"strings"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// RustContractTypeResolver applies return types from the Rust contracts KB.
+type RustContractTypeResolver struct {
+	kb *contracts.KnowledgeBase
+}
+
+// NewRustContractTypeResolver creates a resolver backed by the supplied KB.
+func NewRustContractTypeResolver(kb *contracts.KnowledgeBase) *RustContractTypeResolver {
+	return &RustContractTypeResolver{kb: kb}
+}
+
+// NewRustContractTypeResolverFromEmbedded loads the embedded Rust KB. Contract
+// load failures degrade to a no-op resolver.
+func NewRustContractTypeResolverFromEmbedded() *RustContractTypeResolver {
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		return NewRustContractTypeResolver(nil)
+	}
+	return NewRustContractTypeResolver(kb)
+}
+
+// ResolveTypes fills missing declaration return types from unconditional contracts.
+func (r *RustContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) error {
+	if r.kb == nil || len(r.kb.Contracts) == 0 {
+		return nil
+	}
+	for _, fn := range graph.Functions {
+		if fn.ReturnType != "" {
+			continue
+		}
+		for _, contract := range r.kb.ContractsForTolerant(rustFunctionFQN(fn), len(fn.Parameters)) {
+			if contract.When == nil && contract.Return.Type != "" {
+				fn.ReturnType = contract.Return.Type
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func rustFunctionFQN(fn *FunctionDecl) string {
+	parts := []string{fn.ID.Package}
+	if fn.ID.Type != "" {
+		parts = append(parts, fn.ID.Type)
+	}
+	return strings.Join(append(parts, fn.ID.Name), "::")
+}

--- a/internal/callgraph/rust_type_resolver_test.go
+++ b/internal/callgraph/rust_type_resolver_test.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+	"github.com/scanoss/crypto-finder/internal/javaruntime"
+)
+
+func TestNewTypeResolverForEcosystem_Rust(t *testing.T) {
+	if _, ok := NewTypeResolverForEcosystem("rust", javaruntime.Config{}).(*RustContractTypeResolver); !ok {
+		t.Fatal("expected RustContractTypeResolver")
+	}
+}
+
+func TestRustContractTypeResolver_SetsReturnTypeFromKB(t *testing.T) {
+	kb, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: rust
+library:
+  name: test-rust
+contracts:
+  - method: ring::aead::LessSafeKey::new
+    arity: 1
+    return:
+      type: ring::aead::LessSafeKey
+      confidence: high
+`))
+	if err != nil {
+		t.Fatalf("load test KB: %v", err)
+	}
+	fn := &FunctionDecl{
+		ID:         FunctionID{Package: "ring::aead", Type: "LessSafeKey", Name: "new"},
+		Parameters: []FunctionParameter{{Type: "UnboundKey"}},
+	}
+
+	if err := NewRustContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(fn), nil); err != nil {
+		t.Fatalf("ResolveTypes: %v", err)
+	}
+	if fn.ReturnType != "ring::aead::LessSafeKey" {
+		t.Fatalf("ReturnType = %q, want ring::aead::LessSafeKey", fn.ReturnType)
+	}
+
+	fn.ReturnType = "ExistingType"
+	if err := NewRustContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(fn), nil); err != nil {
+		t.Fatalf("ResolveTypes with existing return type: %v", err)
+	}
+	if fn.ReturnType != "ExistingType" {
+		t.Fatalf("existing ReturnType was overwritten: %q", fn.ReturnType)
+	}
+}


### PR DESCRIPTION
Closes #69

## Summary

- add the Rust contract-backed type resolver and ecosystem factory wiring
- embed a schema-v2 Rust KB bootstrap without claiming any library contract scope
- add focused resolver/loader tests, contract-layout documentation, and an Unreleased changelog entry

## Changes

| File | Change |
|------|--------|
| `internal/callgraph/rust_type_resolver.go` | Applies unconditional Rust KB return types without overwriting parser-known types |
| `internal/callgraph/contracts/` | Embeds and loads the Rust schema-v2 KB directory |
| `internal/callgraph/*_test.go` | Covers resolver selection, FQN lookup, preservation, and embedded loading |
| `AGENTS.md`, `CHANGELOG.md` | Documents the Rust KB layout and observable support |

## Test plan

- [x] `go test ./internal/callgraph/... -count=1`
- [x] `make lint`

## Checklist

- [x] Issue linked
- [x] Tests included with behavior
- [x] User-facing change documented under `[Unreleased]`
- [x] Conventional commit
- [x] No AI attribution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Rust callgraph support using schema-v2 contract knowledge bases.
  - Rust builds now automatically load embedded contract data and use Rust-specific type resolution.
  - Missing function return types can now be inferred from Rust contract definitions.

- **Documentation**
  - Updated the changelog and knowledge base layout documentation to reflect Rust support.

- **Tests**
  - Added coverage for Rust contract loading, resolver selection, and return-type inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->