### PR TITLE
fix(scan): attribute nested findings by source span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- Nested-call findings now attribute matched operations and canonical call identities to the tightest source invocation instead of an enclosing call. (#134)
 - Supporting-call catalogs now preserve every callable overload deterministically instead of selecting one by traversal order. (#131)
 - Stitched graph-fragment callgraph exports now retain parameter roles on supporting calls. (#130)
 - Concurrent scans sharing the default rules cache no longer expose partial metadata or lose in-flight filtered rule files when another process refreshes the cache. (#128)

--- a/internal/cli/dependency_intelligence_acceptance_integration_test.go
+++ b/internal/cli/dependency_intelligence_acceptance_integration_test.go
@@ -48,6 +48,8 @@ type acceptanceCase struct {
 
 type acceptanceMatch struct {
 	needle, ruleID, api  string
+	wantSymbol           string
+	wantSignature        string
 	staticProvider       bool
 	runtimeProvider      bool
 	requiresSupport      bool
@@ -77,6 +79,12 @@ func TestDependencyIntelligenceExportContract(t *testing.T) {
 			pinFile: "pom.xml", pinText: "<version>1.78.1</version>",
 			matches: []acceptanceMatch{
 				{needle: "new KeyParameter(key)", ruleID: "java.acceptance.key-parameter", api: "org.bouncycastle.crypto.params.KeyParameter.<init>", requiresSupport: true, supportingCategories: []string{"factory", "output"}},
+				{
+					needle: "new KeyParameter(data)", ruleID: "java.acceptance.nested-key-parameter",
+					api:           "org.bouncycastle.crypto.modes.GCMBlockCipher.init",
+					wantSymbol:    "org.bouncycastle.crypto.params.KeyParameter.<init>",
+					wantSignature: "org.bouncycastle.crypto.params.KeyParameter.<init>(byte[]): KeyParameter",
+				},
 				{needle: "params.getKey()", ruleID: "java.acceptance.key-output", api: "org.bouncycastle.crypto.params.KeyParameter.getKey", requiresSupport: true, supportingCategories: []string{"factory", "output"}},
 				{needle: "gcm.getOutputSize(16)", ruleID: "java.acceptance.gcm", api: "org.bouncycastle.crypto.modes.GCMBlockCipher.getOutputSize", requiresSupport: true, supportingCategories: []string{"config"}},
 				{needle: "new AESEngine()", ruleID: "java.acceptance.engine", api: "org.bouncycastle.crypto.engines.AESEngine.<init>", requiresSupport: true, supportingCategories: []string{"operation"}},
@@ -336,6 +344,13 @@ func assertFragmentContract(t *testing.T, tc acceptanceCase, payload *graphfrag.
 		seen++
 		if match.requiresSupport {
 			require.NotEmptyf(t, op.SupportingCallIDs, "finding %s must link its applicable supporting calls", op.RuleID)
+		}
+		if match.wantSymbol != "" {
+			require.NotNil(t, op.MatchedOperation, "finding %s matched operation", op.RuleID)
+			assert.Equal(t, match.wantSymbol, op.MatchedOperation.Symbol, "finding %s matched invocation", op.RuleID)
+			require.NotNil(t, op.CryptoCall, "finding %s crypto call", op.RuleID)
+			assert.Equal(t, match.wantSymbol, op.CryptoCall.FunctionName, "finding %s crypto call identity", op.RuleID)
+			assert.Equal(t, match.wantSignature, op.CryptoCall.CanonicalSignature, "finding %s canonical signature", op.RuleID)
 		}
 		findingCategories := make(map[string]bool)
 		for _, id := range op.SupportingCallIDs {

--- a/internal/scan/annotate_supporting.go
+++ b/internal/scan/annotate_supporting.go
@@ -208,13 +208,13 @@ func edgeCandidateViews(edges []fragEdge) []candidateView {
 // running the SAME position/chain selection policy (terminal_selection.go) as the
 // live exporter (findCryptoCallNode) over the cached fragment's edges. Because
 // graph-fragment 1.4 edges now carry call columns (start_col/end_col), the
-// column-intersection anchor is identical on both paths — so a finding's terminal,
+// source-position anchor is identical on both paths — so a finding's terminal,
 // and therefore its derived supporting calls, match a live
-// `scan --export-graph-fragment` even on multi-call / fluent-chain lines.
+// `scan --export-graph-fragment` even on nested / multi-call / fluent-chain lines.
 //
 // Steps mirror findCryptoCallNode:
 //  1. line-range candidates (edges on the finding's line);
-//  2. column intersection (shared columnFilterIndices);
+//  2. column intersection and tightest containing span (shared columnFilterIndices);
 //  3. chain-root, then longest-chain tie-break (shared);
 //  4. fallback for legacy column-less fragments (schema < 1.4, every column 0) or
 //     non-chain calls: see annotateNonChainEdgeIndex.

--- a/internal/scan/annotate_supporting_test.go
+++ b/internal/scan/annotate_supporting_test.go
@@ -165,6 +165,28 @@ func TestTerminalEdgeIndex_ColumnAwareSelection(t *testing.T) {
 		}
 	})
 
+	t.Run("nested invocation spans select the matched edge", func(t *testing.T) {
+		edges := []fragEdge{
+			{raw: "cipher.encrypt(new KeyParameter(key))", line: 5, startCol: 10, endCol: 49},
+			{raw: "new KeyParameter(key)", line: 5, startCol: 25, endCol: 46},
+		}
+		for _, tt := range []struct {
+			name       string
+			start, end int
+			want       int
+		}{
+			{"nested constructor", 25, 46, 1},
+			{"enclosing invocation", 10, 49, 0},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				asset := entities.CryptographicAsset{StartLine: 5, EndLine: 5, StartCol: tt.start, EndCol: tt.end}
+				if got := terminalEdgeIndex(edges, asset); got != tt.want {
+					t.Fatalf("terminalEdgeIndex = %d, want %d", got, tt.want)
+				}
+			})
+		}
+	})
+
 	t.Run("fluent chain on one line - chain root (AssignedVar) selected", func(t *testing.T) {
 		edges := []fragEdge{
 			{raw: "Password.hash(p)", line: 6, startCol: 1, endCol: 17, identity: objectIdentity{ChainID: "c1"}},
@@ -173,9 +195,11 @@ func TestTerminalEdgeIndex_ColumnAwareSelection(t *testing.T) {
 				identity: objectIdentity{ChainID: "c1", AssignedVar: "hash"},
 			},
 		}
-		asset := entities.CryptographicAsset{StartLine: 6, EndLine: 6, StartCol: 1, EndCol: 46}
-		if got := terminalEdgeIndex(edges, asset); got != 1 {
-			t.Fatalf("terminalEdgeIndex = %d, want 1 (chain root with AssignedVar)", got)
+		for _, endCol := range []int{17, 46} {
+			asset := entities.CryptographicAsset{StartLine: 6, EndLine: 6, StartCol: 1, EndCol: endCol}
+			if got := terminalEdgeIndex(edges, asset); got != 1 {
+				t.Fatalf("span [1,%d) selected edge %d, want chain root", endCol, got)
+			}
 		}
 	})
 

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -1649,8 +1649,7 @@ func looksLikeInvocationExpression(expression string) bool {
 //
 //  2. Column filter (when both asset and call have non-zero columns):
 //     keep candidates whose [StartCol, EndCol) intersects [asset.StartCol,
-//     asset.EndCol) using the half-open test:
-//     c.StartCol < asset.EndCol && asset.StartCol < c.EndCol.
+//     asset.EndCol), then prefer the tightest call span containing the match.
 //     If the filter yields 0 matches, use the full line-only set (never worse).
 //
 //  3. Tie-break to chain ROOT among survivors.

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -152,7 +152,48 @@ func TestFindCryptoCallNode(t *testing.T) {
 		}
 	})
 
-	t.Run("whole-chain span selects chain ROOT (AssignedVar set)", func(t *testing.T) {
+	t.Run("nested invocation spans select the matched call", func(t *testing.T) {
+		constructor := callgraph.FunctionCall{
+			Callee:   callgraph.FunctionID{Type: "KeyParameter", Name: "<init>#1$byte[]"},
+			Line:     5,
+			StartCol: 20,
+			EndCol:   38,
+			Raw:      "new KeyParameter(key)",
+		}
+		encrypt := callgraph.FunctionCall{
+			Callee:    callgraph.FunctionID{Type: "Cipher", Name: "encrypt#1$KeyParameter"},
+			Line:      5,
+			StartCol:  10,
+			EndCol:    39,
+			Raw:       "cipher.encrypt(new KeyParameter(key))",
+			Arguments: []string{"new KeyParameter(key)"},
+		}
+		fn := &callgraph.FunctionDecl{Calls: []callgraph.FunctionCall{encrypt, constructor}}
+		for _, tt := range []struct {
+			name       string
+			start, end int
+			want       string
+		}{
+			{"nested constructor", 20, 38, "<init>#1$byte[]"},
+			{"enclosing invocation", 10, 39, "encrypt#1$KeyParameter"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				asset := entities.CryptographicAsset{
+					StartLine: 5, EndLine: 5, StartCol: tt.start, EndCol: tt.end,
+					Metadata: map[string]string{"api": "wrong.metadata.Api"},
+				}
+				got := findCryptoCallNode(emptyGraph, fn, asset, 5, 5)
+				if got == nil {
+					t.Fatal("findCryptoCallNode returned nil")
+				}
+				if got.Callee.Name != tt.want {
+					t.Fatalf("selected call = %q, want %q", got.Callee.Name, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("fluent-chain spans preserve the chain ROOT (AssignedVar set)", func(t *testing.T) {
 		// Line 6: a 3-link fluent chain. The root is the one with AssignedVar set.
 		// All three share ChainID "chain-1". Asset spans the entire line [1,50).
 		chainRoot := callgraph.FunctionCall{
@@ -183,20 +224,16 @@ func TestFindCryptoCallNode(t *testing.T) {
 		fn := &callgraph.FunctionDecl{
 			Calls: []callgraph.FunctionCall{chainLink1, chainLink2, chainRoot},
 		}
-		asset := entities.CryptographicAsset{
-			StartLine: 6,
-			EndLine:   6,
-			StartCol:  1,
-			EndCol:    50,
-		}
-
-		got := findCryptoCallNode(emptyGraph, fn, asset, 6, 6)
-		if got == nil {
-			t.Fatal("findCryptoCallNode returned nil, want chainRoot")
-		}
-		if got.AssignedVar != "hash" {
-			t.Errorf("selected call AssignedVar = %q, want %q; Callee = %q",
-				got.AssignedVar, "hash", got.Callee.Name)
+		for _, endCol := range []int{20, 50} {
+			asset := entities.CryptographicAsset{StartLine: 6, EndLine: 6, StartCol: 1, EndCol: endCol}
+			got := findCryptoCallNode(emptyGraph, fn, asset, 6, 6)
+			if got == nil {
+				t.Fatal("findCryptoCallNode returned nil, want chainRoot")
+			}
+			if got.AssignedVar != "hash" {
+				t.Errorf("span [1,%d) selected AssignedVar = %q, want %q; Callee = %q",
+					endCol, got.AssignedVar, "hash", got.Callee.Name)
+			}
 		}
 	})
 

--- a/internal/scan/terminal_selection.go
+++ b/internal/scan/terminal_selection.go
@@ -8,11 +8,11 @@ package scan
 // variable its result binds to, and the length of its raw expression. The live
 // exporter projects it from *callgraph.FunctionCall (callCandidateViews) and the
 // annotate-from-cache path projects it from a graph-fragment edge
-// (edgeCandidateViews), so BOTH run the IDENTICAL column-intersection +
-// chain-root selection policy. This is the single source of truth for "which
+// (edgeCandidateViews), so BOTH run the IDENTICAL tightest-span + chain-root
+// selection policy. This is the single source of truth for "which
 // call on this line is the terminal crypto operation"; keeping the policy here
 // (not duplicated per path) is what guarantees cache-derived supporting calls
-// match a live scan on multi-call / fluent-chain lines.
+// match a live scan on nested / multi-call / fluent-chain lines.
 type candidateView struct {
 	StartCol    int
 	EndCol      int
@@ -32,8 +32,10 @@ func identityIndices(n int) []int {
 }
 
 // columnFilterIndices keeps the candidates (from idxs) whose [StartCol, EndCol)
-// half-open span intersects the asset's [assetStartCol, assetEndCol) span. It is
-// the shared column anchor for both paths.
+// half-open span intersects the asset's [assetStartCol, assetEndCol) span. When
+// nested calls both intersect, it keeps the tightest call span that contains the
+// complete asset span. Candidates from that call's fluent chain stay eligible so
+// the existing chain-root tie-break still applies.
 //
 // It falls back to the input idxs unchanged (line-only behavior, never worse)
 // when the asset carries no columns, or when no surviving candidate carries
@@ -57,7 +59,37 @@ func columnFilterIndices(views []candidateView, idxs []int, assetStartCol, asset
 	if len(filtered) == 0 {
 		return idxs
 	}
-	return filtered
+	return tightestContainingIndices(views, filtered, assetStartCol, assetEndCol)
+}
+
+func tightestContainingIndices(views []candidateView, idxs []int, assetStartCol, assetEndCol int) []int {
+	best := -1
+	for _, i := range idxs {
+		v := views[i]
+		if v.StartCol > assetStartCol || v.EndCol < assetEndCol {
+			continue
+		}
+		if best == -1 || v.EndCol-v.StartCol < views[best].EndCol-views[best].StartCol {
+			best = i
+		}
+	}
+	if best == -1 {
+		return idxs
+	}
+
+	minSpan := views[best].EndCol - views[best].StartCol
+	chainID := views[best].ChainID
+	tightest := make([]int, 0, len(idxs))
+	for _, i := range idxs {
+		v := views[i]
+		if v.StartCol > assetStartCol || v.EndCol < assetEndCol {
+			continue
+		}
+		if v.EndCol-v.StartCol == minSpan || chainID != "" && v.ChainID == chainID {
+			tightest = append(tightest, i)
+		}
+	}
+	return tightest
 }
 
 // chainRootIndexAmong returns the index (drawn from idxs) of the fluent-chain

--- a/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
+++ b/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
@@ -41,6 +41,7 @@ class Acceptance {
         params.getKey();
         GCMBlockCipher gcm = new GCMBlockCipher();
         gcm.init(true, params);
+        gcm.init(true, new KeyParameter(data));
         gcm.getOutputSize(16);
         AESEngine engine = new AESEngine();
         helper(data, key, 16);


### PR DESCRIPTION
Closes #134

## Summary

- prefer the tightest call span containing a finding before applying existing call-selection tie-breaks
- keep fluent-chain root behavior and live/cache-derived attribution equivalent
- add nested-constructor and enclosing-call regressions plus public CLI export acceptance coverage

## Root cause

Overlapping nested call spans all survived column filtering. Generic scoring then favored the enclosing argument-bearing invocation instead of the source callable matched by the rule.

## Test plan

- [x] `go test ./internal/scan -run 'TestFindCryptoCallNode|TestTerminalEdgeIndex_ColumnAwareSelection' -count=1`
- [x] `go test ./internal/cli -run '^TestDependencyIntelligenceExportContract$' -count=1`
- [x] `go test ./internal/scan ./internal/cli -count=1`
- [x] `go test ./... -count=1`
- [x] `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested-call finding accuracy by attributing matched operations and canonical call identities to the tightest source invocation.
  * Enhanced handling of nested constructor calls and fluent chains for more precise crypto-operation matching.

* **Tests**
  * Added coverage validating matched operation symbols and signatures.
  * Expanded verification for nested invocations and chain-based call selection.

* **Documentation**
  * Clarified how crypto calls are selected when multiple nested spans overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->