### PR TITLE
feat(callgraph): add C++ parser foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C++ callgraph parsing now recognizes C++ source and header files, include paths, namespace-qualified and receiver calls, assignment targets, and 1-based half-open call columns. (#68)
 - Graph-fragment exports now carry complete canonical target signatures and hierarchy-proven compatible callable signatures, allowing interface-typed dependency calls to join concrete crypto entry points without fabricating call edges. (#136)
 - Java callgraph contracts now model the version-pinned Nimbus JOSE JWE and Spring Security Crypto lifecycles, including factory, operation, output, hierarchy, and key-size parameter-role semantics. (#137)
 - Java callgraph lifecycle contracts now cover Bouncy Castle OpenPGP builders, Tink AEAD operations, and Apache Santuario XMLCipher factories and finalization. (#138)

--- a/internal/callgraph/c_parser.go
+++ b/internal/callgraph/c_parser.go
@@ -249,7 +249,7 @@ func (p *CParser) parseCall(node *sitter.Node, src []byte, filePath, packagePath
 	case cNodeIdentifier:
 		call.Callee.Name = function.Content(src)
 		call.Callee.Package = cFunctionPackage(packagePath, filePath, call.Callee.Name, staticFunctions)
-	case "field_expression":
+	case fieldExpressionNode:
 		field := function.ChildByFieldName("field")
 		argument := function.ChildByFieldName("argument")
 		if field == nil {

--- a/internal/callgraph/cpp_parser.go
+++ b/internal/callgraph/cpp_parser.go
@@ -1,0 +1,232 @@
+package callgraph
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	sitter "github.com/smacker/go-tree-sitter"
+	treecpp "github.com/smacker/go-tree-sitter/cpp"
+)
+
+const cppNodeFunctionDefinition = "function_definition"
+
+// CPPParser extracts C++ function declarations, calls, and include paths.
+type CPPParser struct {
+	parser       *sitter.Parser
+	includeTests bool
+}
+
+// NewCPPParser creates a C++ source parser backed by tree-sitter.
+func NewCPPParser(opts ...ParserOption) *CPPParser {
+	cfg := newParserConfig(opts)
+	parser := sitter.NewParser()
+	parser.SetLanguage(treecpp.GetLanguage())
+	return &CPPParser{parser: parser, includeTests: cfg.includeTests}
+}
+
+// CloneParser returns an independent parser for concurrent use.
+func (p *CPPParser) CloneParser() Parser {
+	return NewCPPParser(WithIncludeTests(p.includeTests))
+}
+
+// ParseDirectory parses C++ source and header files directly under dir.
+func (p *CPPParser) ParseDirectory(dir, packagePath string) ([]*FileAnalysis, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("callgraph: cpp parser: read directory %s: %w", dir, err)
+	}
+
+	analyses := make([]*FileAnalysis, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !isCPPFile(entry.Name()) || (!p.includeTests && strings.Contains(strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())), "_test")) {
+			continue
+		}
+		filePath := filepath.Join(dir, entry.Name())
+		analysis, err := p.parseFile(filePath, packagePath)
+		if err != nil {
+			log.Error().Err(err).Str("file", filePath).Str("package", packagePath).Msg("failed to parse file")
+			continue
+		}
+		analyses = append(analyses, analysis)
+	}
+	return analyses, nil
+}
+
+func isCPPFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".cc", ".cp", ".cpp", ".cxx", ".c++", ".h", ".hh", ".hpp", ".hxx", ".h++":
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *CPPParser) parseFile(filePath, packagePath string) (*FileAnalysis, error) {
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("callgraph: cpp parser: read %s: %w", filePath, err)
+	}
+	tree, err := p.parser.ParseCtx(context.TODO(), nil, src)
+	if err != nil {
+		return nil, fmt.Errorf("callgraph: cpp parser: parse %s: %w", filePath, err)
+	}
+	defer tree.Close()
+
+	analysis := &FileAnalysis{FilePath: filePath, PackageName: packagePath, PackagePath: packagePath, Imports: make(map[string]string)}
+	staticFunctions := make(map[string]bool)
+	collectCPPStaticFunctions(tree.RootNode(), src, staticFunctions)
+	p.walkFile(tree.RootNode(), src, filePath, packagePath, staticFunctions, analysis)
+	return analysis, nil
+}
+
+func (p *CPPParser) walkFile(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, analysis *FileAnalysis) {
+	switch node.Type() {
+	case "preproc_include":
+		p.extractInclude(node, src, analysis)
+	case cppNodeFunctionDefinition:
+		if decl := p.parseFunction(node, src, filePath, packagePath, staticFunctions); decl != nil {
+			analysis.Functions = append(analysis.Functions, *decl)
+		}
+		return
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkFile(node.Child(i), src, filePath, packagePath, staticFunctions, analysis)
+	}
+}
+
+func collectCPPStaticFunctions(node *sitter.Node, src []byte, result map[string]bool) {
+	if node.Type() == cppNodeFunctionDefinition {
+		for i := 0; i < int(node.ChildCount()); i++ {
+			child := node.Child(i)
+			if child.Type() == "storage_class_specifier" && child.Content(src) == "static" {
+				result[cppDeclaratorName(node.ChildByFieldName("declarator"), src)] = true
+				return
+			}
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		collectCPPStaticFunctions(node.Child(i), src, result)
+	}
+}
+
+func (p *CPPParser) extractInclude(node *sitter.Node, src []byte, analysis *FileAnalysis) {
+	path := node.ChildByFieldName("path")
+	if path == nil {
+		return
+	}
+	header := strings.Trim(strings.TrimSpace(path.Content(src)), "<>\"")
+	if header != "" {
+		analysis.Imports[header] = header
+	}
+}
+
+func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) *FunctionDecl {
+	declarator := node.ChildByFieldName("declarator")
+	name := cppDeclaratorName(declarator, src)
+	body := node.ChildByFieldName("body")
+	if name == "" || body == nil {
+		return nil
+	}
+	decl := &FunctionDecl{
+		ID:           FunctionID{Package: cFunctionPackage(packagePath, filePath, name, staticFunctions), Name: name},
+		FilePath:     filePath,
+		StartLine:    int(node.StartPoint().Row) + 1,
+		EndLine:      int(node.EndPoint().Row) + 1,
+		OwnerType:    "module",
+		OwnerName:    packagePath,
+		FunctionType: "function",
+		Parameters:   cParameters(declarator, src),
+	}
+	p.walkCalls(body, src, filePath, packagePath, staticFunctions, &decl.Calls)
+	return decl
+}
+
+func cppDeclaratorName(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Type() {
+	case cNodeIdentifier, "qualified_identifier":
+		parts := strings.Split(node.Content(src), "::")
+		return parts[len(parts)-1]
+	default:
+		return cppDeclaratorName(node.ChildByFieldName("declarator"), src)
+	}
+}
+
+func (p *CPPParser) walkCalls(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, calls *[]FunctionCall) {
+	if node.Type() == cNodeCallExpression {
+		if call := p.parseCall(node, src, filePath, packagePath, staticFunctions); call != nil {
+			*calls = append(*calls, *call)
+		}
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkCalls(node.Child(i), src, filePath, packagePath, staticFunctions, calls)
+	}
+}
+
+func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) *FunctionCall {
+	function := node.ChildByFieldName("function")
+	if function == nil {
+		return nil
+	}
+	call := &FunctionCall{
+		Callee:      FunctionID{Package: packagePath},
+		Raw:         function.Content(src),
+		FilePath:    filePath,
+		Line:        int(node.StartPoint().Row) + 1,
+		StartCol:    int(node.StartPoint().Column) + 1,
+		EndCol:      int(node.EndPoint().Column) + 1,
+		AssignedVar: cAssignedVar(node, src),
+		Arguments:   cCallArguments(node, src),
+	}
+	switch function.Type() {
+	case cNodeIdentifier:
+		call.Callee.Name = function.Content(src)
+		call.Callee.Package = cFunctionPackage(packagePath, filePath, call.Callee.Name, staticFunctions)
+	case fieldExpressionNode:
+		field, argument := function.ChildByFieldName("field"), function.ChildByFieldName("argument")
+		if field == nil {
+			return nil
+		}
+		call.Callee.Name = field.Content(src)
+		if argument != nil && argument.Type() == cNodeIdentifier {
+			call.ReceiverVar = argument.Content(src)
+		}
+	case "qualified_identifier":
+		parts := strings.Split(function.Content(src), "::")
+		if len(parts) < 2 {
+			return nil
+		}
+		call.Callee.Name = parts[len(parts)-1]
+		call.Callee.Type = strings.Join(parts[:len(parts)-1], "::")
+	default:
+		return nil
+	}
+	return call
+}
+
+// SkipDirs returns build and dependency directories excluded from C++ traversal.
+func (p *CPPParser) SkipDirs() map[string]bool {
+	skip := map[string]bool{"build": true, "vendor": true}
+	if !p.includeTests {
+		skip["test"] = true
+		skip["tests"] = true
+	}
+	return skip
+}
+
+// SubPackagePath constructs a child namespace using path separators.
+func (p *CPPParser) SubPackagePath(parentPath, dirName string) string {
+	if parentPath == "" {
+		return dirName
+	}
+	return parentPath + "/" + dirName
+}
+
+// PackageSeparator returns the C++ package-path separator.
+func (p *CPPParser) PackageSeparator() string { return "/" }

--- a/internal/callgraph/cpp_parser.go
+++ b/internal/callgraph/cpp_parser.go
@@ -126,13 +126,13 @@ func (p *CPPParser) extractInclude(node *sitter.Node, src []byte, analysis *File
 
 func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) *FunctionDecl {
 	declarator := node.ChildByFieldName("declarator")
-	name := cppDeclaratorName(declarator, src)
+	name, typeName := cppDeclaratorIdentity(declarator, src)
 	body := node.ChildByFieldName("body")
 	if name == "" || body == nil {
 		return nil
 	}
 	decl := &FunctionDecl{
-		ID:           FunctionID{Package: cFunctionPackage(packagePath, filePath, name, staticFunctions), Name: name},
+		ID:           FunctionID{Package: cFunctionPackage(packagePath, filePath, name, staticFunctions), Type: typeName, Name: name},
 		FilePath:     filePath,
 		StartLine:    int(node.StartPoint().Row) + 1,
 		EndLine:      int(node.EndPoint().Row) + 1,
@@ -146,15 +146,22 @@ func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packa
 }
 
 func cppDeclaratorName(node *sitter.Node, src []byte) string {
+	name, _ := cppDeclaratorIdentity(node, src)
+	return name
+}
+
+func cppDeclaratorIdentity(node *sitter.Node, src []byte) (name, typeName string) {
 	if node == nil {
-		return ""
+		return "", ""
 	}
 	switch node.Type() {
-	case cNodeIdentifier, "qualified_identifier":
+	case cNodeIdentifier:
+		return node.Content(src), ""
+	case "qualified_identifier":
 		parts := strings.Split(node.Content(src), "::")
-		return parts[len(parts)-1]
+		return parts[len(parts)-1], strings.Join(parts[:len(parts)-1], "::")
 	default:
-		return cppDeclaratorName(node.ChildByFieldName("declarator"), src)
+		return cppDeclaratorIdentity(node.ChildByFieldName("declarator"), src)
 	}
 }
 
@@ -174,6 +181,7 @@ func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePa
 	if function == nil {
 		return nil
 	}
+	chainID, assignedVar := cppCallChainContext(node, src)
 	call := &FunctionCall{
 		Callee:      FunctionID{Package: packagePath},
 		Raw:         function.Content(src),
@@ -181,7 +189,8 @@ func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePa
 		Line:        int(node.StartPoint().Row) + 1,
 		StartCol:    int(node.StartPoint().Column) + 1,
 		EndCol:      int(node.EndPoint().Column) + 1,
-		AssignedVar: cAssignedVar(node, src),
+		AssignedVar: assignedVar,
+		ChainID:     chainID,
 		Arguments:   cCallArguments(node, src),
 	}
 	switch function.Type() {
@@ -208,6 +217,37 @@ func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePa
 		return nil
 	}
 	return call
+}
+
+func cppCallChainContext(node *sitter.Node, src []byte) (chainID, assignedVar string) {
+	root := cppChainRoot(node)
+	if !sameSyntaxNode(root, node) {
+		return fmt.Sprintf("%d", root.StartByte()), ""
+	}
+	function := node.ChildByFieldName("function")
+	if function != nil && function.Type() == fieldExpressionNode {
+		argument := function.ChildByFieldName("argument")
+		if argument != nil && argument.Type() == cNodeCallExpression {
+			chainID = fmt.Sprintf("%d", root.StartByte())
+		}
+	}
+	return chainID, cAssignedVar(root, src)
+}
+
+func cppChainRoot(node *sitter.Node) *sitter.Node {
+	root := node
+	for {
+		field := root.Parent()
+		if field == nil || field.Type() != fieldExpressionNode || !sameSyntaxNode(field.ChildByFieldName("argument"), root) {
+			break
+		}
+		call := field.Parent()
+		if call == nil || call.Type() != cNodeCallExpression || !sameSyntaxNode(call.ChildByFieldName("function"), field) {
+			break
+		}
+		root = call
+	}
+	return root
 }
 
 // SkipDirs returns build and dependency directories excluded from C++ traversal.

--- a/internal/callgraph/cpp_parser_test.go
+++ b/internal/callgraph/cpp_parser_test.go
@@ -1,0 +1,73 @@
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCPPParser_ParseDirectory(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "crypto.cpp")
+	src := `#include <botan/hash.h>
+#include "crypto/local.hpp"
+
+Botan::HashFunction* build_hash() {
+    auto hash = Botan::HashFunction::create("SHA-256");
+    hash->update("message");
+    CryptoPP::AutoSeededRandomPool rng;
+	CryptoPP::OS_GenerateRandomBlock(false, buffer, 16);
+    return hash;
+}
+`
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyses, err := NewCPPParser().ParseDirectory(dir, "example/crypto")
+	if err != nil {
+		t.Fatalf("ParseDirectory error: %v", err)
+	}
+	if len(analyses) != 1 {
+		t.Fatalf("analyses = %d, want 1", len(analyses))
+	}
+
+	analysis := analyses[0]
+	if analysis.Imports["botan/hash.h"] != "botan/hash.h" || analysis.Imports["crypto/local.hpp"] != "crypto/local.hpp" {
+		t.Fatalf("imports = %#v, want both include paths", analysis.Imports)
+	}
+	if len(analysis.Functions) != 1 {
+		t.Fatalf("functions = %d, want 1", len(analysis.Functions))
+	}
+	calls := make(map[string]FunctionCall, len(analysis.Functions[0].Calls))
+	for _, call := range analysis.Functions[0].Calls {
+		calls[call.Raw] = call
+	}
+
+	create, ok := calls["Botan::HashFunction::create"]
+	if !ok {
+		t.Fatalf("create call missing from %#v", analysis.Functions[0].Calls)
+	}
+	if create.Callee != (FunctionID{Package: "example/crypto", Type: "Botan::HashFunction", Name: "create"}) || create.AssignedVar != "hash" {
+		t.Fatalf("create call = %#v", create)
+	}
+	if create.Line != 5 || create.StartCol != 17 || create.EndCol != 55 {
+		t.Fatalf("create position = %d, %d:%d, want 5, 17:55", create.Line, create.StartCol, create.EndCol)
+	}
+
+	update, ok := calls["hash->update"]
+	if !ok || update.Callee.Name != "update" || update.ReceiverVar != "hash" {
+		t.Fatalf("update call = %#v", update)
+	}
+
+	random, ok := calls["CryptoPP::OS_GenerateRandomBlock"]
+	if !ok || random.Callee != (FunctionID{Package: "example/crypto", Type: "CryptoPP", Name: "OS_GenerateRandomBlock"}) {
+		t.Fatalf("CryptoPP call = %#v", random)
+	}
+}
+
+func TestCPPParser_Registered(t *testing.T) {
+	if _, ok := NewParserForEcosystem("cpp").(*CPPParser); !ok {
+		t.Fatalf("NewParserForEcosystem(cpp) = %T, want *CPPParser", NewParserForEcosystem("cpp"))
+	}
+}

--- a/internal/callgraph/cpp_parser_test.go
+++ b/internal/callgraph/cpp_parser_test.go
@@ -1,7 +1,10 @@
 package callgraph
 
 import (
+	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -48,21 +51,147 @@ Botan::HashFunction* build_hash() {
 	if !ok {
 		t.Fatalf("create call missing from %#v", analysis.Functions[0].Calls)
 	}
-	if create.Callee != (FunctionID{Package: "example/crypto", Type: "Botan::HashFunction", Name: "create"}) || create.AssignedVar != "hash" {
+	if create.Callee != (FunctionID{Package: "example/crypto", Type: "Botan::HashFunction", Name: "create"}) || create.AssignedVar != "hash" || create.ChainID != "" {
 		t.Fatalf("create call = %#v", create)
 	}
-	if create.Line != 5 || create.StartCol != 17 || create.EndCol != 55 {
-		t.Fatalf("create position = %d, %d:%d, want 5, 17:55", create.Line, create.StartCol, create.EndCol)
+	if create.Line != 5 {
+		t.Fatalf("create line = %d, want 5", create.Line)
 	}
 
 	update, ok := calls["hash->update"]
-	if !ok || update.Callee.Name != "update" || update.ReceiverVar != "hash" {
+	if !ok || update.Callee.Name != "update" || update.ReceiverVar != "hash" || update.ChainID != "" {
 		t.Fatalf("update call = %#v", update)
 	}
 
 	random, ok := calls["CryptoPP::OS_GenerateRandomBlock"]
-	if !ok || random.Callee != (FunctionID{Package: "example/crypto", Type: "CryptoPP", Name: "OS_GenerateRandomBlock"}) {
+	if !ok || random.Callee != (FunctionID{Package: "example/crypto", Type: "CryptoPP", Name: "OS_GenerateRandomBlock"}) || random.ChainID != "" {
 		t.Fatalf("CryptoPP call = %#v", random)
+	}
+}
+
+// TestCPPParser_ColumnConventionPinning compares C++ parser output against a
+// real opengrep/semgrep match, which defines the 1-based, end-exclusive
+// coordinates used to anchor findings to call-graph calls.
+func TestCPPParser_ColumnConventionPinning(t *testing.T) {
+	bin, err := exec.LookPath("opengrep")
+	if err != nil {
+		if bin, err = exec.LookPath("semgrep"); err != nil {
+			t.Skip("neither opengrep nor semgrep in PATH; skipping column-convention pin")
+		}
+	}
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "crypto.cpp")
+	src := `void hash_message() {
+    auto hash = Botan::HashFunction::create("SHA-256");
+}
+`
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rulePath := filepath.Join(dir, "rule.yaml")
+	rule := "rules:\n- id: cpp-column-pin\n  languages: [cpp]\n  message: pin\n  severity: INFO\n  pattern: Botan::HashFunction::create(\"SHA-256\")\n"
+	if err := os.WriteFile(rulePath, []byte(rule), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var args []string
+	if filepath.Base(bin) == "opengrep" {
+		args = []string{"scan", "--json", "--config", rulePath, dir}
+	} else {
+		args = []string{"--json", "--metrics", "off", "--config", rulePath, dir}
+	}
+	out, err := exec.CommandContext(context.Background(), bin, args...).Output()
+	if err != nil {
+		t.Skipf("%s present but unusable: %v", bin, err)
+	}
+	var result struct {
+		Results []struct {
+			Start struct {
+				Line int `json:"line"`
+				Col  int `json:"col"`
+			} `json:"start"`
+			End struct {
+				Col int `json:"col"`
+			} `json:"end"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("decode scanner output: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("scanner results = %d, want 1", len(result.Results))
+	}
+
+	analyses, err := NewCPPParser().ParseDirectory(dir, "example/crypto")
+	if err != nil {
+		t.Fatalf("ParseDirectory error: %v", err)
+	}
+	call := analyses[0].Functions[0].Calls[0]
+	match := result.Results[0]
+	if call.Line != match.Start.Line || call.StartCol != match.Start.Col || call.EndCol != match.End.Col {
+		t.Fatalf("parser position = %d, %d:%d; scanner position = %d, %d:%d", call.Line, call.StartCol, call.EndCol, match.Start.Line, match.Start.Col, match.End.Col)
+	}
+}
+
+func TestCPPParser_FluentChainContext(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "crypto.cpp")
+	src := `void hash_message() {
+    auto hash = Botan::HashFunction::create("SHA-256")->update("message");
+}
+`
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyses, err := NewCPPParser().ParseDirectory(dir, "example/crypto")
+	if err != nil {
+		t.Fatalf("ParseDirectory error: %v", err)
+	}
+	calls := analyses[0].Functions[0].Calls
+	if len(calls) != 2 {
+		t.Fatalf("calls = %#v, want create and update", calls)
+	}
+
+	var create, update FunctionCall
+	for _, call := range calls {
+		switch call.Callee.Name {
+		case "create":
+			create = call
+		case "update":
+			update = call
+		}
+	}
+	if create.ChainID == "" || create.ChainID != update.ChainID {
+		t.Fatalf("chain IDs = create %q, update %q, want one non-empty shared ID", create.ChainID, update.ChainID)
+	}
+	if create.AssignedVar != "" || update.AssignedVar != "hash" {
+		t.Fatalf("assigned vars = create %q, update %q, want only outer call assigned to hash", create.AssignedVar, update.AssignedVar)
+	}
+}
+
+func TestCPPParser_QualifiedDeclarationsResolveCalls(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "crypto.cpp")
+	src := `void Botan::hash() {}
+
+void Botan::caller() {
+    Botan::hash();
+}
+`
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	graph, err := NewBuilderForEcosystem("cpp", NewCPPParser()).BuildFromDirectories([]PackageDir{{Dir: dir, ImportPath: "example/crypto"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories error: %v", err)
+	}
+	target := (FunctionID{Package: "example/crypto", Type: "Botan", Name: "hash"}).String()
+	caller := (FunctionID{Package: "example/crypto", Type: "Botan", Name: "caller"}).String()
+	if !containsString(graph.Callers[target], caller) {
+		t.Fatalf("Callers[%q] = %#v, want %q", target, graph.Callers[target], caller)
 	}
 }
 

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -8,6 +8,8 @@ func NewParserForEcosystem(ecosystem string, opts ...ParserOption) Parser {
 	switch ecosystem {
 	case "c":
 		return NewCParser(opts...)
+	case "cpp", "c++":
+		return NewCPPParser(opts...)
 	case "go":
 		return NewGoParser(opts...)
 	case "java":

--- a/internal/callgraph/parser_registry_extra_test.go
+++ b/internal/callgraph/parser_registry_extra_test.go
@@ -21,6 +21,15 @@ func TestNewParserForEcosystem_IncludeTestsOption(t *testing.T) {
 			},
 		},
 		{
+			ecosystem: "cpp",
+			check: func(t *testing.T, parser Parser) {
+				p, ok := parser.(*CPPParser)
+				if !ok || !p.includeTests {
+					t.Fatalf("expected CPPParser with includeTests, got %#v", parser)
+				}
+			},
+		},
+		{
 			ecosystem: "go",
 			check: func(t *testing.T, parser Parser) {
 				p, ok := parser.(*GoParser)

--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -497,7 +497,7 @@ func (p *RustParser) parseCallExpr(node *sitter.Node, src []byte, filePath strin
 			Line:      line,
 			Arguments: args,
 		}
-	case "field_expression":
+	case fieldExpressionNode:
 		// Method call like `self.encrypt(...)` or `obj.method(...)`
 		return p.parseFieldCall(funcNode, src, filePath, line, args, analysis, currentReceiverType, varTypes)
 	}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -11,6 +11,8 @@ import (
 
 const constructorMethodName = "<init>"
 
+const fieldExpressionNode = "field_expression"
+
 // clinitMethodName names the synthetic function that represents a Java class's
 // static initialization context — its `static { ... }` blocks and its
 // initialized static `field_declaration` values. Mirrors the JVM `<clinit>`

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -18,7 +18,9 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -207,13 +209,8 @@ func ecosystemFromHints(target string, languageHints []string) string {
 	// instead of trusting languageHints[0] blindly. When hints come from an
 	// explicit --languages flag, the user's ordering is honored as-is.
 	for _, hint := range languageHints {
-		switch hint {
-		case "c", "go", ecosystemJava, "python", "rust":
-			return hint
-		case ecosystemCPP, "c++":
-			return ecosystemCPP
-		case ecosystemNode, "javascript", "typescript":
-			return ecosystemNode
+		if ecosystem := ecosystemFromHint(target, hint); ecosystem != "" {
+			return ecosystem
 		}
 	}
 
@@ -242,6 +239,66 @@ func ecosystemFromHints(target string, languageHints []string) string {
 	default:
 		return ""
 	}
+}
+
+func ecosystemFromHint(target, hint string) string {
+	switch hint {
+	case "c":
+		if cppHeaderTarget(target) {
+			return ecosystemCPP
+		}
+		return hint
+	case "go", ecosystemJava, "python", "rust":
+		return hint
+	case ecosystemCPP, "c++":
+		return ecosystemCPP
+	case ecosystemNode, "javascript", "typescript":
+		return ecosystemNode
+	default:
+		return ""
+	}
+}
+
+var errCPPHeaderDetected = errors.New("c++ header detected")
+
+func cppHeaderTarget(target string) bool {
+	info, err := os.Stat(target)
+	if err != nil {
+		return false
+	}
+	if !info.IsDir() {
+		return isCPPHeader(target)
+	}
+
+	err = filepath.WalkDir(target, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "build", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if isCPPHeader(path) {
+			return errCPPHeaderDetected
+		}
+		return nil
+	})
+	return errors.Is(err, errCPPHeaderDetected)
+}
+
+func isCPPHeader(path string) bool {
+	if strings.ToLower(filepath.Ext(path)) != ".h" {
+		return false
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	text := string(contents)
+	return strings.Contains(text, "namespace ") || strings.Contains(text, "class ") || strings.Contains(text, "template<") || strings.Contains(text, "template <") || strings.Contains(text, "::")
 }
 
 func resolveJavaRuntimeConfig(cfg *config.Config) (javaruntime.Config, error) {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -58,6 +58,7 @@ const (
 	defaultRulesetVersion = "latest"
 	ecosystemJava         = "java"
 	ecosystemNode         = "node"
+	ecosystemCPP          = "cpp"
 
 	findingsCacheBackendDisk     = "disk"
 	findingsCacheBackendNone     = "none"
@@ -209,6 +210,8 @@ func ecosystemFromHints(target string, languageHints []string) string {
 		switch hint {
 		case "c", "go", ecosystemJava, "python", "rust":
 			return hint
+		case ecosystemCPP, "c++":
+			return ecosystemCPP
 		case ecosystemNode, "javascript", "typescript":
 			return ecosystemNode
 		}
@@ -224,6 +227,8 @@ func ecosystemFromHints(target string, languageHints []string) string {
 	switch filepath.Ext(target) {
 	case ".c", ".h":
 		return "c"
+	case ".cc", ".cp", ".cpp", ".cxx", ".c++", ".hh", ".hpp", ".hxx", ".h++":
+		return ecosystemCPP
 	case ".go":
 		return "go"
 	case ".java":

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -47,6 +47,24 @@ func TestEcosystemFromHints_C(t *testing.T) {
 	}
 }
 
+func TestEcosystemFromHints_CPP(t *testing.T) {
+	for _, hint := range []string{ecosystemCPP, "c++"} {
+		if got := ecosystemFromHints(t.TempDir(), []string{hint}); got != ecosystemCPP {
+			t.Fatalf("ecosystemFromHints(%q hint) = %q, want cpp", hint, got)
+		}
+	}
+
+	for _, name := range []string{"crypto.cc", "crypto.cpp", "crypto.cxx", "crypto.hpp"} {
+		filePath := filepath.Join(t.TempDir(), name)
+		if err := os.WriteFile(filePath, []byte("int main() { return 0; }"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := ecosystemFromHints(filePath, nil); got != ecosystemCPP {
+			t.Fatalf("ecosystemFromHints(%s file) = %q, want cpp", filepath.Ext(name), got)
+		}
+	}
+}
+
 func TestNewFindingsCache_NoneBackend(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	cfg := &config.Config{}

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -65,6 +65,20 @@ func TestEcosystemFromHints_CPP(t *testing.T) {
 	}
 }
 
+func TestEcosystemFromHints_CPPHeaderOverridesCHint(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "crypto.h")
+	if err := os.WriteFile(headerPath, []byte("namespace Botan { class HashFunction {}; }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, target := range []string{headerPath, dir} {
+		if got := ecosystemFromHints(target, []string{"c"}); got != ecosystemCPP {
+			t.Fatalf("ecosystemFromHints(%q, c hint) = %q, want cpp", target, got)
+		}
+	}
+}
+
 func TestNewFindingsCache_NoneBackend(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	cfg := &config.Config{}


### PR DESCRIPTION
Closes #68

## Summary
- add tree-sitter C++ parsing for source/header files, includes, qualified and receiver calls
- route C++ hints and extensions to the new callgraph parser
- cover parser and routing behavior with focused tests

## Test plan
- [x] `go test ./...`
- [x] `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added C++ call-graph parsing for source and header files.
  - Recognizes includes, namespaces, qualified calls, receiver calls, assignments, and call locations.
  - Automatically detects C++ projects from language hints and common C++ file extensions.
  - Supports both `cpp` and `c++` ecosystem identifiers.

- **Documentation**
  - Updated the unreleased changelog with C++ parsing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->