### PR TITLE
feat(callgraph): add golang-fips OpenSSL v2 contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Go callgraph contracts now model the legacy `github.com/golang-fips/openssl/v2` API's symmetric, KDF, public-key, and post-quantum cryptographic lifecycles. (#127)
 - Graph-fragment exports now carry complete canonical target signatures and hierarchy-proven compatible callable signatures, allowing interface-typed dependency calls to join concrete crypto entry points without fabricating call edges. (#136)
 - Java callgraph contracts now model the version-pinned Nimbus JOSE JWE and Spring Security Crypto lifecycles, including factory, operation, output, hierarchy, and key-size parameter-role semantics. (#137)
 - Java callgraph lifecycle contracts now cover Bouncy Castle OpenPGP builders, Tink AEAD operations, and Apache Santuario XMLCipher factories and finalization. (#138)

--- a/internal/callgraph/contracts/go/golang-fips-openssl-v2.yaml
+++ b/internal/callgraph/contracts/go/golang-fips-openssl-v2.yaml
@@ -1,0 +1,366 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: golang-fips-openssl-v2
+  coordinates:
+    - "github.com/golang-fips/openssl/v2"
+  version_range: ">=2.0.0,<3.0.0"
+  description: "Legacy Go OpenSSL v2 cryptographic bindings"
+
+# API inventory source: upstream v2 branch at 9696eb4fdc48b79fdcb0381b341ffbb143d9d942.
+# Capability probes and OpenSSL/FIPS runtime setup are intentionally omitted: they do not
+# construct, configure, or execute a source-visible cryptographic operation.
+contracts:
+  # Symmetric ciphers and MAC/hash factories.
+  - method: github.com/golang-fips/openssl/v2.NewAESCipher
+    arity: 1
+    return: {type: crypto/cipher.Block, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: github.com/golang-fips/openssl/v2.NewChaCha20Poly1305
+    arity: 1
+    return: {type: crypto/cipher.AEAD, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: github.com/golang-fips/openssl/v2.NewDESCipher
+    arity: 1
+    return: {type: crypto/cipher.Block, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: github.com/golang-fips/openssl/v2.NewTripleDESCipher
+    arity: 1
+    return: {type: crypto/cipher.Block, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: github.com/golang-fips/openssl/v2.NewGCMTLS
+    arity: 1
+    return: {type: crypto/cipher.AEAD, confidence: high}
+    role: config
+  - method: github.com/golang-fips/openssl/v2.NewGCMTLS13
+    arity: 1
+    return: {type: crypto/cipher.AEAD, confidence: high}
+    role: config
+  - method: github.com/golang-fips/openssl/v2.NewHMAC
+    arity: 2
+    return: {type: hash.Hash, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: github.com/golang-fips/openssl/v2.NewSHA256
+    arity: 0
+    return: {type: hash.Hash, confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewSHA512
+    arity: 0
+    return: {type: hash.Hash, confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewSHA3_256
+    arity: 0
+    return: {type: github.com/golang-fips/openssl/v2.Hash, confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewSHAKE128
+    arity: 0
+    return: {type: github.com/golang-fips/openssl/v2.SHAKE, confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewCSHAKE128
+    arity: 2
+    return: {type: github.com/golang-fips/openssl/v2.SHAKE, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: functionName, derivation: argument_value}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: customization, derivation: argument_value}
+
+  # KDFs and TLS PRF.
+  - method: github.com/golang-fips/openssl/v2.ExtractHKDF
+    arity: 3
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: sharedSecret, derivation: argument_value}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: salt, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.ExpandHKDFOneShot
+    arity: 4
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: info, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: outputLength, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.ExpandTLS13KDF
+    arity: 5
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: label, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: context, derivation: argument_value}
+      - index: 4
+        role: metadata-contributing
+        contributes: {property: outputLength, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.PBKDF2
+    arity: 5
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: password, derivation: argument_value}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: salt, derivation: argument_value}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_value}
+      - index: 4
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+  - method: github.com/golang-fips/openssl/v2.TLS1PRF
+    arity: 5
+    return: {type: error, confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: output, derivation: argument_value}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: sharedSecret, derivation: argument_value}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: label, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: seed, derivation: argument_value}
+      - index: 4
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+
+  # Public key factories and operations.
+  - method: github.com/golang-fips/openssl/v2.NewPublicKeyRSA
+    arity: 2
+    return: {type: "*github.com/golang-fips/openssl/v2.PublicKeyRSA", confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewPrivateKeyRSA
+    arity: 8
+    return: {type: "*github.com/golang-fips/openssl/v2.PrivateKeyRSA", confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.EncryptRSAOAEP
+    arity: 5
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_type}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: publicKey, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: plaintext, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.DecryptRSAOAEP
+    arity: 5
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: privateKey, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: ciphertext, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.SignRSAPSS
+    arity: 4
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: privateKey, derivation: argument_value}
+      - index: 1
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 2
+        role: metadata-contributing
+        contributes: {property: digest, derivation: argument_value}
+      - index: 3
+        role: metadata-contributing
+        contributes: {property: saltLength, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.VerifyRSAPSS
+    arity: 5
+    return: {type: error, confidence: high}
+    role: operation
+  - method: github.com/golang-fips/openssl/v2.NewPrivateKeyECDSA
+    arity: 4
+    return: {type: "*github.com/golang-fips/openssl/v2.PrivateKeyECDSA", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: curve, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.SignMarshalECDSA
+    arity: 2
+    return: {type: "[]byte", confidence: high}
+    role: operation
+  - method: github.com/golang-fips/openssl/v2.NewPrivateKeyEd25519
+    arity: 1
+    return: {type: "*github.com/golang-fips/openssl/v2.PrivateKeyEd25519", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: privateKey, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.SignEd25519
+    arity: 2
+    return: {type: "[]byte", confidence: high}
+    role: operation
+  - method: github.com/golang-fips/openssl/v2.NewPrivateKeyECDH
+    arity: 2
+    return: {type: "*github.com/golang-fips/openssl/v2.PrivateKeyECDH", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: curve, derivation: argument_value}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: privateKey, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.ECDH
+    arity: 2
+    return: {type: "[]byte", confidence: high}
+    role: operation
+  - method: github.com/golang-fips/openssl/v2.(*PrivateKeyEd25519).Public
+    arity: 0
+    return: {type: "*github.com/golang-fips/openssl/v2.PublicKeyEd25519", confidence: high}
+    role: output
+  - method: github.com/golang-fips/openssl/v2.(*PrivateKeyECDH).PublicKey
+    arity: 0
+    return: {type: "*github.com/golang-fips/openssl/v2.PublicKeyECDH", confidence: high}
+    role: output
+
+  # Post-quantum key material and operations.
+  - method: github.com/golang-fips/openssl/v2.GenerateKeyMLKEM768
+    arity: 0
+    return: {type: github.com/golang-fips/openssl/v2.DecapsulationKeyMLKEM768, confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewDecapsulationKeyMLKEM768
+    arity: 1
+    return: {type: github.com/golang-fips/openssl/v2.DecapsulationKeyMLKEM768, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: seed, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.(DecapsulationKeyMLKEM768).Decapsulate
+    arity: 1
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: ciphertext, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.(DecapsulationKeyMLKEM768).EncapsulationKey
+    arity: 0
+    return: {type: github.com/golang-fips/openssl/v2.EncapsulationKeyMLKEM768, confidence: high}
+    role: output
+  - method: github.com/golang-fips/openssl/v2.GenerateKeyMLDSA
+    arity: 1
+    return: {type: "*github.com/golang-fips/openssl/v2.PrivateKeyMLDSA", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: operation-determining
+        contributes: {property: parameterSet, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.(*PrivateKeyMLDSA).Sign
+    arity: 2
+    return: {type: "[]byte", confidence: high}
+    role: operation
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: plaintext, derivation: argument_value}
+      - index: 1
+        role: metadata-contributing
+        contributes: {property: context, derivation: argument_value}
+  - method: github.com/golang-fips/openssl/v2.(*PrivateKeyMLDSA).PublicKey
+    arity: 0
+    return: {type: "*github.com/golang-fips/openssl/v2.PublicKeyMLDSA", confidence: high}
+    role: output
+
+  # DSA and RC4 are stable legacy API identities. They remain modeled without
+  # inferring runtime provider or compliance state.
+  - method: github.com/golang-fips/openssl/v2.NewPrivateKeyDSA
+    arity: 3
+    return: {type: "*github.com/golang-fips/openssl/v2.PrivateKeyDSA", confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.NewPublicKeyDSA
+    arity: 2
+    return: {type: "*github.com/golang-fips/openssl/v2.PublicKeyDSA", confidence: high}
+    role: factory
+  - method: github.com/golang-fips/openssl/v2.SignDSA
+    arity: 2
+    return: {type: "[]byte", confidence: high}
+    role: operation
+  - method: github.com/golang-fips/openssl/v2.VerifyDSA
+    arity: 3
+    return: {type: bool, confidence: high}
+    role: operation
+  - method: github.com/golang-fips/openssl/v2.NewRC4Cipher
+    arity: 1
+    return: {type: "*github.com/golang-fips/openssl/v2.RC4Cipher", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_golang_fips_openssl_v2_test.go
+++ b/internal/callgraph/contracts/go_golang_fips_openssl_v2_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGolangFIPSOpenSSLV2Contracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/golang-fips/openssl/v2.NewAESCipher", "factory", "keySize", 1},
+		{"github.com/golang-fips/openssl/v2.NewGCMTLS13", "config", "", 1},
+		{"github.com/golang-fips/openssl/v2.PBKDF2", "operation", "password", 5},
+		{"github.com/golang-fips/openssl/v2.(*PrivateKeyEd25519).Public", "output", "", 0},
+		{"github.com/golang-fips/openssl/v2.GenerateKeyMLDSA", "factory", "parameterSet", 1},
+		{"github.com/golang-fips/openssl/v2.(*PrivateKeyMLDSA).Sign", "operation", "plaintext", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "golang-fips-openssl-v2" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want golang-fips-openssl-v2 %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Closes #127

## Summary
- Add schema-v2 contracts for legacy `github.com/golang-fips/openssl/v2` crypto factories, KDFs, asymmetric operations, and ML-KEM/ML-DSA lifecycles.
- Preserve parameter contributions for keys, salts, passwords, nonces, ciphertexts, labels, seeds, and KDF parameters.
- Add embedded-KB regression coverage and an Unreleased changelog entry.

## API inventory
- **Contracted:** AES, ChaCha20-Poly1305, DES/3DES, GCM TLS variants, HMAC, SHA-2/SHA-3/SHAKE/cSHAKE factories, HKDF, PBKDF2, TLS 1 PRF, RSA, DSA, ECDSA, Ed25519, ECDH, RC4, ML-KEM, and ML-DSA lifecycle APIs with stable callable identities.
- **Skipped, informative return:** direct fixed-size digest and XOF helpers, byte/key serialization methods, and public constructors whose declared concrete type already carries the required identity.
- **Skipped, non-crypto/capability:** version, FIPS, and `Supports*` probes. This PR does not infer a runtime provider, FIPS mode, or module certification.
- **Unsupported:** methods on unexported concrete implementations behind `cipher.Block`, `cipher.AEAD`, `hash.Hash`, and `io.Reader`; the Go parser cannot bind those implementation-only identities safely.
- **Not applicable:** the upstream public v2 API exposes no certificate API. TLS coverage is limited to the explicit GCM TLS constructors and TLS 1 PRF.

## Verification
- [x] `go test ./internal/callgraph/contracts/...`
- [x] `go test ./internal/callgraph/...`