### PR TITLE
feat(callgraph): add ring contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Java callgraph contracts now model the version-pinned Nimbus JOSE JWE and Spring Security Crypto lifecycles, including factory, operation, output, hierarchy, and key-size parameter-role semantics. (#137)
 - Java callgraph lifecycle contracts now cover Bouncy Castle OpenPGP builders, Tink AEAD operations, and Apache Santuario XMLCipher factories and finalization. (#138)
 - Rust callgraph inference now recognizes RustCrypto `chacha20poly1305` 0.11 factories and AEAD operations, including ChaCha20-Poly1305 and XChaCha20-Poly1305 detached and in-place calls. (#125)
+- Rust callgraph inference now models `ring` 0.17 AEAD, digest, HMAC, HKDF, key-agreement, and signature lifecycles. (#70)
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)
 - Go callgraph builds now load schema-v2 contract knowledge bases and select the Go contract type resolver. (#75)
 - Python callgraph inference now covers synchronous and asynchronous Azure Key Vault Secrets client construction and secret set, get, deleted-secret, backup, and restore results. (scanoss/crypto_rules#115)

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -803,7 +803,7 @@ func (b *Builder) expandAbstractClassDispatch(
 	// default constructor, unparsed overload) fans out to EVERY same-arity
 	// constructor in the namespace root — on the bcprov corpus that synthesized
 	// 6.58M of the graph's 7.16M edges, all semantically impossible.
-	if base := BaseFunctionName(callee.Name); base == "<init>" || base == "<clinit>" {
+	if base := BaseFunctionName(callee.Name); base == constructorMethodName || base == clinitMethodName {
 		return nil
 	}
 	calleeKey := callee.String()

--- a/internal/callgraph/contracts/rust/ring.yaml
+++ b/internal/callgraph/contracts/rust/ring.yaml
@@ -1,0 +1,196 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ring
+  coordinates:
+    - ring
+  version_range: ">=0.17.0,<0.18.0"
+  description: "ring cryptography library"
+
+contracts:
+  - method: ring::aead::UnboundKey.new
+    arity: 2
+    return: { type: ring::aead::UnboundKey, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+      - index: 1
+        name: key_material
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: ring::aead::LessSafeKey.new
+    arity: 1
+    return: { type: ring::aead::LessSafeKey, confidence: high }
+    role: factory
+  - method: ring::aead::Nonce.assume_unique_for_key
+    arity: 1
+    return: { type: ring::aead::Nonce, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: value
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+  - method: ring::aead::LessSafeKey.seal_in_place_append_tag
+    arity: 3
+    return: { type: (), confidence: high }
+    role: operation
+    parameters: &aead_operation
+      - index: 0
+        name: nonce
+        role: metadata-contributing
+        contributes: { property: nonceSize, derivation: argument_bit_length }
+      - index: 1
+        name: aad
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+      - index: 2
+        name: plaintext
+        role: metadata-contributing
+        contributes: { property: plaintext, derivation: argument_value }
+
+  - method: ring::digest.digest
+    arity: 2
+    return: { type: ring::digest::Digest, confidence: high }
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: ring::digest::Context.new
+    arity: 1
+    return: { type: ring::digest::Context, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: ring::digest::Context.update
+    arity: 1
+    return: { type: (), confidence: high }
+    role: operation
+  - method: ring::digest::Context.finish
+    arity: 0
+    return: { type: ring::digest::Digest, confidence: high }
+    role: output
+
+  - method: ring::hmac::Key.new
+    arity: 2
+    return: { type: ring::hmac::Key, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+      - index: 1
+        name: key_value
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: ring::hmac::Key.generate
+    arity: 2
+    return: { type: ring::hmac::Key, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: ring::hmac.sign
+    arity: 2
+    return: { type: ring::hmac::Tag, confidence: high }
+    role: operation
+  - method: ring::hmac.verify
+    arity: 3
+    return: { type: (), confidence: high }
+    role: operation
+  - method: ring::hmac::Context.with_key
+    arity: 1
+    return: { type: ring::hmac::Context, confidence: high }
+    role: factory
+  - method: ring::hmac::Context.update
+    arity: 1
+    return: { type: (), confidence: high }
+    role: operation
+  - method: ring::hmac::Context.sign
+    arity: 0
+    return: { type: ring::hmac::Tag, confidence: high }
+    role: output
+
+  - method: ring::hkdf::Salt.new
+    arity: 2
+    return: { type: ring::hkdf::Salt, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+      - index: 1
+        name: value
+        role: metadata-contributing
+        contributes: { property: saltSize, derivation: argument_bit_length }
+  - method: ring::hkdf::Salt.extract
+    arity: 1
+    return: { type: ring::hkdf::Prk, confidence: high }
+    role: operation
+  - method: ring::hkdf::Prk.expand
+    arity: 2
+    return: { type: ring::hkdf::Okm, confidence: high }
+    role: operation
+  - method: ring::hkdf::Okm.fill
+    arity: 1
+    return: { type: (), confidence: high }
+    role: output
+
+  - method: ring::agreement::EphemeralPrivateKey.generate
+    arity: 2
+    return: { type: ring::agreement::EphemeralPrivateKey, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: ring::agreement::EphemeralPrivateKey.compute_public_key
+    arity: 0
+    return: { type: ring::agreement::PublicKey, confidence: high }
+    role: output
+  - method: ring::agreement::UnparsedPublicKey.new
+    arity: 2
+    return: { type: ring::agreement::UnparsedPublicKey, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+
+  - method: ring::signature::Ed25519KeyPair.from_pkcs8
+    arity: 1
+    return: { type: ring::signature::Ed25519KeyPair, confidence: high }
+    role: factory
+  - method: ring::signature::Ed25519KeyPair.sign
+    arity: 1
+    return: { type: ring::signature::Signature, confidence: high }
+    role: operation
+  - method: ring::signature::UnparsedPublicKey.new
+    arity: 2
+    return: { type: ring::signature::UnparsedPublicKey, confidence: high }
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: ring::signature::UnparsedPublicKey.verify
+    arity: 2
+    return: { type: (), confidence: high }
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_libraries_test.go
+++ b/internal/callgraph/contracts/rust_libraries_test.go
@@ -95,3 +95,104 @@ func assertChacha20Poly1305ParameterRoles(t *testing.T, method string, parameter
 		}
 	}
 }
+
+func TestLoadEmbeddedRustIncludesRingContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		role   string
+		ret    string
+	}{
+		{"ring::aead::UnboundKey.new", 2, "factory", "ring::aead::UnboundKey"},
+		{"ring::aead::LessSafeKey.new", 1, "factory", "ring::aead::LessSafeKey"},
+		{"ring::aead::Nonce.assume_unique_for_key", 1, "factory", "ring::aead::Nonce"},
+		{"ring::aead::LessSafeKey.seal_in_place_append_tag", 3, "operation", "()"},
+		{"ring::digest.digest", 2, "operation", "ring::digest::Digest"},
+		{"ring::digest::Context.new", 1, "factory", "ring::digest::Context"},
+		{"ring::digest::Context.update", 1, "operation", "()"},
+		{"ring::digest::Context.finish", 0, "output", "ring::digest::Digest"},
+		{"ring::hmac::Key.new", 2, "factory", "ring::hmac::Key"},
+		{"ring::hmac::Key.generate", 2, "factory", "ring::hmac::Key"},
+		{"ring::hmac.sign", 2, "operation", "ring::hmac::Tag"},
+		{"ring::hmac.verify", 3, "operation", "()"},
+		{"ring::hmac::Context.with_key", 1, "factory", "ring::hmac::Context"},
+		{"ring::hmac::Context.update", 1, "operation", "()"},
+		{"ring::hmac::Context.sign", 0, "output", "ring::hmac::Tag"},
+		{"ring::hkdf::Salt.new", 2, "factory", "ring::hkdf::Salt"},
+		{"ring::hkdf::Salt.extract", 1, "operation", "ring::hkdf::Prk"},
+		{"ring::hkdf::Prk.expand", 2, "operation", "ring::hkdf::Okm"},
+		{"ring::hkdf::Okm.fill", 1, "output", "()"},
+		{"ring::agreement::EphemeralPrivateKey.generate", 2, "factory", "ring::agreement::EphemeralPrivateKey"},
+		{"ring::agreement::EphemeralPrivateKey.compute_public_key", 0, "output", "ring::agreement::PublicKey"},
+		{"ring::agreement::UnparsedPublicKey.new", 2, "factory", "ring::agreement::UnparsedPublicKey"},
+		{"ring::signature::Ed25519KeyPair.from_pkcs8", 1, "factory", "ring::signature::Ed25519KeyPair"},
+		{"ring::signature::Ed25519KeyPair.sign", 1, "operation", "ring::signature::Signature"},
+		{"ring::signature::UnparsedPublicKey.new", 2, "factory", "ring::signature::UnparsedPublicKey"},
+		{"ring::signature::UnparsedPublicKey.verify", 2, "operation", "()"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].SourceLibrary != "ring" || got[0].Role != tt.role || got[0].Return.Type != tt.ret {
+				t.Fatalf("%s#%d = %#v, want ring %s returning %s", tt.method, tt.arity, got[0], tt.role, tt.ret)
+			}
+		})
+	}
+}
+
+func TestRingContractParameterRoles(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   []struct{ property, derivation string }
+	}{
+		{"ring::aead::UnboundKey.new", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}, {"keySize", "argument_bit_length"}}},
+		{"ring::aead::Nonce.assume_unique_for_key", 1, []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}}},
+		{"ring::aead::LessSafeKey.seal_in_place_append_tag", 3, []struct{ property, derivation string }{{"nonceSize", "argument_bit_length"}, {"associatedData", "argument_value"}, {"plaintext", "argument_value"}}},
+		{"ring::digest.digest", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}}},
+		{"ring::digest::Context.new", 1, []struct{ property, derivation string }{{"algorithm", "argument_value"}}},
+		{"ring::hmac::Key.new", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}, {"keySize", "argument_bit_length"}}},
+		{"ring::hmac::Key.generate", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}}},
+		{"ring::hkdf::Salt.new", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}, {"saltSize", "argument_bit_length"}}},
+		{"ring::agreement::EphemeralPrivateKey.generate", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}}},
+		{"ring::agreement::UnparsedPublicKey.new", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}}},
+		{"ring::signature::UnparsedPublicKey.new", 2, []struct{ property, derivation string }{{"algorithm", "argument_value"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 || len(got[0].Parameters) != len(tt.want) {
+				t.Fatalf("%s#%d parameters = %#v, want %d", tt.method, tt.arity, got, len(tt.want))
+			}
+			for i, want := range tt.want {
+				parameter := got[0].Parameters[i]
+				role := "metadata-contributing"
+				if want.property == "algorithm" {
+					role = "operation-determining"
+				}
+				if parameter.Index == nil || *parameter.Index != i || parameter.Role != role || parameter.Contributes == nil || parameter.Contributes.Property != want.property || parameter.Contributes.Derivation != want.derivation {
+					t.Fatalf("%s parameters[%d] = %#v, want %s/%s", tt.method, i, parameter, want.property, want.derivation)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #70

## Summary
- Add schema-v2 `ring` 0.17 contracts for AEAD, digest, HMAC, HKDF, key-agreement, and signature lifecycles.
- Preserve algorithm, key-size, nonce-size, salt-size, AAD, and plaintext parameter-role derivations where the API supplies those inputs.
- Add embedded-KB assertions and the consumer-facing changelog entry.

## API inventory
- **Contracted:** rule-selected algorithm factories and the stable AEAD, digest, HMAC, HKDF, key-agreement, and Ed25519 signing lifecycle APIs in `ring` 0.17.
- **Skipped, unsupported:** generic callback/result APIs such as `agreement::agree_ephemeral` and borrowed-slice AEAD opening methods, because the Rust parser cannot emit a stable generic or borrowed canonical return identity.
- **Skipped, non-crypto/informative:** algorithm constants, accessors, trait implementations, and serialization helpers that do not create, configure, execute, or output a crypto lifecycle value.
- **Out of scope:** parser/resolver infrastructure, detection rules, TLS, and other crates.

Source inventory: https://docs.rs/ring/0.17.14/ring/

## Verification
- [x] `go test ./internal/callgraph/contracts -count=1`
- [x] `go test ./internal/callgraph/... -count=1`
- [x] `git diff --check`

Paired detection scope: scanoss/crypto_rules#89