### PR TITLE
feat(callgraph): add Java lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph lifecycle contracts now cover Bouncy Castle OpenPGP builders, Tink AEAD operations, and Apache Santuario XMLCipher factories and finalization. (#138)
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)

--- a/internal/callgraph/contracts/java/apache-santuario-xmlsec.yaml
+++ b/internal/callgraph/contracts/java/apache-santuario-xmlsec.yaml
@@ -1,0 +1,79 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: apache-santuario-xmlsec
+  coordinates:
+    - "org.apache.santuario:xmlsec"
+  version_range: "4.0.3"
+  description: "Apache Santuario XMLCipher factory and encryption lifecycle contracts"
+
+contracts:
+  - method: org.apache.xml.security.encryption.XMLCipher.getInstance
+    arity: 0
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+  - method: org.apache.xml.security.encryption.XMLCipher.getInstance
+    arity: 1
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: transformation
+        role: operation-determining
+        contributes: { property: transformation, derivation: argument_value }
+  # XMLCipher has two arity-2 getInstance overloads. Their common return and
+  # factory role are stable, while the selector position is not.
+  - method: org.apache.xml.security.encryption.XMLCipher.getInstance
+    arity: 2
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+  - method: org.apache.xml.security.encryption.XMLCipher.getInstance
+    arity: 3
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: transformation
+        role: operation-determining
+        contributes: { property: transformation, derivation: argument_value }
+  - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
+    arity: 1
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+  - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
+    arity: 2
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: transformation
+        role: operation-determining
+        contributes: { property: transformation, derivation: argument_value }
+  - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
+    arity: 3
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+  - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
+    arity: 4
+    return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
+    role: factory
+  - method: org.apache.xml.security.encryption.XMLCipher.init
+    arity: 2
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.apache.xml.security.encryption.XMLCipher.doFinal
+    arity: 2
+    return: { type: org.w3c.dom.Document, confidence: high }
+    role: operation
+  - method: org.apache.xml.security.encryption.XMLCipher.doFinal
+    arity: 3
+    return: { type: org.w3c.dom.Document, confidence: high }
+    role: operation
+
+hierarchy:
+  org.apache.xml.security.encryption.XMLCipher:
+    - java.lang.Object
+  org.w3c.dom.Document:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/bouncycastle-openpgp.yaml
+++ b/internal/callgraph/contracts/java/bouncycastle-openpgp.yaml
@@ -1,0 +1,185 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: bouncycastle-openpgp
+  coordinates:
+    - "org.bouncycastle:bcpg-jdk18on"
+  version_range: "1.78.1"
+  description: "Bouncy Castle OpenPGP data-encryption builder and generator contracts"
+
+contracts:
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: encAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setWithIntegrityPacket
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setWithAEAD
+    arity: 2
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: config
+    parameters:
+      - index: 0
+        name: aeadAlgorithm
+        role: operation-determining
+        contributes: { property: aeadAlgorithm, derivation: argument_value }
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setUseV5AEAD
+    arity: 0
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setUseV6AEAD
+    arity: 0
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setProvider
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setSecureRandom
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.getAlgorithm
+    arity: 0
+    return: { type: int, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.getAeadAlgorithm
+    arity: 0
+    return: { type: int, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.getChunkSize
+    arity: 0
+    return: { type: int, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.isV5StyleAEAD
+    arity: 0
+    return: { type: boolean, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.getSecureRandom
+    arity: 0
+    return: { type: java.security.SecureRandom, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.build
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.PGPDataEncryptor, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: keyBytes
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.<init>
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: encAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.setWithIntegrityPacket
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.setWithAEAD
+    arity: 2
+    return: { type: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder, confidence: high }
+    role: config
+    parameters:
+      - index: 0
+        name: aeadAlgorithm
+        role: operation-determining
+        contributes: { property: aeadAlgorithm, derivation: argument_value }
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.setUseV5AEAD
+    arity: 0
+    return: { type: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.setUseV6AEAD
+    arity: 0
+    return: { type: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.setSecureRandom
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.getAlgorithm
+    arity: 0
+    return: { type: int, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.getAeadAlgorithm
+    arity: 0
+    return: { type: int, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.getChunkSize
+    arity: 0
+    return: { type: int, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.isV5StyleAEAD
+    arity: 0
+    return: { type: boolean, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.getSecureRandom
+    arity: 0
+    return: { type: java.security.SecureRandom, confidence: high }
+    role: output
+  - method: org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.build
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.operator.PGPDataEncryptor, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: keyBytes
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  - method: org.bouncycastle.openpgp.PGPEncryptedDataGenerator.<init>
+    arity: 1
+    return: { type: org.bouncycastle.openpgp.PGPEncryptedDataGenerator, confidence: high }
+    role: factory
+  - method: org.bouncycastle.openpgp.PGPEncryptedDataGenerator.<init>
+    arity: 2
+    return: { type: org.bouncycastle.openpgp.PGPEncryptedDataGenerator, confidence: high }
+    role: factory
+  - method: org.bouncycastle.openpgp.PGPEncryptedDataGenerator.setForceSessionKey
+    arity: 1
+    return: { type: void, confidence: high }
+    role: config
+  - method: org.bouncycastle.openpgp.PGPEncryptedDataGenerator.addMethod
+    arity: 1
+    return: { type: void, confidence: high }
+    role: config
+  # Both supported public open overloads have arity 2 and return OutputStream.
+  - method: org.bouncycastle.openpgp.PGPEncryptedDataGenerator.open
+    arity: 2
+    return: { type: java.io.OutputStream, confidence: high }
+    role: operation
+  - method: org.bouncycastle.openpgp.PGPEncryptedDataGenerator.close
+    arity: 0
+    return: { type: void, confidence: high }
+    role: operation
+
+hierarchy:
+  org.bouncycastle.openpgp.operator.PGPDataEncryptorBuilder:
+    - java.lang.Object
+  org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder:
+    - org.bouncycastle.openpgp.operator.PGPDataEncryptorBuilder
+  org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder:
+    - org.bouncycastle.openpgp.operator.PGPDataEncryptorBuilder
+  org.bouncycastle.openpgp.operator.PGPDataEncryptor:
+    - java.lang.Object
+  org.bouncycastle.openpgp.PGPEncryptedDataGenerator:
+    - java.lang.Object
+  java.io.OutputStream:
+    - java.lang.Object
+  java.security.SecureRandom:
+    - java.util.Random
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/tink.yaml
+++ b/internal/callgraph/contracts/java/tink.yaml
@@ -27,6 +27,7 @@ contracts:
     return:
       type: com.google.crypto.tink.KeysetHandle
       confidence: high
+    role: factory
 
   # getPrimitive(Class<P>) — classic arity-1 form, conditional on the requested
   # primitive class literal.
@@ -109,12 +110,14 @@ contracts:
     return:
       type: "byte[]"
       confidence: high
+    role: operation
 
   - method: com.google.crypto.tink.Aead.decrypt
     arity: 2
     return:
       type: "byte[]"
       confidence: high
+    role: operation
 
   - method: com.google.crypto.tink.Mac.computeMac
     arity: 1

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -96,6 +96,47 @@ func TestLoadEmbeddedJavaIncludesTier0GapContracts(t *testing.T) {
 	}
 }
 
+func TestLoadEmbeddedJavaIncludesIssue138LifecycleContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantRole   string
+		wantLib    string
+	}{
+		{"org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>", 1, "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder", "factory", "bouncycastle-openpgp"},
+		{"org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.getAlgorithm", 0, "int", "output", "bouncycastle-openpgp"},
+		{"org.bouncycastle.openpgp.operator.bc.BcPGPDataEncryptorBuilder.build", 1, "org.bouncycastle.openpgp.operator.PGPDataEncryptor", "factory", "bouncycastle-openpgp"},
+		{"org.bouncycastle.openpgp.PGPEncryptedDataGenerator.open", 2, "java.io.OutputStream", "operation", "bouncycastle-openpgp"},
+		{"com.google.crypto.tink.KeysetHandle.generateNew", 1, "com.google.crypto.tink.KeysetHandle", "factory", "tink"},
+		{"com.google.crypto.tink.Aead.encrypt", 2, "byte[]", "operation", "tink"},
+		{"com.google.crypto.tink.Aead.decrypt", 2, "byte[]", "operation", "tink"},
+		{"org.apache.xml.security.encryption.XMLCipher.getInstance", 1, "org.apache.xml.security.encryption.XMLCipher", "factory", "apache-santuario-xmlsec"},
+		{"org.apache.xml.security.encryption.XMLCipher.init", 2, "void", "config", "apache-santuario-xmlsec"},
+		{"org.apache.xml.security.encryption.XMLCipher.doFinal", 2, "org.w3c.dom.Document", "operation", "apache-santuario-xmlsec"},
+		{"org.apache.xml.security.encryption.XMLCipher.doFinal", 3, "org.w3c.dom.Document", "operation", "apache-santuario-xmlsec"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.wantReturn || got[0].Role != tt.wantRole || got[0].SourceLibrary != tt.wantLib {
+				t.Fatalf("%s#%d = %#v, want return %s, role %s, library %s", tt.method, tt.arity, got[0], tt.wantReturn, tt.wantRole, tt.wantLib)
+			}
+		})
+	}
+}
+
 // TestLoadEmbeddedJava_BouncyCastleRoleCoverage is the issue-103 (WU1/BC-YAML)
 // acceptance test scoped to what a unit test can verify without a real BC
 // corpus (see internal/scan/bcprov_fragment_profile_test.go for the

--- a/internal/scan/fragment_reachability_test.go
+++ b/internal/scan/fragment_reachability_test.go
@@ -110,6 +110,65 @@ func TestBuildGraphFragmentExport13_DerivesSupportingCallsFromObjectLifecycle(t 
 	}
 }
 
+func TestBuildGraphFragmentExport_Issue138ExportsXMLCipherLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ownerID := callgraph.FunctionID{Package: "com.acme", Type: "XmlCrypto", Name: "encrypt#1"}
+	factoryID := callgraph.FunctionID{Package: "org.apache.xml.security.encryption", Type: "XMLCipher", Name: "getInstance#1"}
+	initID := callgraph.FunctionID{Package: "org.apache.xml.security.encryption", Type: "XMLCipher", Name: "init#2"}
+	finalID := callgraph.FunctionID{Package: "org.apache.xml.security.encryption", Type: "XMLCipher", Name: "doFinal#2"}
+
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		ownerID.String(): {
+			ID:        ownerID,
+			FilePath:  "XmlCrypto.java",
+			StartLine: 1,
+			EndLine:   8,
+			Calls: []callgraph.FunctionCall{
+				{Callee: factoryID, FilePath: "XmlCrypto.java", Line: 3, Raw: "XMLCipher.getInstance(XMLCipher.AES_256_GCM)", AssignedVar: "cipher"},
+				{Callee: initID, FilePath: "XmlCrypto.java", Line: 4, Raw: "cipher.init(XMLCipher.ENCRYPT_MODE, key)", ReceiverVar: "cipher"},
+				{Callee: finalID, FilePath: "XmlCrypto.java", Line: 5, Raw: "cipher.doFinal(document, element)", ReceiverVar: "cipher"},
+			},
+		},
+		factoryID.String(): {ID: factoryID, FilePath: "XMLCipher.java", StartLine: 1, ReturnType: "org.apache.xml.security.encryption.XMLCipher", Parameters: []callgraph.FunctionParameter{{Type: "java.lang.String"}}},
+		initID.String():    {ID: initID, FilePath: "XMLCipher.java", StartLine: 2, ReturnType: "void", Parameters: []callgraph.FunctionParameter{{Type: "int"}, {Type: "java.security.Key"}}},
+		finalID.String():   {ID: finalID, FilePath: "XMLCipher.java", StartLine: 3, ReturnType: "org.w3c.dom.Document", Parameters: []callgraph.FunctionParameter{{Type: "org.w3c.dom.Document"}, {Type: "org.w3c.dom.Element"}}},
+	}}
+	report := &entities.InterimReport{Findings: []entities.Finding{{
+		FilePath: "XmlCrypto.java",
+		Language: "java",
+		CryptographicAssets: []entities.CryptographicAsset{{
+			FindingID: "xmlcipher-aes-256",
+			StartLine: 3,
+			EndLine:   3,
+			Match:     "XMLCipher.getInstance(XMLCipher.AES_256_GCM)",
+			Rules:     []entities.RuleInfo{{ID: "java.santuario.xmlcipher"}},
+			Metadata:  map[string]string{"api": "wrong.on.purpose", "assetType": "algorithm"},
+		}},
+	}}}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: "java"})
+	if len(payload.CryptoAnnotations) != 1 {
+		t.Fatalf("crypto_annotations = %#v, want one finding", payload.CryptoAnnotations)
+	}
+
+	supportByName := map[string]string{}
+	for _, support := range payload.SupportingCalls {
+		if support.SupportingCall != nil {
+			supportByName[support.SupportingCall.FunctionName] = support.Category
+		}
+	}
+	if supportByName["org.apache.xml.security.encryption.XMLCipher.init"] != "config" {
+		t.Fatalf("XMLCipher.init category = %q, want config; supporting_calls = %#v", supportByName["org.apache.xml.security.encryption.XMLCipher.init"], payload.SupportingCalls)
+	}
+	if supportByName["org.apache.xml.security.encryption.XMLCipher.doFinal"] != "operation" {
+		t.Fatalf("XMLCipher.doFinal category = %q, want operation; supporting_calls = %#v", supportByName["org.apache.xml.security.encryption.XMLCipher.doFinal"], payload.SupportingCalls)
+	}
+	if len(payload.CryptoAnnotations[0].SupportingCallIDs) != 2 {
+		t.Fatalf("supporting_call_ids = %#v, want init and doFinal", payload.CryptoAnnotations[0].SupportingCallIDs)
+	}
+}
+
 // lastSegment returns the substring after the final dot, or the input unchanged.
 func lastSegment(s string) string {
 	if i := lastIndexByte(s, '.'); i >= 0 {


### PR DESCRIPTION
Closes #138

## Summary
- add version-pinned Bouncy Castle OpenPGP and Apache Santuario XMLCipher lifecycle contracts
- classify Tink keyset generation and AEAD encryption/decryption with lifecycle roles
- verify loader semantics and public graph-fragment supporting-call export behavior

## Contract inventory
- **Bouncy Castle OpenPGP 1.78.1:** contracted both data-encryptor builders, crypto-relevant configuration and output methods, key-material derivation, and encrypted-data-generator lifecycle methods. Source: `bcpg-jdk18on-1.78.1-sources.jar`.
- **Tink 1.13.0:** existing template and primitive inference remains covered; `KeysetHandle.generateNew`, `Aead.encrypt`, and `Aead.decrypt` now carry their lifecycle roles. Source: `tink-1.13.0-sources.jar`.
- **Apache Santuario XMLSec 4.0.3:** contracted all `XMLCipher` factory arities, initialization, and supported `doFinal` overloads. Source: `xmlsec-4.0.3-sources.jar`. Other XML encryption helpers are outside this ticket’s factory/finalization scope.

## Related
- `scanoss/crypto_rules#137` introduced the paired OpenPGP builder detections.

## Test plan
- [x] `GOCACHE=/tmp/crypto-finder-gocache go test ./...`
- [x] `git diff --check`
- [x] Added loader coverage for each library and graph-fragment coverage for XMLCipher lifecycle supporting calls