### PR TITLE
feat(graphfrag): join hierarchy-compatible entry targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Graph-fragment exports now carry complete canonical target signatures and hierarchy-proven compatible callable signatures, allowing interface-typed dependency calls to join concrete crypto entry points without fabricating call edges. (#136)
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -34,6 +34,7 @@ const (
 	callGraphExportProgress  = 100
 	callGraphExportMaxDepth  = 32
 	callGraphExportMaxChains = 128
+	constructorMethodName    = "<init>"
 )
 
 // --- v4 JSON schema types (simplified) ---
@@ -2703,7 +2704,7 @@ func mergeExportParameterTypeRefs(existing []exportTypeRef, fallback []callgraph
 
 func normalizeExportReturnType(id callgraph.FunctionID, returnType string) string {
 	trimmed := strings.TrimSpace(returnType)
-	if callgraph.BaseFunctionName(id.Name) != "<init>" {
+	if callgraph.BaseFunctionName(id.Name) != constructorMethodName {
 		return trimmed
 	}
 	if trimmed != "" && trimmed != "void" {
@@ -2831,7 +2832,7 @@ func exportDisplaySymbolAndAliases(id callgraph.FunctionID, functionName string)
 }
 
 func constructorDisplaySymbol(id callgraph.FunctionID, fallback string) string {
-	if callgraph.BaseFunctionName(id.Name) != "<init>" {
+	if callgraph.BaseFunctionName(id.Name) != constructorMethodName {
 		return fallback
 	}
 	typeName := sanitizeSymbol(id.Type)

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -613,6 +613,9 @@ func buildFragmentExternalCall(
 		EndCol:               res.EndCol,
 	}
 	external.TargetFunctionName = fragmentTargetFunctionName(ctx, callerKey, callerDecl, calleeKey, &external)
+	if calleeID, err := callgraph.ParseFunctionID(calleeKey); err == nil {
+		external.TargetCanonicalSignature = buildExportFunctionMetadata(ctx.graph, calleeID, nil).CanonicalSignature
+	}
 	if call != nil {
 		external.Raw = call.Raw
 		external.ReceiverVar = call.ReceiverVar
@@ -1053,18 +1056,19 @@ func (ctx *exportBuildContext) callSignatureIndexForCaller(callerKey string, cal
 func buildGraphFragmentFunction(ctx *exportBuildContext, id callgraph.FunctionID, decl *callgraph.FunctionDecl) graphfrag.GraphFragmentFunction {
 	meta := buildExportFunctionMetadata(ctx.graph, id, decl)
 	fn := graphfrag.GraphFragmentFunction{
-		Key:                id.String(),
-		FunctionName:       meta.FunctionName,
-		CanonicalSignature: meta.CanonicalSignature,
-		Package:            id.Package,
-		Type:               id.Type,
-		Name:               id.Name,
-		ReturnType:         meta.ReturnType,
-		ParameterTypes:     meta.ParameterTypes,
-		Visibility:         meta.Visibility,
-		OwnerVisibility:    meta.OwnerVisibility,
-		DisplaySymbol:      meta.DisplaySymbol,
-		Aliases:            cloneStringSlice(meta.Aliases),
+		Key:                           id.String(),
+		FunctionName:                  meta.FunctionName,
+		CanonicalSignature:            meta.CanonicalSignature,
+		CompatibleCanonicalSignatures: compatibleCanonicalSignatures(ctx, id, decl),
+		Package:                       id.Package,
+		Type:                          id.Type,
+		Name:                          id.Name,
+		ReturnType:                    meta.ReturnType,
+		ParameterTypes:                meta.ParameterTypes,
+		Visibility:                    meta.Visibility,
+		OwnerVisibility:               meta.OwnerVisibility,
+		DisplaySymbol:                 meta.DisplaySymbol,
+		Aliases:                       cloneStringSlice(meta.Aliases),
 	}
 	if decl != nil {
 		fn.FilePath = normalizeExportPath(ctx, decl.FilePath).FilePath
@@ -1072,6 +1076,63 @@ func buildGraphFragmentFunction(ctx *exportBuildContext, id callgraph.FunctionID
 		fn.EndLine = decl.EndLine
 	}
 	return fn
+}
+
+// compatibleCanonicalSignatures emits only source-hierarchy-proven parent
+// callable signatures. The concrete declaration keeps its own canonical
+// signature; these are additional join keys for interface/override clients.
+func compatibleCanonicalSignatures(ctx *exportBuildContext, id callgraph.FunctionID, decl *callgraph.FunctionDecl) []string {
+	if ctx == nil || ctx.graph == nil || decl == nil || id.Package == "" || id.Type == "" {
+		return nil
+	}
+	method := callgraph.BaseFunctionName(id.Name)
+	if method == "" || method == constructorMethodName || method == "<clinit>" {
+		return nil
+	}
+	owner := id.Package + "." + id.Type
+	return compatibleParentSignatures(ctx, hierarchyAncestors(ctx.graph.TypeHierarchy, owner), method, len(decl.Parameters))
+}
+
+func hierarchyAncestors(hierarchy map[string][]string, owner string) []string {
+	seen := map[string]bool{owner: true}
+	pending := append([]string(nil), hierarchy[owner]...)
+	var ancestors []string
+	for len(pending) > 0 {
+		parent := pending[0]
+		pending = pending[1:]
+		if parent == "" || seen[parent] {
+			continue
+		}
+		seen[parent] = true
+		ancestors = append(ancestors, parent)
+		pending = append(pending, hierarchy[parent]...)
+	}
+	return ancestors
+}
+
+func compatibleParentSignatures(ctx *exportBuildContext, parents []string, method string, arity int) []string {
+	compatible := make(map[string]bool)
+	for _, parent := range parents {
+		for _, candidate := range ctx.declsByMethod[method] {
+			candidateID := candidate.decl.ID
+			if candidateID.Package+"."+candidateID.Type != parent || len(candidate.decl.Parameters) != arity {
+				continue
+			}
+			signature := buildExportFunctionMetadata(ctx.graph, candidateID, candidate.decl).CanonicalSignature
+			if signature != "" {
+				compatible[signature] = true
+			}
+		}
+	}
+	if len(compatible) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(compatible))
+	for signature := range compatible {
+		out = append(out, signature)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func buildGraphFragmentCryptoAnnotations(ctx *exportBuildContext, result *engine.DepScanResult) []graphfrag.GraphFragmentCryptoOp {

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -139,6 +139,45 @@ func TestBuildGraphFragmentExport_PreservesSupportingOverloadsAcrossRepeatedExpo
 	}
 }
 
+func TestBuildGraphFragmentExport_ExportsHierarchyCompatibleCanonicalSignatures(t *testing.T) {
+	t.Parallel()
+
+	interfaceID := callgraph.FunctionID{Package: "security", Type: "PasswordEncoder", Name: "encode#1"}
+	concreteID := callgraph.FunctionID{Package: "security", Type: "BCryptPasswordEncoder", Name: "encode#1"}
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			interfaceID.String(): {ID: interfaceID, Parameters: []callgraph.FunctionParameter{{Type: "CharSequence"}}, ReturnType: "String"},
+			concreteID.String():  {ID: concreteID, Parameters: []callgraph.FunctionParameter{{Type: "CharSequence"}}, ReturnType: "String"},
+		},
+		TypeHierarchy: map[string][]string{
+			"security.BCryptPasswordEncoder": {"security.PasswordEncoder"},
+		},
+	}
+
+	payload := BuildGraphFragmentExport(&engine.DepScanResult{CallGraph: graph, Ecosystem: "java"})
+	var concrete *graphfrag.GraphFragmentFunction
+	for i := range payload.Functions {
+		if payload.Functions[i].Key == concreteID.String() {
+			concrete = &payload.Functions[i]
+			break
+		}
+	}
+	if concrete == nil {
+		t.Fatalf("missing concrete function: %#v", payload.Functions)
+	}
+	want := "security.PasswordEncoder.encode(CharSequence): String"
+	found := false
+	for _, signature := range concrete.CompatibleCanonicalSignatures {
+		found = signature == want
+		if found {
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CompatibleCanonicalSignatures = %#v, want %q", concrete.CompatibleCanonicalSignatures, want)
+	}
+}
+
 func TestExportGraphFragment_WritesDecodableNoEscapeJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -171,22 +171,23 @@ type GraphFragmentScanMetadata struct {
 // GraphFragmentFunction is one function declaration included in a component's
 // graph-fragment export.
 type GraphFragmentFunction struct {
-	Key                string          `json:"key"`
-	FunctionName       string          `json:"function_name"`
-	CanonicalSignature string          `json:"canonical_signature,omitempty"`
-	Package            string          `json:"package,omitempty"`
-	Type               string          `json:"type,omitempty"`
-	Name               string          `json:"name,omitempty"`
-	FilePath           string          `json:"file_path,omitempty"`
-	StartLine          int             `json:"start_line,omitempty"`
-	EndLine            int             `json:"end_line,omitempty"`
-	ReturnType         string          `json:"return_type,omitempty"`
-	ParameterTypes     []string        `json:"parameter_types,omitempty"`
-	Visibility         string          `json:"visibility,omitempty"`
-	OwnerVisibility    string          `json:"owner_visibility,omitempty"`
-	DisplaySymbol      string          `json:"display_symbol,omitempty"`
-	Aliases            []string        `json:"aliases,omitempty"`
-	InferredReturn     json.RawMessage `json:"-"`
+	Key                           string          `json:"key"`
+	FunctionName                  string          `json:"function_name"`
+	CanonicalSignature            string          `json:"canonical_signature,omitempty"`
+	CompatibleCanonicalSignatures []string        `json:"compatible_canonical_signatures,omitempty"`
+	Package                       string          `json:"package,omitempty"`
+	Type                          string          `json:"type,omitempty"`
+	Name                          string          `json:"name,omitempty"`
+	FilePath                      string          `json:"file_path,omitempty"`
+	StartLine                     int             `json:"start_line,omitempty"`
+	EndLine                       int             `json:"end_line,omitempty"`
+	ReturnType                    string          `json:"return_type,omitempty"`
+	ParameterTypes                []string        `json:"parameter_types,omitempty"`
+	Visibility                    string          `json:"visibility,omitempty"`
+	OwnerVisibility               string          `json:"owner_visibility,omitempty"`
+	DisplaySymbol                 string          `json:"display_symbol,omitempty"`
+	Aliases                       []string        `json:"aliases,omitempty"`
+	InferredReturn                json.RawMessage `json:"-"`
 }
 
 // GraphFragmentCallSite carries the per-edge call-site invocation detail: the
@@ -352,15 +353,16 @@ type GraphFragmentEdge struct {
 // GraphFragmentExternal is one external (cross-component) call edge plus its
 // resolution metadata.
 type GraphFragmentExternal struct {
-	CallerKey          string `json:"caller_key"`
-	TargetKey          string `json:"target_key"`
-	TargetFunctionName string `json:"target_function_name,omitempty"`
-	Raw                string `json:"raw,omitempty"`
-	Line               int    `json:"line,omitempty"`
-	Resolution         string `json:"resolution"`
-	DeclaredType       string `json:"declared_type,omitempty"`
-	MethodName         string `json:"method_name,omitempty"`
-	Arity              int    `json:"arity,omitempty"`
+	CallerKey                string `json:"caller_key"`
+	TargetKey                string `json:"target_key"`
+	TargetFunctionName       string `json:"target_function_name,omitempty"`
+	TargetCanonicalSignature string `json:"target_canonical_signature,omitempty"`
+	Raw                      string `json:"raw,omitempty"`
+	Line                     int    `json:"line,omitempty"`
+	Resolution               string `json:"resolution"`
+	DeclaredType             string `json:"declared_type,omitempty"`
+	MethodName               string `json:"method_name,omitempty"`
+	Arity                    int    `json:"arity,omitempty"`
 	// ReceiverVar/AssignedVar/ChainID carry the call-site object identity (1.4+)
 	// for cache-side object-lifecycle re-derivation. Empty on schema < 1.4.
 	ReceiverVar string `json:"receiver_var,omitempty"`

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -41,19 +41,20 @@ func appendFragmentFunctions(frag *Fragment, functions []GraphFragmentFunction) 
 	for i := range functions {
 		fn := &functions[i]
 		frag.Functions = append(frag.Functions, Function{
-			Signature:          fn.Key,
-			FunctionName:       fn.FunctionName,
-			DeclaringType:      fn.Type,
-			CanonicalSignature: fn.CanonicalSignature,
-			ReturnType:         fn.ReturnType,
-			ParameterTypes:     fn.ParameterTypes,
-			Visibility:         fn.Visibility,
-			OwnerVisibility:    fn.OwnerVisibility,
-			StartLine:          fn.StartLine,
-			EndLine:            fn.EndLine,
-			FilePath:           fn.FilePath,
-			DisplaySymbol:      fn.DisplaySymbol,
-			Aliases:            append([]string(nil), fn.Aliases...),
+			Signature:                     fn.Key,
+			FunctionName:                  fn.FunctionName,
+			DeclaringType:                 fn.Type,
+			CanonicalSignature:            fn.CanonicalSignature,
+			CompatibleCanonicalSignatures: append([]string(nil), fn.CompatibleCanonicalSignatures...),
+			ReturnType:                    fn.ReturnType,
+			ParameterTypes:                fn.ParameterTypes,
+			Visibility:                    fn.Visibility,
+			OwnerVisibility:               fn.OwnerVisibility,
+			StartLine:                     fn.StartLine,
+			EndLine:                       fn.EndLine,
+			FilePath:                      fn.FilePath,
+			DisplaySymbol:                 fn.DisplaySymbol,
+			Aliases:                       append([]string(nil), fn.Aliases...),
 		})
 	}
 }
@@ -119,21 +120,22 @@ func appendExternalCalls(frag *Fragment, calls []GraphFragmentExternal) {
 	for i := range calls {
 		ec := &calls[i]
 		frag.ExternalCalls = append(frag.ExternalCalls, ExternalCall{
-			Caller:               ec.CallerKey,
-			TargetSignature:      ec.TargetKey,
-			Raw:                  ec.Raw,
-			Resolution:           normalizeResolutionKind(ec.Resolution),
-			DeclaredType:         ec.DeclaredType,
-			MethodName:           ec.MethodName,
-			Arity:                ec.Arity,
-			CallSite:             ec.Line,
-			ReceiverVar:          ec.ReceiverVar,
-			AssignedVar:          ec.AssignedVar,
-			ChainID:              ec.ChainID,
-			StartCol:             ec.StartCol,
-			EndCol:               ec.EndCol,
-			EntryCall:            toCallSite(ec.EntryCall),
-			ResolvedReceiverType: ec.ResolvedReceiverType,
+			Caller:                   ec.CallerKey,
+			TargetSignature:          ec.TargetKey,
+			TargetCanonicalSignature: ec.TargetCanonicalSignature,
+			Raw:                      ec.Raw,
+			Resolution:               normalizeResolutionKind(ec.Resolution),
+			DeclaredType:             ec.DeclaredType,
+			MethodName:               ec.MethodName,
+			Arity:                    ec.Arity,
+			CallSite:                 ec.Line,
+			ReceiverVar:              ec.ReceiverVar,
+			AssignedVar:              ec.AssignedVar,
+			ChainID:                  ec.ChainID,
+			StartCol:                 ec.StartCol,
+			EndCol:                   ec.EndCol,
+			EntryCall:                toCallSite(ec.EntryCall),
+			ResolvedReceiverType:     ec.ResolvedReceiverType,
 		})
 	}
 }

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -85,6 +85,9 @@ type Function struct {
 	DeclaringType string
 	// CanonicalSignature is the canonical function signature (1.2+).
 	CanonicalSignature string
+	// CompatibleCanonicalSignatures are hierarchy-proven inherited or override
+	// identities that resolve to this declaration.
+	CompatibleCanonicalSignatures []string
 	// ReturnType is the declared return type (1.2+).
 	ReturnType string
 	// ParameterTypes lists the declared parameter types in order (1.2+).
@@ -338,6 +341,8 @@ const (
 type ExternalCall struct {
 	Caller          string
 	TargetSignature string
+	// TargetCanonicalSignature is the complete callable join key when known.
+	TargetCanonicalSignature string
 
 	// Raw is the source call expression (e.g. "gen.init"). Carried so the
 	// annotate path can reproduce a supporting call's matched_operation.expression

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -123,9 +123,9 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		return nil, &ErrMissingFragment{Components: missing}
 	}
 
-	functionsBySignature := indexFunctions(closure, fragments)
+	functionsBySignature, functionsByCanonicalSignature := indexFunctions(closure, fragments)
 	functionsByNode := indexFunctionsByNode(closure, fragments)
-	adjacency, suppressed := buildAdjacency(closure, deps, fragments, functionsBySignature, functionsByNode)
+	adjacency, suppressed := buildAdjacency(closure, deps, fragments, functionsBySignature, functionsByCanonicalSignature, functionsByNode)
 	opsByNode := indexCryptoOperations(closure, fragments)
 	supportingByNode := indexSupportingCalls(closure, fragments)
 
@@ -324,16 +324,26 @@ func missingFragments(closure []ComponentKey, fragments map[ComponentKey]Fragmen
 	return missing
 }
 
-func indexFunctions(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[string][]graphNode {
-	out := make(map[string][]graphNode)
+func indexFunctions(closure []ComponentKey, fragments map[ComponentKey]Fragment) (map[string][]graphNode, map[string][]graphNode) {
+	byKey := make(map[string][]graphNode)
+	byCanonicalSignature := make(map[string][]graphNode)
 	for _, key := range closure {
 		fragment := fragments[key]
 		for i := range fragment.Functions {
 			node := graphNode{Component: key, Function: fragment.Functions[i].Signature}
-			out[fragment.Functions[i].Signature] = append(out[fragment.Functions[i].Signature], node)
+			fn := fragment.Functions[i]
+			byKey[fn.Signature] = append(byKey[fn.Signature], node)
+			if fn.CanonicalSignature != "" {
+				byCanonicalSignature[fn.CanonicalSignature] = append(byCanonicalSignature[fn.CanonicalSignature], node)
+			}
+			for _, compatible := range fn.CompatibleCanonicalSignatures {
+				if compatible != "" {
+					byCanonicalSignature[compatible] = append(byCanonicalSignature[compatible], node)
+				}
+			}
 		}
 	}
-	return out
+	return byKey, byCanonicalSignature
 }
 
 func indexFunctionsByNode(closure []ComponentKey, fragments map[ComponentKey]Fragment) map[graphNode]Function {
@@ -368,17 +378,18 @@ type dispatchGroupKey struct {
 // call site whose implementations straddle the component boundary must be judged
 // as one group, not two.
 type callEdge struct {
-	caller               string
-	target               string
-	resolution           ResolutionKind
-	method               string
-	arity                int
-	callSite             int
-	startCol             int
-	endCol               int
-	internal             bool
-	entryCall            *CallSite
-	resolvedReceiverType string
+	caller                   string
+	target                   string
+	targetCanonicalSignature string
+	resolution               ResolutionKind
+	method                   string
+	arity                    int
+	callSite                 int
+	startCol                 int
+	endCol                   int
+	internal                 bool
+	entryCall                *CallSite
+	resolvedReceiverType     string
 }
 
 // buildAdjacency composes the traversable call graph from the fragment closure
@@ -398,6 +409,7 @@ func buildAdjacency(
 	deps DependencyGraph,
 	fragments map[ComponentKey]Fragment,
 	functionsBySignature map[string][]graphNode,
+	functionsByCanonicalSignature map[string][]graphNode,
 	functionsByNode map[graphNode]Function,
 ) (map[graphNode][]adjacencyEdge, []SuppressedEdge) {
 	out := make(map[graphNode][]adjacencyEdge)
@@ -408,7 +420,7 @@ func buildAdjacency(
 		fragment := fragments[key]
 		componentSigs := indexComponentSignatures(key, fragment, out)
 		edges := collectCallEdges(fragment)
-		resolve := callEdgeResolver(key, componentSigs, componentSet(deps[key]), functionsBySignature)
+		resolve := callEdgeResolver(key, componentSigs, componentSet(deps[key]), functionsBySignature, functionsByCanonicalSignature)
 
 		dispatchGroups := applyImmediateEdgePolicy(key, edges, resolve, out, &suppressed)
 		applyDispatchGroups(key, dispatchGroups, resolve, ownerTypes, fragments, functionsByNode, out, &suppressed)
@@ -482,7 +494,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 	for i := range fragment.ExternalCalls {
 		c := &fragment.ExternalCalls[i]
 		edges = append(edges, callEdge{
-			caller: c.Caller, target: c.TargetSignature, resolution: c.Resolution,
+			caller: c.Caller, target: c.TargetSignature, targetCanonicalSignature: c.TargetCanonicalSignature, resolution: c.Resolution,
 			method: c.MethodName, arity: c.Arity, callSite: c.CallSite, startCol: c.StartCol, endCol: c.EndCol, internal: false, entryCall: c.EntryCall,
 			resolvedReceiverType: c.ResolvedReceiverType,
 		})
@@ -490,7 +502,12 @@ func collectCallEdges(fragment Fragment) []callEdge {
 	return edges
 }
 
-type edgeResolver func(callEdge) []graphNode
+type edgeTargets struct {
+	nodes         []graphNode
+	compatibility bool
+}
+
+type edgeResolver func(callEdge) edgeTargets
 
 // callEdgeResolver maps one edge to the concrete target nodes it could reach.
 // Internal edges resolve within the component; external edges resolve to other
@@ -500,23 +517,26 @@ func callEdgeResolver(
 	componentSigs map[string]bool,
 	directDeps map[ComponentKey]bool,
 	functionsBySignature map[string][]graphNode,
+	functionsByCanonicalSignature map[string][]graphNode,
 ) edgeResolver {
-	return func(e callEdge) []graphNode {
+	return func(e callEdge) edgeTargets {
 		if e.internal {
 			if componentSigs[e.target] {
-				return []graphNode{{Component: key, Function: e.target}}
+				return edgeTargets{nodes: []graphNode{{Component: key, Function: e.target}}}
 			}
-			return nil
+			return edgeTargets{}
 		}
-		return externalTargets(e.target, directDeps, functionsBySignature)
+		return externalTargets(e.target, e.targetCanonicalSignature, directDeps, functionsBySignature, functionsByCanonicalSignature)
 	}
 }
 
 func externalTargets(
 	target string,
+	targetCanonicalSignature string,
 	directDeps map[ComponentKey]bool,
 	functionsBySignature map[string][]graphNode,
-) []graphNode {
+	functionsByCanonicalSignature map[string][]graphNode,
+) edgeTargets {
 	var targets []graphNode
 	for _, callee := range functionsBySignature[target] {
 		if !directDeps[callee.Component] {
@@ -524,7 +544,15 @@ func externalTargets(
 		}
 		targets = append(targets, callee)
 	}
-	return targets
+	if len(targets) > 0 || targetCanonicalSignature == "" {
+		return edgeTargets{nodes: targets}
+	}
+	for _, callee := range functionsByCanonicalSignature[targetCanonicalSignature] {
+		if directDeps[callee.Component] {
+			targets = append(targets, callee)
+		}
+	}
+	return edgeTargets{nodes: targets, compatibility: true}
 }
 
 func applyImmediateEdgePolicy(
@@ -541,18 +569,24 @@ func applyImmediateEdgePolicy(
 	for i := range edges {
 		e := &edges[i]
 		caller := graphNode{Component: key, Function: e.caller}
+		targets := resolve(*e)
 		switch e.resolution {
 		case ResolutionExact:
-			appendAdjacencyEdges(adjacency, caller, resolve(*e), e.entryCall)
+			if targets.compatibility && len(targets.nodes) > 1 {
+				gk := dispatchKey(key, *e)
+				dispatchGroups[gk] = append(dispatchGroups[gk], *e)
+				continue
+			}
+			appendAdjacencyEdges(adjacency, caller, targets.nodes, e.entryCall)
 		case ResolutionInterfaceDispatch:
 			gk := dispatchKey(key, *e)
 			dispatchGroups[gk] = append(dispatchGroups[gk], *e)
 		case ResolutionNameOnly:
-			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonNameOnly, candidateComponents(resolve(*e))))
+			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonNameOnly, candidateComponents(targets.nodes)))
 		case ResolutionUnknown:
-			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonUnknown, candidateComponents(resolve(*e))))
+			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonUnknown, candidateComponents(targets.nodes)))
 		default: // Future unhandled kind: fail closed.
-			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonUnknown, candidateComponents(resolve(*e))))
+			*suppressed = append(*suppressed, suppressedEdge(key, *e, SuppressReasonUnknown, candidateComponents(targets.nodes)))
 		}
 	}
 	return dispatchGroups
@@ -679,7 +713,7 @@ func distinctTargetEdges(edges []callEdge, resolve edgeResolver) []adjacencyEdge
 	var targets []adjacencyEdge
 	for i := range edges {
 		e := &edges[i]
-		for _, t := range resolve(*e) {
+		for _, t := range resolve(*e).nodes {
 			if distinct[t] {
 				continue
 			}

--- a/pkg/graphfrag/stitch_resolution_test.go
+++ b/pkg/graphfrag/stitch_resolution_test.go
@@ -151,6 +151,62 @@ func TestStitch_InterfaceDispatchUniqueImplReaches(t *testing.T) {
 	}
 }
 
+func TestStitch_InterfaceDispatchJoinsConcreteEntryByCanonicalCompatibility(t *testing.T) {
+	fragments := map[ComponentKey]Fragment{
+		componentA: {
+			Component: componentA,
+			Functions: []Function{{Signature: "app.Client.call#0"}},
+			ExternalCalls: []ExternalCall{{
+				Caller:                   "app.Client.call#0",
+				TargetSignature:          "security.PasswordEncoder.encode#1",
+				TargetCanonicalSignature: "security.PasswordEncoder.encode(CharSequence): String",
+				Resolution:               ResolutionExact,
+				DeclaredType:             "security.PasswordEncoder",
+				MethodName:               "encode",
+				Arity:                    1,
+				CallSite:                 7,
+			}},
+		},
+		componentC: {
+			Component: componentC,
+			Functions: []Function{{
+				Signature:                     "security.BCryptPasswordEncoder.encode#1",
+				CanonicalSignature:            "security.BCryptPasswordEncoder.encode(CharSequence): String",
+				CompatibleCanonicalSignatures: []string{"security.PasswordEncoder.encode(CharSequence): String"},
+			}},
+			CryptoOperations: []CryptoOperation{{Function: "security.BCryptPasswordEncoder.encode#1", FindingID: "compatible-interface"}},
+		},
+	}
+
+	res, err := Stitch(componentA, DependencyGraph{componentA: {componentC}}, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 1 || res.Chains[0].FindingID != "compatible-interface" {
+		t.Fatalf("chains = %#v, want compatible concrete interface target", res.Chains)
+	}
+}
+
+func TestStitch_CanonicalCompatibilityCandidatesFailClosed(t *testing.T) {
+	const compatible = "security.PasswordEncoder.encode(CharSequence): String"
+	fragments := map[ComponentKey]Fragment{
+		componentA: {Component: componentA, Functions: []Function{{Signature: "app.Client.call#0"}}, ExternalCalls: []ExternalCall{{
+			Caller: "app.Client.call#0", TargetSignature: "security.PasswordEncoder.encode#1", TargetCanonicalSignature: compatible,
+			Resolution: ResolutionExact, MethodName: "encode", Arity: 1, CallSite: 7,
+		}}},
+		componentC: {Component: componentC, Functions: []Function{{Signature: "security.BCryptPasswordEncoder.encode#1", CompatibleCanonicalSignatures: []string{compatible}}}, CryptoOperations: []CryptoOperation{{Function: "security.BCryptPasswordEncoder.encode#1", FindingID: "bcrypt"}}},
+		componentE: {Component: componentE, Functions: []Function{{Signature: "security.Argon2PasswordEncoder.encode#1", CompatibleCanonicalSignatures: []string{compatible}}}, CryptoOperations: []CryptoOperation{{Function: "security.Argon2PasswordEncoder.encode#1", FindingID: "argon2"}}},
+	}
+
+	res, err := Stitch(componentA, DependencyGraph{componentA: {componentC, componentE}}, fragments)
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if len(res.Chains) != 0 || len(res.Suppressed) != 1 || res.Suppressed[0].Reason != SuppressReasonAmbiguousDispatch {
+		t.Fatalf("chains=%#v suppressed=%#v, want one fail-closed compatibility ambiguity", res.Chains, res.Suppressed)
+	}
+}
+
 // TestStitch_InterfaceDispatchAmbiguousDropsClosed proves that when more than
 // one concrete implementation of the dispatched interface method is present in
 // the closure, the stitcher refuses to guess: it drops the whole call site and


### PR DESCRIPTION
Closes #136

## Summary
- Export canonical external call targets and hierarchy-proven compatible signatures for concrete overrides.
- Join a unique compatible dependency target during stitching.
- Preserve fail-closed behavior when compatibility identifies multiple implementations.

## Verification
- [x] `GOCACHE=/tmp/crypto-finder-issue-136-gocache go test ./pkg/graphfrag ./internal/scan`
- [x] `git diff --check`
