### PR TITLE
fix(graphfrag): preserve supporting parameter roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- Stitched graph-fragment callgraph exports now retain parameter roles on supporting calls. (#130)
 - Concurrent scans sharing the default rules cache no longer expose partial metadata or lose in-flight filtered rule files when another process refreshes the cache. (#128)
 - Rule files with zero rules (`rules: []`) are excluded from language filtering — previously treated as "unknown language", they always survived the filter and could become the sole config passed to opengrep, which exits with code 7 on an empty ruleset and hard-failed the whole scan. (#112)
 - `role: operation` contract methods declared on an interface/abstract type now resolve through concrete implementors via the contract hierarchy (e.g. `AESEngine.processBlock` synthesizes an operation entry via the `BlockCipher.processBlock` contract) — closes the concrete-body-only gap flagged in #108. (#109)

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -952,6 +952,7 @@ func exportCryptoCall(cc *CryptoCall) *ExportCryptoCall {
 		DisplaySymbol:      cc.DisplaySymbol,
 		Aliases:            append([]string(nil), cc.Aliases...),
 		Line:               cc.Line,
+		ParameterRoles:     exportParameterRoles(cc.ParameterRoles),
 	}
 	for i := range cc.Parameters {
 		ec.Parameters = append(ec.Parameters, exportParameter(cc.Parameters[i]))

--- a/pkg/graphfrag/stitch_regression_test.go
+++ b/pkg/graphfrag/stitch_regression_test.go
@@ -17,8 +17,107 @@
 package graphfrag
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 )
+
+func TestSupportingParameterRolesSurviveDecodeStitchAndExport(t *testing.T) {
+	t.Parallel()
+
+	root := ComponentKey{Purl: "pkg:maven/com.acme/crypto", Version: "1.0.0"}
+	const fragmentJSON = `{
+	  "schema_version": "graph-fragment-1.8",
+	  "functions": [{
+	    "key": "com.acme.(Crypto).run#1",
+	    "function_name": "com.acme.Crypto.run",
+	    "parameter_types": ["byte[]"]
+	  }],
+	  "crypto_annotations": [{
+	    "function_key": "com.acme.(Crypto).run#1",
+	    "finding_id": "finding-1",
+	    "rule_id": "java.crypto.run",
+	    "symbol": "com.acme.Crypto.run",
+	    "supporting_call_ids": ["support-role", "support-plain"]
+	  }],
+	  "supporting_calls": [
+	    {
+	      "supporting_id": "support-role",
+	      "function_key": "com.acme.(Crypto).run#1",
+	      "supporting_call": {
+	        "function_name": "org.bc.KeyParameter.<init>",
+	        "parameter_roles": [{
+	          "index": 0,
+	          "name": "key",
+	          "role": "metadata-contributing",
+	          "contributes": {
+	            "property": "keySize",
+	            "derivation": "argument_bit_length"
+	          }
+	        }]
+	      }
+	    },
+	    {
+	      "supporting_id": "support-plain",
+	      "function_key": "com.acme.(Crypto).run#1",
+	      "supporting_call": {"function_name": "org.bc.Engine.processBlock"}
+	    }
+	  ],
+	  "crypto_entry_points": [{
+	    "function_key": "com.acme.(Crypto).run#1",
+	    "parameter_roles": [{"index": 0, "role": "operation-determining"}]
+	  }]
+	}`
+
+	fragment, err := DecodeFragment(root, []byte(fragmentJSON))
+	if err != nil {
+		t.Fatalf("DecodeFragment: %v", err)
+	}
+	if len(fragment.SupportingCalls) != 2 || fragment.SupportingCalls[0].SupportingCall == nil ||
+		len(fragment.SupportingCalls[0].SupportingCall.ParameterRoles) != 1 {
+		t.Fatalf("decoded supporting calls lost parameter roles: %#v", fragment.SupportingCalls)
+	}
+	result, err := StitchWithOptions(root, DependencyGraph{root: nil}, map[ComponentKey]Fragment{root: fragment}, StitchOptions{EntryRootedOnly: true})
+	if err != nil {
+		t.Fatalf("StitchWithOptions: %v", err)
+	}
+	if len(result.SupportingCalls) != 2 || result.SupportingCalls[0].SupportingCall == nil ||
+		len(result.SupportingCalls[0].SupportingCall.ParameterRoles) != 1 {
+		t.Fatalf("stitched supporting calls lost parameter roles: %#v", result.SupportingCalls)
+	}
+	exported := result.ToCallgraphExport(root, ScanMeta{})
+
+	byID := make(map[string]ExportSupportingCall, len(exported.SupportingCalls))
+	for i := range exported.SupportingCalls {
+		byID[exported.SupportingCalls[i].SupportingID] = exported.SupportingCalls[i]
+	}
+	roleCall := byID["support-role"].SupportingCall
+	if roleCall == nil || len(roleCall.ParameterRoles) != 1 {
+		t.Fatalf("role-bearing supporting call = %#v, want one parameter role", roleCall)
+	}
+	role := roleCall.ParameterRoles[0]
+	if role.Index != 0 || role.Name != "key" || role.Role != "metadata-contributing" ||
+		role.Contributes == nil || role.Contributes.Property != "keySize" || role.Contributes.Derivation != "argument_bit_length" {
+		t.Fatalf("parameter role = %#v, want index=0 key metadata-contributing keySize/argument_bit_length", role)
+	}
+
+	plainCall := byID["support-plain"].SupportingCall
+	if plainCall == nil {
+		t.Fatal("plain supporting call missing")
+	}
+	plainJSON, err := json.Marshal(plainCall)
+	if err != nil {
+		t.Fatalf("marshal plain supporting call: %v", err)
+	}
+	if bytes.Contains(plainJSON, []byte(`"parameter_roles"`)) {
+		t.Fatalf("plain supporting call unexpectedly emits parameter_roles: %s", plainJSON)
+	}
+
+	entry := findExportEntryPointByFunctionKey(exported.CryptoEntryPoints, "com.acme.(Crypto).run#1")
+	if entry == nil || len(entry.ParameterRoles) != 1 || entry.ParameterRoles[0].Role != "operation-determining" {
+		t.Fatalf("crypto entry point parameter roles changed: %#v", entry)
+	}
+}
 
 // TestStitch_ContractFKSupportingCallsSurviveNonRootStitch guards REQ-8.1:
 // a supporting call that is referenced by a finding's SupportingCallIDs FK but


### PR DESCRIPTION
Closes #130

## Summary

- Preserve parameter roles when stitched supporting calls are projected to the public callgraph export.
- Keep role-free supporting calls unchanged and omit `parameter_roles`.
- Cover the full `DecodeFragment` → `StitchWithOptions` → `ToCallgraphExport` path.

## Root cause

`DecodeFragment` and stitching retained `CryptoCall.ParameterRoles`, but `exportCryptoCall` did not project them into `ExportCryptoCall`.

## Test plan

- [x] `go test ./pkg/graphfrag -run 'TestSupportingParameterRolesSurviveDecodeStitchAndExport|TestDecodeFragment_MapsRoleFields' -count=1`
- [x] `go test ./pkg/graphfrag/... -count=1`
- [x] `go test ./... -count=1`
- [x] `make lint`

## Self-review

- Standards review: no findings.
- Issue #130 spec review: no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stitched graph-fragment callgraph exports so supporting calls retain their parameter roles.
  * Preserved parameter role details through decoding, stitching, and export.
  * Ensured calls without defined parameter roles do not incorrectly include them in exports.
  * Maintained correct parameter roles for crypto entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->