### PR TITLE
feat(callgraph): add Nimbus and Spring lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the version-pinned Nimbus JOSE JWE and Spring Security Crypto lifecycles, including factory, operation, output, hierarchy, and key-size parameter-role semantics. (#137)
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)

--- a/internal/callgraph/contracts/java/nimbus-jose-jwt.yaml
+++ b/internal/callgraph/contracts/java/nimbus-jose-jwt.yaml
@@ -5,7 +5,7 @@ library:
   name: nimbus-jose-jwt
   coordinates:
     - "com.nimbusds:nimbus-jose-jwt"
-  version_range: ">=9,<11"
+  version_range: "9.37.3"
   description: "Nimbus JOSE + JWT contracts for JWS construction, signing, verification, and compact serialization"
 
 contracts:
@@ -14,6 +14,7 @@ contracts:
     return:
       type: com.nimbusds.jose.JWSObject
       confidence: high
+    role: factory
   - method: com.nimbusds.jose.JWSObject.parse
     arity: 1
     return:
@@ -44,31 +45,85 @@ contracts:
     return:
       type: com.nimbusds.jose.crypto.DirectEncrypter
       confidence: high
+    role: factory
   - method: com.nimbusds.jose.crypto.DirectDecrypter.<init>
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.DirectDecrypter
       confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.DirectDecrypter.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.crypto.DirectDecrypter
+      confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.DirectDecrypter.<init>
+    arity: 3
+    return:
+      type: com.nimbusds.jose.crypto.DirectDecrypter
+      confidence: high
+    role: factory
   - method: com.nimbusds.jose.crypto.ECDHEncrypter.<init>
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.ECDHEncrypter
       confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.ECDHEncrypter.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.crypto.ECDHEncrypter
+      confidence: high
+    role: factory
   - method: com.nimbusds.jose.crypto.ECDHDecrypter.<init>
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.ECDHDecrypter
       confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.ECDHDecrypter.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.crypto.ECDHDecrypter
+      confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.ECDHDecrypter.<init>
+    arity: 3
+    return:
+      type: com.nimbusds.jose.crypto.ECDHDecrypter
+      confidence: high
+    role: factory
   - method: com.nimbusds.jose.crypto.RSAEncrypter.<init>
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.RSAEncrypter
       confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.RSAEncrypter.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.crypto.RSAEncrypter
+      confidence: high
+    role: factory
   - method: com.nimbusds.jose.crypto.RSADecrypter.<init>
     arity: 1
     return:
       type: com.nimbusds.jose.crypto.RSADecrypter
       confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.RSADecrypter.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.crypto.RSADecrypter
+      confidence: high
+    role: factory
+  - method: com.nimbusds.jose.crypto.RSADecrypter.<init>
+    arity: 3
+    return:
+      type: com.nimbusds.jose.crypto.RSADecrypter
+      confidence: high
+    role: factory
   - method: com.nimbusds.jose.crypto.RSASSASigner.<init>
     arity: 1
     return:
@@ -130,9 +185,91 @@ contracts:
       type: com.nimbusds.jose.jwk.RSAKey
       confidence: high
 
+  # JWE lifecycle contracts are authored on the public JWE interfaces. Concrete
+  # encrypters and decrypters resolve through hierarchy below, avoiding copies
+  # of the same operation for every key-management implementation.
+  - method: com.nimbusds.jose.JWEObject.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.JWEObject
+      confidence: high
+    role: factory
+  - method: com.nimbusds.jose.JWEObject.<init>
+    arity: 5
+    return:
+      type: com.nimbusds.jose.JWEObject
+      confidence: high
+    role: factory
+  - method: com.nimbusds.jose.JWEObject.parse
+    arity: 1
+    return:
+      type: com.nimbusds.jose.JWEObject
+      confidence: high
+    role: factory
+  - method: com.nimbusds.jose.JWEObject.encrypt
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: com.nimbusds.jose.JWEObject.decrypt
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: com.nimbusds.jose.JWEObject.serialize
+    arity: 0
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.nimbusds.jose.JWEEncrypter.encrypt
+    arity: 3
+    return:
+      type: com.nimbusds.jose.JWECryptoParts
+      confidence: high
+    role: operation
+  - method: com.nimbusds.jose.JWEDecrypter.decrypt
+    arity: 6
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: com.nimbusds.jose.jwk.gen.RSAKeyGenerator.<init>
+    arity: 1
+    return:
+      type: com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: keySize
+        role: metadata-contributing
+        contributes:
+          property: keySize
+          derivation: argument_value
+  - method: com.nimbusds.jose.jwk.gen.RSAKeyGenerator.<init>
+    arity: 2
+    return:
+      type: com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: keySize
+        role: metadata-contributing
+        contributes:
+          property: keySize
+          derivation: argument_value
+
 hierarchy:
   com.nimbusds.jose.JWSObject:
     - java.lang.Object
+  com.nimbusds.jose.JOSEObject:
+    - java.lang.Object
+  com.nimbusds.jose.JWEObject:
+    - com.nimbusds.jose.JOSEObject
   com.nimbusds.jose.Payload:
     - java.lang.Object
   com.nimbusds.jose.JWSSigner:
@@ -140,8 +277,12 @@ hierarchy:
   com.nimbusds.jose.JWSVerifier:
     - java.lang.Object
   com.nimbusds.jose.JWEEncrypter:
-    - java.lang.Object
+    - com.nimbusds.jose.JWEProvider
   com.nimbusds.jose.JWEDecrypter:
+    - com.nimbusds.jose.JWEProvider
+  com.nimbusds.jose.JWEProvider:
+    - java.lang.Object
+  com.nimbusds.jose.JWECryptoParts:
     - java.lang.Object
   com.nimbusds.jose.crypto.DirectEncrypter:
     - com.nimbusds.jose.JWEEncrypter
@@ -172,6 +313,8 @@ hierarchy:
   com.nimbusds.jose.crypto.MACVerifier:
     - com.nimbusds.jose.JWSVerifier
   com.nimbusds.jose.jwk.RSAKey:
+    - java.lang.Object
+  com.nimbusds.jose.jwk.gen.RSAKeyGenerator:
     - java.lang.Object
   com.nimbusds.jose.util.Base64URL:
     - java.lang.Object

--- a/internal/callgraph/contracts/java/spring-security-crypto.yaml
+++ b/internal/callgraph/contracts/java/spring-security-crypto.yaml
@@ -1,0 +1,164 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: spring-security-crypto
+  coordinates:
+    - "org.springframework.security:spring-security-crypto"
+  version_range: "6.3.4"
+  description: "Spring Security password encoders and encryption lifecycle contracts"
+
+contracts:
+  # PasswordEncoder is the shared operation surface. Concrete encoders resolve
+  # through hierarchy instead of repeating encode and matches per implementation.
+  - method: org.springframework.security.crypto.password.PasswordEncoder.encode
+    arity: 1
+    return: { type: java.lang.String, confidence: high }
+    role: operation
+  - method: org.springframework.security.crypto.password.PasswordEncoder.matches
+    arity: 2
+    return: { type: boolean, confidence: high }
+    role: operation
+  - method: org.springframework.security.crypto.password.PasswordEncoder.upgradeEncoding
+    arity: 1
+    return: { type: boolean, confidence: high }
+    role: output
+
+  - method: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.<init>
+    arity: 0
+    return: { type: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.<init>
+    arity: 1
+    return: { type: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.<init>
+    arity: 2
+    return: { type: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder.<init>
+    arity: 3
+    return: { type: org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.argon2.Argon2PasswordEncoder.<init>
+    arity: 5
+    return: { type: org.springframework.security.crypto.argon2.Argon2PasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.argon2.Argon2PasswordEncoder.defaultsForSpringSecurity_v5_2
+    arity: 0
+    return: { type: org.springframework.security.crypto.argon2.Argon2PasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.argon2.Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8
+    arity: 0
+    return: { type: org.springframework.security.crypto.argon2.Argon2PasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.scrypt.SCryptPasswordEncoder.<init>
+    arity: 5
+    return: { type: org.springframework.security.crypto.scrypt.SCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.scrypt.SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1
+    arity: 0
+    return: { type: org.springframework.security.crypto.scrypt.SCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.scrypt.SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8
+    arity: 0
+    return: { type: org.springframework.security.crypto.scrypt.SCryptPasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.password.Pbkdf2PasswordEncoder.<init>
+    arity: 4
+    return: { type: org.springframework.security.crypto.password.Pbkdf2PasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.password.Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_5
+    arity: 0
+    return: { type: org.springframework.security.crypto.password.Pbkdf2PasswordEncoder, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.password.Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_8
+    arity: 0
+    return: { type: org.springframework.security.crypto.password.Pbkdf2PasswordEncoder, confidence: high }
+    role: factory
+
+  - method: org.springframework.security.crypto.encrypt.Encryptors.standard
+    arity: 2
+    return: { type: org.springframework.security.crypto.encrypt.BytesEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.Encryptors.stronger
+    arity: 2
+    return: { type: org.springframework.security.crypto.encrypt.BytesEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.BytesEncryptor.encrypt
+    arity: 1
+    return: { type: "byte[]", confidence: high }
+    role: operation
+  - method: org.springframework.security.crypto.encrypt.BytesEncryptor.decrypt
+    arity: 1
+    return: { type: "byte[]", confidence: high }
+    role: operation
+  - method: org.springframework.security.crypto.encrypt.TextEncryptor.encrypt
+    arity: 1
+    return: { type: java.lang.String, confidence: high }
+    role: operation
+  - method: org.springframework.security.crypto.encrypt.TextEncryptor.decrypt
+    arity: 1
+    return: { type: java.lang.String, confidence: high }
+    role: operation
+
+  # RsaSecretEncryptor has overloaded constructors with different selector
+  # positions. Keep their common factory role, but do not guess a parameter role.
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 0
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 1
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 2
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 3
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 4
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 5
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>
+    arity: 6
+    return: { type: org.springframework.security.crypto.encrypt.RsaSecretEncryptor, confidence: high }
+    role: factory
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.getPublicKey
+    arity: 0
+    return: { type: java.lang.String, confidence: high }
+    role: output
+  - method: org.springframework.security.crypto.encrypt.RsaSecretEncryptor.canDecrypt
+    arity: 0
+    return: { type: boolean, confidence: high }
+    role: output
+
+hierarchy:
+  org.springframework.security.crypto.password.PasswordEncoder:
+    - java.lang.Object
+  org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder:
+    - org.springframework.security.crypto.password.PasswordEncoder
+  org.springframework.security.crypto.argon2.Argon2PasswordEncoder:
+    - org.springframework.security.crypto.password.PasswordEncoder
+  org.springframework.security.crypto.scrypt.SCryptPasswordEncoder:
+    - org.springframework.security.crypto.password.PasswordEncoder
+  org.springframework.security.crypto.password.Pbkdf2PasswordEncoder:
+    - org.springframework.security.crypto.password.PasswordEncoder
+  org.springframework.security.crypto.encrypt.BytesEncryptor:
+    - java.lang.Object
+  org.springframework.security.crypto.encrypt.TextEncryptor:
+    - java.lang.Object
+  org.springframework.security.crypto.encrypt.RsaSecretEncryptor:
+    - org.springframework.security.crypto.encrypt.BytesEncryptor
+    - org.springframework.security.crypto.encrypt.TextEncryptor
+  java.lang.String:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -167,3 +167,59 @@ func TestLoadEmbeddedJava_BouncyCastleRoleCoverage(t *testing.T) {
 		t.Fatalf("AESEngine hierarchy = %v, want [BlockCipher]", parents)
 	}
 }
+
+func TestLoadEmbeddedJava_NimbusAndSpringLifecycleCoverage(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+	}{
+		{"com.nimbusds.jose.JWEObject.<init>", 2, "com.nimbusds.jose.JWEObject", "factory"},
+		{"com.nimbusds.jose.JWEObject.encrypt", 1, "void", "operation"},
+		{"com.nimbusds.jose.JWEObject.decrypt", 1, "void", "operation"},
+		{"com.nimbusds.jose.JWEEncrypter.encrypt", 3, "com.nimbusds.jose.JWECryptoParts", "operation"},
+		{"com.nimbusds.jose.JWEDecrypter.decrypt", 6, "byte[]", "operation"},
+		{"com.nimbusds.jose.jwk.gen.RSAKeyGenerator.<init>", 1, "com.nimbusds.jose.jwk.gen.RSAKeyGenerator", "factory"},
+		{"org.springframework.security.crypto.password.PasswordEncoder.encode", 1, "java.lang.String", "operation"},
+		{"org.springframework.security.crypto.password.PasswordEncoder.matches", 2, "boolean", "operation"},
+		{"org.springframework.security.crypto.encrypt.Encryptors.stronger", 2, "org.springframework.security.crypto.encrypt.BytesEncryptor", "factory"},
+		{"org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>", 0, "org.springframework.security.crypto.encrypt.RsaSecretEncryptor", "factory"},
+		{"org.springframework.security.crypto.encrypt.BytesEncryptor.encrypt", 1, "byte[]", "operation"},
+		{"org.springframework.security.crypto.encrypt.BytesEncryptor.decrypt", 1, "byte[]", "operation"},
+		{"org.springframework.security.crypto.encrypt.TextEncryptor.encrypt", 1, "java.lang.String", "operation"},
+		{"org.springframework.security.crypto.encrypt.TextEncryptor.decrypt", 1, "java.lang.String", "operation"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q", tt.method, tt.arity, got[0], tt.want, tt.role)
+			}
+		})
+	}
+
+	rsaGenerator := kb.ContractsFor("com.nimbusds.jose.jwk.gen.RSAKeyGenerator.<init>", 1)
+	if len(rsaGenerator) != 1 || len(rsaGenerator[0].Parameters) != 1 {
+		t.Fatalf("RSAKeyGenerator.<init>#1 parameters = %#v, want key-size parameter role", rsaGenerator)
+	}
+	p := rsaGenerator[0].Parameters[0]
+	if p.Index == nil || *p.Index != 0 || p.Role != "metadata-contributing" || p.Contributes == nil || p.Contributes.Property != "keySize" || p.Contributes.Derivation != "argument_value" {
+		t.Fatalf("RSAKeyGenerator.<init>#1 parameters[0] = %#v, want index=0 keySize/argument_value", p)
+	}
+
+	if parents := kb.Hierarchy["org.springframework.security.crypto.encrypt.RsaSecretEncryptor"]; len(parents) != 2 || parents[0] != "org.springframework.security.crypto.encrypt.BytesEncryptor" || parents[1] != "org.springframework.security.crypto.encrypt.TextEncryptor" {
+		t.Fatalf("RsaSecretEncryptor hierarchy = %v, want BytesEncryptor and TextEncryptor", parents)
+	}
+}

--- a/internal/scan/spring_lifecycle_export_test.go
+++ b/internal/scan/spring_lifecycle_export_test.go
@@ -1,0 +1,73 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+)
+
+func TestBuildGraphFragmentExport_Issue137ExportsRsaSecretEncryptorOperations(t *testing.T) {
+	t.Parallel()
+
+	ownerID := callgraph.FunctionID{Package: "com.acme", Type: "Secrets", Name: "roundTrip#1"}
+	factoryID := callgraph.FunctionID{Package: "org.springframework.security.crypto.encrypt", Type: "RsaSecretEncryptor", Name: "<init>#0"}
+	encryptID := callgraph.FunctionID{Package: "org.springframework.security.crypto.encrypt", Type: "RsaSecretEncryptor", Name: "encrypt#1"}
+	decryptID := callgraph.FunctionID{Package: "org.springframework.security.crypto.encrypt", Type: "RsaSecretEncryptor", Name: "decrypt#1"}
+
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		ownerID.String(): {
+			ID:        ownerID,
+			FilePath:  "Secrets.java",
+			StartLine: 1,
+			EndLine:   8,
+			Calls: []callgraph.FunctionCall{
+				{Callee: factoryID, FilePath: "Secrets.java", Line: 3, Raw: "new RsaSecretEncryptor()", AssignedVar: "encryptor"},
+				{Callee: encryptID, FilePath: "Secrets.java", Line: 4, Raw: "encryptor.encrypt(plain)", ReceiverVar: "encryptor"},
+				{Callee: decryptID, FilePath: "Secrets.java", Line: 5, Raw: "encryptor.decrypt(ciphertext)", ReceiverVar: "encryptor"},
+			},
+		},
+		factoryID.String(): {ID: factoryID, FilePath: "RsaSecretEncryptor.java", StartLine: 1, ReturnType: "org.springframework.security.crypto.encrypt.RsaSecretEncryptor"},
+		encryptID.String(): {ID: encryptID, FilePath: "RsaSecretEncryptor.java", StartLine: 2, ReturnType: "java.lang.String", Parameters: []callgraph.FunctionParameter{{Type: "java.lang.String"}}},
+		decryptID.String(): {ID: decryptID, FilePath: "RsaSecretEncryptor.java", StartLine: 3, ReturnType: "java.lang.String", Parameters: []callgraph.FunctionParameter{{Type: "java.lang.String"}}},
+	}}
+	report := &entities.InterimReport{Findings: []entities.Finding{{
+		FilePath: "Secrets.java",
+		Language: "java",
+		CryptographicAssets: []entities.CryptographicAsset{{
+			FindingID: "rsa-secret-encryptor",
+			StartLine: 3,
+			EndLine:   3,
+			Match:     "new RsaSecretEncryptor()",
+			Rules:     []entities.RuleInfo{{ID: engine.SyntheticEntryPointRuleID}},
+			Metadata: map[string]string{
+				"api":       "org.springframework.security.crypto.encrypt.RsaSecretEncryptor.<init>",
+				"assetType": "algorithm",
+			},
+		}},
+	}}}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: "java"})
+	if len(payload.CryptoAnnotations) != 1 {
+		t.Fatalf("crypto_annotations = %#v, want one finding", payload.CryptoAnnotations)
+	}
+
+	operations := map[string]string{}
+	for _, support := range payload.SupportingCalls {
+		if support.SupportingCall != nil {
+			operations[support.SupportingCall.FunctionName] = support.Category
+		}
+	}
+	for _, name := range []string{
+		"org.springframework.security.crypto.encrypt.RsaSecretEncryptor.encrypt",
+		"org.springframework.security.crypto.encrypt.RsaSecretEncryptor.decrypt",
+	} {
+		if operations[name] != "operation" {
+			t.Fatalf("%s category = %q, want operation; supporting_calls = %#v", name, operations[name], payload.SupportingCalls)
+		}
+	}
+	if len(payload.CryptoAnnotations[0].SupportingCallIDs) < 2 {
+		t.Fatalf("supporting_call_ids = %#v, want encrypt and decrypt", payload.CryptoAnnotations[0].SupportingCallIDs)
+	}
+}


### PR DESCRIPTION
Closes #137

## Summary
- add version-pinned Nimbus JWE factory, operation, output, hierarchy, and RSA key-size contracts
- add Spring Security Crypto password-encoder and RSA encryptor lifecycle contracts
- prove role loading and exported RSA operation supporting calls

## API inventory
- **Nimbus JOSE+JWT 9.37.3**: contracted all public JWEObject constructors and lifecycle calls, JWE encrypter/decrypter interfaces, public Direct/RSA/ECDH constructor arities, and RSAKeyGenerator constructors. Existing JWS and JWK contracts remain covered.
- **Spring Security Crypto 6.3.4**: contracted current BCrypt, Argon2, SCrypt, and PBKDF2 encoder construction/factory APIs; PasswordEncoder operations; Encryptors.standard/stronger; BytesEncryptor/TextEncryptor operations; and all RsaSecretEncryptor constructor arities plus output accessors. The deprecated no-arg PBKDF2 rule shape is not modeled because it is absent from 6.3.4.
- Sources: version-pinned local API artifacts and official Javadocs for [Nimbus 9.37.3](https://javadoc.io/static/com.nimbusds/nimbus-jose-jwt/9.37.3/allclasses-index.html) and [Spring Security 6.3.4](https://docs.spring.io/spring-security/site/docs/6.3.4/api/).

## Verification
- `go test ./...`
- `go test ./internal/callgraph/contracts ./internal/scan -run "TestLoadEmbeddedJava_NimbusAndSpringLifecycleCoverage|TestBuildGraphFragmentExport_Issue137ExportsRsaSecretEncryptorOperations" -count=1`