### PR TITLE
feat(callgraph): add chacha20poly1305 contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Rust callgraph inference now recognizes RustCrypto `chacha20poly1305` 0.11 factories and AEAD operations, including ChaCha20-Poly1305 and XChaCha20-Poly1305 detached and in-place calls. (#125)
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)

--- a/internal/callgraph/contracts/rust/chacha20poly1305.yaml
+++ b/internal/callgraph/contracts/rust/chacha20poly1305.yaml
@@ -1,0 +1,273 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: chacha20poly1305
+  coordinates:
+    - chacha20poly1305
+  version_range: ">=0.11.0,<0.12.0"
+  description: "RustCrypto ChaCha20-Poly1305 authenticated encryption"
+
+contracts:
+  # Key/nonce generation through Generate is generic (e.g.
+  # Key::<ChaCha20Poly1305>::generate()) and does not have a stable Rust parser
+  # identity yet. Keep the stable slice constructors instead.
+  - method: chacha20poly1305::Key.from_slice
+    arity: 1
+    return: { type: chacha20poly1305::Key, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: chacha20poly1305::Nonce.from_slice
+    arity: 1
+    return: { type: chacha20poly1305::Nonce, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+  - method: chacha20poly1305::XNonce.from_slice
+    arity: 1
+    return: { type: chacha20poly1305::XNonce, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+
+  - method: chacha20poly1305::ChaCha20Poly1305.new
+    arity: 1
+    return: { type: chacha20poly1305::ChaCha20Poly1305, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: chacha20poly1305::XChaCha20Poly1305.new
+    arity: 1
+    return: { type: chacha20poly1305::XChaCha20Poly1305, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  - method: chacha20poly1305::ChaCha20Poly1305.encrypt
+    arity: 2
+    return: { type: alloc::vec::Vec, confidence: high }
+    role: operation
+    parameters: &aead_message
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: plaintext
+        role: metadata-contributing
+        contributes: { property: plaintext, derivation: argument_value }
+  - method: chacha20poly1305::ChaCha20Poly1305.decrypt
+    arity: 2
+    return: { type: alloc::vec::Vec, confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+  - method: chacha20poly1305::XChaCha20Poly1305.encrypt
+    arity: 2
+    return: { type: alloc::vec::Vec, confidence: high }
+    role: operation
+    parameters: *aead_message
+  - method: chacha20poly1305::XChaCha20Poly1305.decrypt
+    arity: 2
+    return: { type: alloc::vec::Vec, confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+
+  - method: chacha20poly1305::ChaCha20Poly1305.encrypt_in_place
+    arity: 3
+    return: { type: (), confidence: high }
+    role: operation
+    parameters: &aead_in_place
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: associated_data
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: plaintext
+        role: metadata-contributing
+        contributes: { property: plaintext, derivation: argument_value }
+  - method: chacha20poly1305::ChaCha20Poly1305.decrypt_in_place
+    arity: 3
+    return: { type: (), confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: associated_data
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+  - method: chacha20poly1305::XChaCha20Poly1305.encrypt_in_place
+    arity: 3
+    return: { type: (), confidence: high }
+    role: operation
+    parameters: *aead_in_place
+  - method: chacha20poly1305::XChaCha20Poly1305.decrypt_in_place
+    arity: 3
+    return: { type: (), confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: associated_data
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+
+  # aead 0.6's current detached API. The legacy in_place_detached methods
+  # below remain because the crate also implements the deprecated AeadInPlace
+  # compatibility trait.
+  - method: chacha20poly1305::ChaCha20Poly1305.encrypt_inout_detached
+    arity: 3
+    return: { type: chacha20poly1305::Tag, confidence: high }
+    role: operation
+    parameters: *aead_in_place
+  - method: chacha20poly1305::ChaCha20Poly1305.decrypt_inout_detached
+    arity: 4
+    return: { type: (), confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: associated_data
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+      - index: 3
+        name: tag
+        role: metadata-contributing
+        contributes: { property: authenticationTag, derivation: argument_value }
+  - method: chacha20poly1305::XChaCha20Poly1305.encrypt_inout_detached
+    arity: 3
+    return: { type: chacha20poly1305::Tag, confidence: high }
+    role: operation
+    parameters: *aead_in_place
+  - method: chacha20poly1305::XChaCha20Poly1305.decrypt_inout_detached
+    arity: 4
+    return: { type: (), confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: associated_data
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+      - index: 3
+        name: tag
+        role: metadata-contributing
+        contributes: { property: authenticationTag, derivation: argument_value }
+
+  - method: chacha20poly1305::ChaCha20Poly1305.encrypt_in_place_detached
+    arity: 3
+    return: { type: chacha20poly1305::Tag, confidence: high }
+    role: operation
+    parameters: *aead_in_place
+  - method: chacha20poly1305::ChaCha20Poly1305.decrypt_in_place_detached
+    arity: 4
+    return: { type: (), confidence: high }
+    role: operation
+    parameters: &aead_in_place_detached_decrypt
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: associated_data
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: ciphertext
+        role: metadata-contributing
+        contributes: { property: ciphertext, derivation: argument_value }
+      - index: 3
+        name: tag
+        role: metadata-contributing
+        contributes: { property: authenticationTag, derivation: argument_value }
+  - method: chacha20poly1305::XChaCha20Poly1305.encrypt_in_place_detached
+    arity: 3
+    return: { type: chacha20poly1305::Tag, confidence: high }
+    role: operation
+    parameters: *aead_in_place
+  - method: chacha20poly1305::XChaCha20Poly1305.decrypt_in_place_detached
+    arity: 4
+    return: { type: (), confidence: high }
+    role: operation
+    parameters: *aead_in_place_detached_decrypt
+
+hierarchy:
+  chacha20poly1305::ChaCha20Poly1305:
+    - chacha20poly1305::ChaChaPoly1305
+  chacha20poly1305::XChaCha20Poly1305:
+    - chacha20poly1305::ChaChaPoly1305
+  chacha20poly1305::ChaChaPoly1305:
+    - core::any::Any
+  chacha20poly1305::Key:
+    - core::any::Any
+  chacha20poly1305::Nonce:
+    - core::any::Any
+  chacha20poly1305::XNonce:
+    - core::any::Any
+  chacha20poly1305::Tag:
+    - core::any::Any
+  alloc::vec::Vec:
+    - core::any::Any
+  core::any::Any: []

--- a/internal/callgraph/contracts/rust_libraries_test.go
+++ b/internal/callgraph/contracts/rust_libraries_test.go
@@ -1,0 +1,97 @@
+package contracts_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedRustIncludesChacha20Poly1305Contracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		role   string
+		ret    string
+	}{
+		{"chacha20poly1305::Key.from_slice", 1, "factory", "chacha20poly1305::Key"},
+		{"chacha20poly1305::Nonce.from_slice", 1, "factory", "chacha20poly1305::Nonce"},
+		{"chacha20poly1305::XNonce.from_slice", 1, "factory", "chacha20poly1305::XNonce"},
+		{"chacha20poly1305::ChaCha20Poly1305.new", 1, "factory", "chacha20poly1305::ChaCha20Poly1305"},
+		{"chacha20poly1305::XChaCha20Poly1305.new", 1, "factory", "chacha20poly1305::XChaCha20Poly1305"},
+		{"chacha20poly1305::ChaCha20Poly1305.encrypt", 2, "operation", "alloc::vec::Vec"},
+		{"chacha20poly1305::ChaCha20Poly1305.decrypt", 2, "operation", "alloc::vec::Vec"},
+		{"chacha20poly1305::XChaCha20Poly1305.encrypt", 2, "operation", "alloc::vec::Vec"},
+		{"chacha20poly1305::XChaCha20Poly1305.decrypt", 2, "operation", "alloc::vec::Vec"},
+		{"chacha20poly1305::ChaCha20Poly1305.encrypt_in_place", 3, "operation", "()"},
+		{"chacha20poly1305::ChaCha20Poly1305.decrypt_in_place", 3, "operation", "()"},
+		{"chacha20poly1305::XChaCha20Poly1305.encrypt_in_place", 3, "operation", "()"},
+		{"chacha20poly1305::XChaCha20Poly1305.decrypt_in_place", 3, "operation", "()"},
+		{"chacha20poly1305::ChaCha20Poly1305.encrypt_inout_detached", 3, "operation", "chacha20poly1305::Tag"},
+		{"chacha20poly1305::ChaCha20Poly1305.decrypt_inout_detached", 4, "operation", "()"},
+		{"chacha20poly1305::XChaCha20Poly1305.encrypt_inout_detached", 3, "operation", "chacha20poly1305::Tag"},
+		{"chacha20poly1305::XChaCha20Poly1305.decrypt_inout_detached", 4, "operation", "()"},
+		{"chacha20poly1305::ChaCha20Poly1305.encrypt_in_place_detached", 3, "operation", "chacha20poly1305::Tag"},
+		{"chacha20poly1305::ChaCha20Poly1305.decrypt_in_place_detached", 4, "operation", "()"},
+		{"chacha20poly1305::XChaCha20Poly1305.encrypt_in_place_detached", 3, "operation", "chacha20poly1305::Tag"},
+		{"chacha20poly1305::XChaCha20Poly1305.decrypt_in_place_detached", 4, "operation", "()"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].SourceLibrary != "chacha20poly1305" || got[0].Role != tt.role || got[0].Return.Type != tt.ret {
+				t.Fatalf("%s#%d = %#v, want role %q and return %q from chacha20poly1305", tt.method, tt.arity, got[0], tt.role, tt.ret)
+			}
+			assertChacha20Poly1305ParameterRoles(t, tt.method, got[0].Parameters)
+		})
+	}
+}
+
+func assertChacha20Poly1305ParameterRoles(t *testing.T, method string, parameters []contracts.ParameterContract) {
+	t.Helper()
+
+	var want []struct{ property, derivation string }
+	switch {
+	case strings.HasSuffix(method, ".from_slice"):
+		property := "nonceSize"
+		if strings.Contains(method, "::Key.") {
+			property = "keySize"
+		}
+		want = []struct{ property, derivation string }{{property, "argument_bit_length"}}
+	case strings.HasSuffix(method, ".new"):
+		want = []struct{ property, derivation string }{{"keySize", "argument_bit_length"}}
+	case strings.Contains(method, "decrypt_in_place_detached") || strings.Contains(method, "decrypt_inout_detached"):
+		want = []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}, {"associatedData", "argument_value"}, {"ciphertext", "argument_value"}, {"authenticationTag", "argument_value"}}
+	case strings.Contains(method, "encrypt_in_place") || strings.Contains(method, "encrypt_inout_detached"):
+		want = []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}, {"associatedData", "argument_value"}, {"plaintext", "argument_value"}}
+	case strings.Contains(method, "decrypt_in_place"):
+		want = []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}, {"associatedData", "argument_value"}, {"ciphertext", "argument_value"}}
+	case strings.HasSuffix(method, ".encrypt"):
+		want = []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}, {"plaintext", "argument_value"}}
+	case strings.HasSuffix(method, ".decrypt"):
+		want = []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}, {"ciphertext", "argument_value"}}
+	}
+
+	if len(parameters) != len(want) {
+		t.Fatalf("%s parameters = %#v, want %d metadata contributions", method, parameters, len(want))
+	}
+	for i, expected := range want {
+		parameter := parameters[i]
+		if parameter.Index == nil || *parameter.Index != i || parameter.Role != "metadata-contributing" || parameter.Contributes == nil ||
+			parameter.Contributes.Property != expected.property || parameter.Contributes.Derivation != expected.derivation {
+			t.Fatalf("%s parameters[%d] = %#v, want metadata contribution %s/%s", method, i, parameter, expected.property, expected.derivation)
+		}
+	}
+}

--- a/internal/callgraph/rust_parser_extra_test.go
+++ b/internal/callgraph/rust_parser_extra_test.go
@@ -90,6 +90,30 @@ func TestRustParser_ReturnFactory_PopulatesCallTarget(t *testing.T) {
 	}
 }
 
+func TestRustParser_Chacha20Poly1305CallsKeepConcreteTypeEvidence(t *testing.T) {
+	fns := parseRustInline(t, `use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+fn seal(key: Key, nonce: Nonce, plaintext: &[u8], buffer: &mut [u8]) {
+    let cipher = ChaCha20Poly1305::new(&key);
+    cipher.encrypt(&nonce, plaintext);
+    cipher.encrypt_inout_detached(&nonce, b"", buffer);
+}`)
+
+	fn := rustFunctionByName(t, fns, "seal")
+	if len(fn.Calls) != 3 {
+		t.Fatalf("calls = %#v, want constructor plus two operations", fn.Calls)
+	}
+	want := []FunctionID{
+		{Package: "chacha20poly1305", Type: "ChaCha20Poly1305", Name: "new"},
+		{Package: "chacha20poly1305", Type: "ChaCha20Poly1305", Name: "encrypt"},
+		{Package: "chacha20poly1305", Type: "ChaCha20Poly1305", Name: "encrypt_inout_detached"},
+	}
+	for i, expected := range want {
+		if fn.Calls[i].Callee != expected {
+			t.Fatalf("calls[%d] = %#v, want %#v", i, fn.Calls[i].Callee, expected)
+		}
+	}
+}
+
 func TestRustParser_UnknownAndBareReturn_NoReturnSources(t *testing.T) {
 	fns := parseRustInline(t, `fn unknown(flag: bool) -> Key { if flag { key } else { other } }
 fn bare() { return; }`)


### PR DESCRIPTION
## Summary
- Add version-pinned RustCrypto `chacha20poly1305` 0.11 contracts for key and nonce construction plus ChaCha20-Poly1305 and XChaCha20-Poly1305 AEAD operations.
- Preserve concrete parser type evidence for factory and detached operations.
- Add the consumer-visible changelog entry.

## API inventory
- **Contracted:** `Key`/`Nonce`/`XNonce` `from_slice`, both cipher `new` factories, `encrypt`/`decrypt`, current `aead` 0.6 `*_inout_detached`, and legacy-compatible `*_in_place`/`*_in_place_detached`.
- **Skipped, unsupported:** generic `Generate` calls such as `Key::<ChaCha20Poly1305>::generate()`; the Rust parser cannot produce a stable canonical callable identity for generic type arguments.
- **Out of scope:** feature-gated reduced-round variants, other crates, parser/resolver infrastructure, and detection rules.

## Verification
- [x] `go test ./internal/callgraph/contracts/...`
- [x] `go test ./internal/callgraph/...`

Closes #125

Paired detection work: scanoss/crypto_rules#125

