### PR TITLE
fix(scan): preserve supporting call overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- Supporting-call catalogs now preserve every callable overload deterministically instead of selecting one by traversal order. (#131)
 - Stitched graph-fragment callgraph exports now retain parameter roles on supporting calls. (#130)
 - Concurrent scans sharing the default rules cache no longer expose partial metadata or lose in-flight filtered rule files when another process refreshes the cache. (#128)
 - Rule files with zero rules (`rules: []`) are excluded from language filtering — previously treated as "unknown language", they always survived the filter and could become the sole config passed to opengrep, which exits with code 7 on an empty ruleset and hard-failed the whole scan. (#112)

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -52,7 +52,7 @@ type exportBuildContext struct {
 	// supporting calls (fluent lifecycle methods) to synthesized terminal entry
 	// points. nil for ecosystems with no contracts.
 	kb            *contracts.KnowledgeBase
-	declIndex     map[string]*callgraph.FunctionDecl        // base FQN → definition
+	declIndex     map[string][]*callgraph.FunctionDecl      // base FQN → overloads
 	declsByMethod map[string][]operationContractDeclaration // method name → definitions
 	// callsBySignature caches, per caller FunctionID key, an index of that
 	// caller's FunctionCalls grouped by the (Package, Type, BaseFunctionName)
@@ -993,16 +993,22 @@ func (ctx *exportBuildContext) operationContractDeclarations(c contracts.Contrac
 		out = append(out, candidate)
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].declFQN < out[j].declFQN
+		if out[i].declFQN != out[j].declFQN {
+			return out[i].declFQN < out[j].declFQN
+		}
+		return out[i].decl.ID.String() < out[j].decl.ID.String()
 	})
 	return out
 }
 
 func (ctx *exportBuildContext) operationContractDeclarationCandidates(method string) []operationContractDeclaration {
 	out := make([]operationContractDeclaration, 0, 1)
-	for declFQN, decl := range ctx.declIndex {
+	for declFQN, declarations := range ctx.declIndex {
 		_, declMethod := splitFunctionName(declFQN)
-		if declMethod == method {
+		if declMethod != method {
+			continue
+		}
+		for _, decl := range declarations {
 			out = append(out, operationContractDeclaration{declFQN: declFQN, decl: decl})
 		}
 	}
@@ -1017,7 +1023,15 @@ func functionDeclArityMatches(decl *callgraph.FunctionDecl, want int) bool {
 	if i < 0 {
 		return true
 	}
-	got, err := strconv.Atoi(decl.ID.Name[i+1:])
+	suffix := decl.ID.Name[i+1:]
+	digits := 0
+	for digits < len(suffix) && suffix[digits] >= '0' && suffix[digits] <= '9' {
+		digits++
+	}
+	if digits == 0 {
+		return true
+	}
+	got, err := strconv.Atoi(suffix[:digits])
 	return err != nil || got == want
 }
 
@@ -1089,13 +1103,7 @@ func newExportBuildContext(result *engine.DepScanResult) *exportBuildContext {
 			Msg("failed to load embedded callgraph contracts")
 	}
 	if result.CallGraph != nil {
-		// declIndex is keyed by base FQN only (no arity/overload suffix), so the
-		// first encountered overload for a base FQN wins. deriveContractSupportingCalls
-		// therefore resolves contract methods by base FQN to whichever overload was
-		// indexed first; exact overload matching is not supported by this index.
-		// Future overload-aware lookup should store []*callgraph.FunctionDecl per
-		// base FQN instead.
-		ctx.declIndex = make(map[string]*callgraph.FunctionDecl, len(result.CallGraph.Functions))
+		ctx.declIndex = make(map[string][]*callgraph.FunctionDecl, len(result.CallGraph.Functions))
 		ctx.declsByMethod = make(map[string][]operationContractDeclaration)
 		for _, fn := range result.CallGraph.Functions {
 			if fqn := exportFunctionFQN(fn.ID); fqn != "" {
@@ -1104,10 +1112,22 @@ func newExportBuildContext(result *engine.DepScanResult) *exportBuildContext {
 					declFQN: fqn,
 					decl:    fn,
 				})
-				if _, exists := ctx.declIndex[fqn]; !exists {
-					ctx.declIndex[fqn] = fn
-				}
+				ctx.declIndex[fqn] = append(ctx.declIndex[fqn], fn)
 			}
+		}
+		for fqn := range ctx.declIndex {
+			sort.Slice(ctx.declIndex[fqn], func(i, j int) bool {
+				return ctx.declIndex[fqn][i].ID.String() < ctx.declIndex[fqn][j].ID.String()
+			})
+		}
+		for method := range ctx.declsByMethod {
+			sort.Slice(ctx.declsByMethod[method], func(i, j int) bool {
+				left, right := ctx.declsByMethod[method][i], ctx.declsByMethod[method][j]
+				if left.declFQN != right.declFQN {
+					return left.declFQN < right.declFQN
+				}
+				return left.decl.ID.String() < right.decl.ID.String()
+			})
 		}
 	}
 	return ctx
@@ -1329,15 +1349,22 @@ func (ctx *exportBuildContext) appendContractSupportingCall(
 	if c.Role == string(contracts.RoleOperation) {
 		return ctx.appendOperationSupportingCalls(out, seen, c, builderType, returnType)
 	}
-	if _, dup := seen[c.Method]; dup {
-		return out
+	for _, decl := range ctx.declIndex[c.Method] {
+		if !functionDeclArityMatches(decl, c.Arity) {
+			continue
+		}
+		call := buildContractSupportingCall(ctx, c, decl)
+		key := "signature:" + call.CanonicalSignature
+		if call.CanonicalSignature == "" {
+			key = "function:" + call.FunctionKey
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, call)
 	}
-	decl := ctx.declIndex[c.Method]
-	if decl == nil {
-		return out
-	}
-	seen[c.Method] = struct{}{}
-	return append(out, buildContractSupportingCall(ctx, c, decl))
+	return out
 }
 
 func (ctx *exportBuildContext) appendOperationSupportingCalls(
@@ -1348,7 +1375,7 @@ func (ctx *exportBuildContext) appendOperationSupportingCalls(
 	returnType string,
 ) []callGraphSupportingCall {
 	for _, match := range ctx.operationSupportingDeclarations(c, builderType, returnType) {
-		key := match.decl.ID.String()
+		key := "function:" + match.decl.ID.String()
 		if _, dup := seen[key]; dup {
 			continue
 		}

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -20,6 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph"
@@ -535,7 +537,7 @@ func TestBuildCallGraphExport_OperationContractExportsSupportingCallOnly(t *test
 	ctx := &exportBuildContext{
 		graph:                   graph,
 		kb:                      kb,
-		declIndex:               map[string]*callgraph.FunctionDecl{"org.bc.engines.AESEngine.processBlock": processBlock},
+		declIndex:               map[string][]*callgraph.FunctionDecl{"org.bc.engines.AESEngine.processBlock": {processBlock}},
 		containingFunctionCache: make(map[string]cachedContainingFunction),
 		callChainCache:          make(map[string][][]callGraphChainNode),
 		callChainRemainingUses:  make(map[string]int),
@@ -643,7 +645,7 @@ func TestDeriveSupportingCallsForFinding_CombinesContractRolesForDirectAssets(t 
 			},
 			Hierarchy: map[string][]string{"pkg.Builder": {"builtins.object"}},
 		},
-		declIndex: map[string]*callgraph.FunctionDecl{"pkg.Builder.configure": contractDecl},
+		declIndex: map[string][]*callgraph.FunctionDecl{"pkg.Builder.configure": {contractDecl}},
 	}
 	asset := entities.CryptographicAsset{
 		StartLine: 12,
@@ -663,6 +665,113 @@ func TestDeriveSupportingCallsForFinding_CombinesContractRolesForDirectAssets(t 
 	}
 	if got[1].FunctionName != "pkg.Svc.run" {
 		t.Fatalf("structural function = %q, want pkg.Svc.run", got[1].FunctionName)
+	}
+}
+
+func TestDeriveContractSupportingCalls_PreservesOverloadsRegardlessOfInsertionOrder(t *testing.T) {
+	t.Parallel()
+
+	declarations := []*callgraph.FunctionDecl{
+		{
+			ID:         callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "configure#0"},
+			FilePath:   "Builder.java",
+			StartLine:  10,
+			ReturnType: "pkg.Builder",
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "configure#1$int"},
+			FilePath:   "Builder.java",
+			StartLine:  14,
+			ReturnType: "pkg.Builder",
+			Parameters: []callgraph.FunctionParameter{{Type: "int"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "salt#1$byte[]"},
+			FilePath:   "Builder.java",
+			StartLine:  18,
+			ReturnType: "pkg.Builder",
+			Parameters: []callgraph.FunctionParameter{{Type: "byte[]"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "pkg", Type: "Builder", Name: "salt#1$String"},
+			FilePath:   "Builder.java",
+			StartLine:  22,
+			ReturnType: "pkg.Builder",
+			Parameters: []callgraph.FunctionParameter{{Type: "java.lang.String"}},
+		},
+	}
+	kb := &contracts.KnowledgeBase{
+		Contracts: map[string][]contracts.Contract{
+			"pkg.Builder.configure#0": {{
+				Method: "pkg.Builder.configure", Arity: 0,
+				Return: contracts.ContractReturn{Type: "pkg.Builder", Confidence: "high"}, Role: "config",
+			}},
+			"pkg.Builder.configure#1": {{
+				Method: "pkg.Builder.configure", Arity: 1,
+				Return: contracts.ContractReturn{Type: "pkg.Builder", Confidence: "high"}, Role: "config",
+			}},
+			"pkg.Builder.salt#1": {{
+				Method: "pkg.Builder.salt", Arity: 1,
+				Return: contracts.ContractReturn{Type: "pkg.Builder", Confidence: "high"}, Role: "config",
+			}},
+			"pkg.Builder.finish#0": {{
+				Method: "pkg.Builder.finish", Arity: 0,
+				Return: contracts.ContractReturn{Type: "pkg.Result", Confidence: "high"},
+			}},
+		},
+		Hierarchy: map[string][]string{
+			"pkg.Builder": {"java.lang.Object"},
+			"pkg.Result":  {"java.lang.Object"},
+		},
+	}
+	asset := entities.CryptographicAsset{Metadata: map[string]string{"api": "pkg.Builder.finish"}}
+
+	canonicalSet := func(t *testing.T, order []int) []string {
+		t.Helper()
+		graph := &callgraph.CallGraph{Functions: make(map[string]*callgraph.FunctionDecl, len(order))}
+		for _, index := range order {
+			decl := declarations[index]
+			graph.Functions[decl.ID.String()] = decl
+		}
+		ctx := newExportBuildContext(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
+		ctx.kb = kb
+		calls := deriveContractSupportingCalls(ctx, asset)
+		catalog := make(map[string]struct{}, len(calls))
+		for _, call := range dedupSupportingCalls(calls) {
+			catalog[call.SupportingID] = struct{}{}
+		}
+		for _, supportingID := range supportingCallIDsOf(calls) {
+			if _, ok := catalog[supportingID]; !ok {
+				t.Fatalf("supporting call reference %q does not resolve in catalog", supportingID)
+			}
+		}
+		got := make([]string, 0, len(calls))
+		for i := range calls {
+			got = append(got, calls[i].CanonicalSignature)
+		}
+		sort.Strings(got)
+		return got
+	}
+
+	want := []string{
+		"pkg.Builder.configure(): pkg.Builder",
+		"pkg.Builder.configure(int): pkg.Builder",
+		"pkg.Builder.salt(byte[]): pkg.Builder",
+		"pkg.Builder.salt(java.lang.String): pkg.Builder",
+	}
+	tests := []struct {
+		name  string
+		order []int
+	}{
+		{name: "forward insertion", order: []int{0, 1, 2, 3}},
+		{name: "reverse insertion", order: []int{3, 2, 1, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canonicalSet(t, tt.order); !reflect.DeepEqual(got, want) {
+				t.Fatalf("canonical signatures = %v, want %v", got, want)
+			}
+		})
 	}
 }
 

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph"
@@ -13,6 +15,129 @@ import (
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/pkg/graphfrag"
 )
+
+func TestBuildGraphFragmentExport_PreservesSupportingOverloadsAcrossRepeatedExports(t *testing.T) {
+	t.Parallel()
+
+	declarations := []*callgraph.FunctionDecl{
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "Password", Name: "hash#1$byte[]"},
+			FilePath:   "Password.java",
+			StartLine:  10,
+			ReturnType: "com.password4j.HashBuilder",
+			Parameters: []callgraph.FunctionParameter{{Type: "byte[]"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "Password", Name: "hash#1$CharSequence"},
+			FilePath:   "Password.java",
+			StartLine:  14,
+			ReturnType: "com.password4j.HashBuilder",
+			Parameters: []callgraph.FunctionParameter{{Type: "java.lang.CharSequence"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "HashBuilder", Name: "addRandomSalt#0"},
+			FilePath:   "HashBuilder.java",
+			StartLine:  20,
+			ReturnType: "com.password4j.HashBuilder",
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "HashBuilder", Name: "addRandomSalt#1$int"},
+			FilePath:   "HashBuilder.java",
+			StartLine:  24,
+			ReturnType: "com.password4j.HashBuilder",
+			Parameters: []callgraph.FunctionParameter{{Type: "int"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "HashBuilder", Name: "addSalt#1$byte[]"},
+			FilePath:   "HashBuilder.java",
+			StartLine:  28,
+			ReturnType: "com.password4j.HashBuilder",
+			Parameters: []callgraph.FunctionParameter{{Type: "byte[]"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "HashBuilder", Name: "addSalt#1$String"},
+			FilePath:   "HashBuilder.java",
+			StartLine:  32,
+			ReturnType: "com.password4j.HashBuilder",
+			Parameters: []callgraph.FunctionParameter{{Type: "java.lang.String"}},
+		},
+		{
+			ID:         callgraph.FunctionID{Package: "com.password4j", Type: "Hash", Name: "getResult#0"},
+			FilePath:   "Hash.java",
+			StartLine:  8,
+			ReturnType: "java.lang.String",
+		},
+	}
+	report := &entities.InterimReport{Findings: []entities.Finding{{
+		FilePath: "HashBuilder.java",
+		Language: "java",
+		CryptographicAssets: []entities.CryptographicAsset{{
+			FindingID: "password4j-bcrypt",
+			StartLine: 40,
+			EndLine:   40,
+			Match:     "withBcrypt()",
+			Rules:     []entities.RuleInfo{{ID: engine.SyntheticEntryPointRuleID}},
+			Metadata:  map[string]string{"api": "com.password4j.HashBuilder.withBcrypt"},
+		}},
+	}}}
+
+	semanticCatalog := func(t *testing.T, order []int) []string {
+		t.Helper()
+		graph := &callgraph.CallGraph{Functions: make(map[string]*callgraph.FunctionDecl, len(order))}
+		for _, index := range order {
+			decl := declarations[index]
+			graph.Functions[decl.ID.String()] = decl
+		}
+		payload := BuildGraphFragmentExport(&engine.DepScanResult{
+			Report: report, CallGraph: graph, Ecosystem: "java",
+		})
+		catalogIDs := make(map[string]struct{}, len(payload.SupportingCalls))
+		got := make([]string, 0, len(payload.SupportingCalls))
+		for _, supporting := range payload.SupportingCalls {
+			catalogIDs[supporting.SupportingID] = struct{}{}
+			got = append(got, supporting.CanonicalSignature)
+		}
+		if len(payload.CryptoAnnotations) != 1 {
+			t.Fatalf("crypto annotations = %d, want 1", len(payload.CryptoAnnotations))
+		}
+		for _, supportingID := range payload.CryptoAnnotations[0].SupportingCallIDs {
+			if _, ok := catalogIDs[supportingID]; !ok {
+				t.Fatalf("supporting call reference %q does not resolve in exported catalog", supportingID)
+			}
+		}
+		if len(payload.CryptoAnnotations[0].SupportingCallIDs) != len(payload.SupportingCalls) {
+			t.Fatalf("supporting call references = %d, catalog = %d", len(payload.CryptoAnnotations[0].SupportingCallIDs), len(payload.SupportingCalls))
+		}
+		sort.Strings(got)
+		return got
+	}
+
+	want := []string{
+		"com.password4j.Hash.getResult(): java.lang.String",
+		"com.password4j.HashBuilder.addRandomSalt(): com.password4j.HashBuilder",
+		"com.password4j.HashBuilder.addRandomSalt(int): com.password4j.HashBuilder",
+		"com.password4j.HashBuilder.addSalt(byte[]): com.password4j.HashBuilder",
+		"com.password4j.HashBuilder.addSalt(java.lang.String): com.password4j.HashBuilder",
+		"com.password4j.Password.hash(byte[]): com.password4j.HashBuilder",
+		"com.password4j.Password.hash(java.lang.CharSequence): com.password4j.HashBuilder",
+	}
+	sort.Strings(want)
+	tests := []struct {
+		name  string
+		order []int
+	}{
+		{name: "forward", order: []int{0, 1, 2, 3, 4, 5, 6}},
+		{name: "reverse", order: []int{6, 5, 4, 3, 2, 1, 0}},
+		{name: "repeated", order: []int{0, 1, 2, 3, 4, 5, 6}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := semanticCatalog(t, tt.order); !reflect.DeepEqual(got, want) {
+				t.Fatalf("semantic catalog = %v, want %v", got, want)
+			}
+		})
+	}
+}
 
 func TestExportGraphFragment_WritesDecodableNoEscapeJSON(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- retain every declaration for a supporting-call method instead of selecting one from map traversal order
- match overload-decorated Java declarations by contract arity and deduplicate only by complete canonical signature
- cover repeated graph-fragment exports, overload semantics, and finding-to-catalog references

Closes #131

## Test plan

- [x] `go test ./internal/scan -run 'Test(BuildGraphFragmentExport_PreservesSupportingOverloadsAcrossRepeatedExports|DeriveContractSupportingCalls_PreservesOverloadsRegardlessOfInsertionOrder)$' -count=10`
- [x] `go test ./internal/scan -count=1`
- [x] `go test ./... -count=1`
- [x] `make lint`
