### PR TITLE
feat(callgraph): wire Go contract resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ internal/callgraph/contracts/
 ├── contracts.go           # loader, types, validation
 ├── java/
 │   └── jdk-crypto.yaml    # JDK JCA/JCE contracts (shipped in v1)
-├── go/                    # future: stdlib + x/crypto + ...
+├── go/                    # schema-v2 Go callgraph contracts
 ├── python/                # pyca-cryptography, pycryptodome, pycryptodomex, paramiko
 └── rust/                  # schema-v2 Rust callgraph contracts
 ```
@@ -99,6 +99,9 @@ To add a library:
 2. Set `schema_version: "2"`, `ecosystem: <name>`, and a unique `library.name`.
 3. Author contracts and hierarchy edges following the same shape as `jdk-crypto.yaml`.
 4. Tests run automatically — no Go code changes required.
+
+Go contract method names use the canonical `FunctionID.String()` form:
+`package/path.Function` or `package/path.(*Receiver).Method`.
 
 ## Detection vs reachability (rules, supporting calls, new languages)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
+- Go callgraph builds now load schema-v2 contract knowledge bases and select the Go contract type resolver. (#75)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)
 - Callgraph schema `6.6` adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch, including completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance without promoting candidates to resolved edges. (#122)
 - C callgraph parsing now extracts include paths, function declarations, call sites, assignment targets, and 1-based half-open call columns for reachability analysis. (#67)

--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -23,7 +23,12 @@ var pythonFS embed.FS
 //go:embed rust/*.yaml
 var rustFS embed.FS
 
+//go:embed go/*.yaml
+var goFS embed.FS
+
 const (
+	// ecosystemGo is the ecosystem identifier for the Go contract KB.
+	ecosystemGo = "go"
 	// ecosystemPython is the ecosystem identifier for the Python contract KB.
 	ecosystemPython = "python"
 	// ecosystemRust is the ecosystem identifier for the Rust contract KB.
@@ -459,6 +464,8 @@ func embedFSFor(ecosystem string) (fs.FS, string) {
 	switch ecosystem {
 	case "java":
 		return &javaFS, "java"
+	case ecosystemGo:
+		return &goFS, ecosystemGo
 	case ecosystemPython:
 		return &pythonFS, ecosystemPython
 	case ecosystemRust:

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -687,6 +687,16 @@ func TestLoadEmbedded_Rust(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_Go(t *testing.T) {
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(\"go\"): %v", err)
+	}
+	if kb.Ecosystem != "go" {
+		t.Fatalf("Ecosystem = %q, want go", kb.Ecosystem)
+	}
+}
+
 // TestContractsFor_ReturnsCorrectSlice
 // kb.ContractsFor("javax.crypto.Cipher.unwrap", 3) returns 3 conditional entries.
 func TestContractsFor_ReturnsCorrectSlice(t *testing.T) {

--- a/internal/callgraph/contracts/go/bootstrap.yaml
+++ b/internal/callgraph/contracts/go/bootstrap.yaml
@@ -1,0 +1,9 @@
+schema_version: "2"
+ecosystem: go
+# ponytail: go:embed needs one YAML match; remove this file when the first Go library KB lands.
+library:
+  name: go-bootstrap
+  description: "Bootstrap for embedded Go callgraph contracts"
+
+contracts: []
+hierarchy: {}

--- a/internal/callgraph/go_type_resolver.go
+++ b/internal/callgraph/go_type_resolver.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import "github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+
+// GoContractTypeResolver applies return types from the Go contracts KB.
+type GoContractTypeResolver struct {
+	kb *contracts.KnowledgeBase
+}
+
+// NewGoContractTypeResolver creates a resolver backed by the supplied KB.
+func NewGoContractTypeResolver(kb *contracts.KnowledgeBase) *GoContractTypeResolver {
+	return &GoContractTypeResolver{kb: kb}
+}
+
+// NewGoContractTypeResolverFromEmbedded loads the embedded Go KB. Contract
+// load failures degrade to a no-op resolver.
+func NewGoContractTypeResolverFromEmbedded() *GoContractTypeResolver {
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		return NewGoContractTypeResolver(nil)
+	}
+	return NewGoContractTypeResolver(kb)
+}
+
+// ResolveTypes fills missing declaration return types from unconditional contracts.
+func (r *GoContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) error {
+	if r.kb == nil || len(r.kb.Contracts) == 0 {
+		return nil
+	}
+	for _, fn := range graph.Functions {
+		if fn.ReturnType != "" {
+			continue
+		}
+		for _, contract := range r.kb.ContractsForTolerant(fn.ID.String(), len(fn.Parameters)) {
+			if contract.When == nil && contract.Return.Type != "" {
+				fn.ReturnType = contract.Return.Type
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/callgraph/go_type_resolver_test.go
+++ b/internal/callgraph/go_type_resolver_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestGoContractTypeResolver_UsesCanonicalFunctionIDs(t *testing.T) {
+	kb, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: go
+library:
+  name: test-go
+contracts:
+  - method: crypto/aes.NewCipher
+    arity: 1
+    return:
+      type: crypto/cipher.Block
+      confidence: high
+  - method: crypto/aes.(*Block).Encrypt
+    arity: 2
+    return:
+      type: "[]byte"
+      confidence: high
+`))
+	if err != nil {
+		t.Fatalf("load test KB: %v", err)
+	}
+	newCipher := &FunctionDecl{
+		ID:         FunctionID{Package: "crypto/aes", Name: "NewCipher"},
+		Parameters: []FunctionParameter{{Type: "[]byte"}},
+	}
+	encrypt := &FunctionDecl{
+		ID:         FunctionID{Package: "crypto/aes", Type: "*Block", Name: "Encrypt"},
+		Parameters: []FunctionParameter{{Type: "[]byte"}, {Type: "[]byte"}},
+	}
+
+	if err := NewGoContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(newCipher, encrypt), nil); err != nil {
+		t.Fatalf("ResolveTypes: %v", err)
+	}
+	if newCipher.ReturnType != "crypto/cipher.Block" {
+		t.Fatalf("NewCipher ReturnType = %q, want crypto/cipher.Block", newCipher.ReturnType)
+	}
+	if encrypt.ReturnType != "[]byte" {
+		t.Fatalf("Encrypt ReturnType = %q, want []byte", encrypt.ReturnType)
+	}
+
+	newCipher.ReturnType = "existing.Type"
+	if err := NewGoContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(newCipher), nil); err != nil {
+		t.Fatalf("ResolveTypes with existing return type: %v", err)
+	}
+	if newCipher.ReturnType != "existing.Type" {
+		t.Fatalf("existing ReturnType was overwritten: %q", newCipher.ReturnType)
+	}
+}

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -27,6 +27,8 @@ func NewParserForEcosystem(ecosystem string, opts ...ParserOption) Parser {
 // Returns nil if no type resolver is available (tree-sitter-only resolution).
 func NewTypeResolverForEcosystem(ecosystem string, javaRuntime javaruntime.Config) TypeResolver {
 	switch ecosystem {
+	case "go":
+		return NewGoContractTypeResolverFromEmbedded()
 	case "java":
 		return NewJavaBytecodeTypeResolver(javaRuntime)
 	case "python":

--- a/internal/callgraph/parser_registry_extra_test.go
+++ b/internal/callgraph/parser_registry_extra_test.go
@@ -84,7 +84,7 @@ func TestNewTypeResolverForEcosystem(t *testing.T) {
 	if resolver := NewTypeResolverForEcosystem("java", javaruntime.Config{}); resolver == nil {
 		t.Fatal("expected Java type resolver")
 	}
-	if resolver := NewTypeResolverForEcosystem("go", javaruntime.Config{}); resolver != nil {
-		t.Fatalf("expected nil type resolver for go, got %#v", resolver)
+	if _, ok := NewTypeResolverForEcosystem("go", javaruntime.Config{}).(*GoContractTypeResolver); !ok {
+		t.Fatal("expected GoContractTypeResolver")
 	}
 }


### PR DESCRIPTION
Closes #75

## Summary
- Load embedded schema-v2 Go contract knowledge bases.
- Select a Go contract resolver that uses canonical Go function identifiers.
- Document the Go KB key convention and cover loader/resolver selection.

## Verification
- `go test ./internal/callgraph/contracts/... ./internal/callgraph/...`
- `go test ./...`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Go callgraph builds now load schema-v2 contract knowledge bases.
  * Added support for resolving missing Go function and method return types from embedded contract data.
  * Go methods now use canonical function identifiers for contract matching.

* **Documentation**
  * Updated contributor guidance and the unreleased changelog with Go contract support details.

* **Tests**
  * Added coverage for Go contract loading, resolver selection, canonical method identifiers, and preserving existing return types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->