### PR TITLE
feat(callgraph): add C return sources

### DIFF
--- a/internal/callgraph/c_parser.go
+++ b/internal/callgraph/c_parser.go
@@ -17,6 +17,7 @@ const (
 	cNodeFunctionDefinition = "function_definition"
 	cNodeIdentifier         = "identifier"
 	cNodeParameterList      = "parameter_list"
+	cNodeReturnStatement    = "return_statement"
 )
 
 // CParser extracts C function declarations, calls, and include paths.
@@ -150,6 +151,7 @@ func (p *CParser) parseFunction(node *sitter.Node, src []byte, filePath, package
 		Parameters:   cParameters(declarator, src),
 	}
 	p.walkCalls(body, src, filePath, packagePath, staticFunctions, &decl.Calls)
+	decl.ReturnSources = p.extractReturnSources(body, src, filePath, packagePath, staticFunctions)
 	return decl
 }
 
@@ -292,6 +294,54 @@ func cCallArguments(node *sitter.Node, src []byte) []string {
 		return nil
 	}
 	return parseArgumentsFromDelimitedContent(arguments.Content(src))
+}
+
+func (p *CParser) extractReturnSources(body *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) []SourceNode {
+	var sources []SourceNode
+	p.walkReturnSources(body, src, filePath, packagePath, staticFunctions, &sources)
+	return sources
+}
+
+func (p *CParser) walkReturnSources(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, sources *[]SourceNode) {
+	if node.Type() == cNodeReturnStatement {
+		if expr := cReturnExpression(node); expr != nil {
+			if source, ok := p.cReturnSource(expr, src, filePath, packagePath, staticFunctions); ok {
+				*sources = append(*sources, source)
+			}
+		}
+		return
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkReturnSources(node.Child(i), src, filePath, packagePath, staticFunctions, sources)
+	}
+}
+
+func cReturnExpression(node *sitter.Node) *sitter.Node {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		child := node.Child(i)
+		if child.IsNamed() {
+			return child
+		}
+	}
+	return nil
+}
+
+func (p *CParser) cReturnSource(expr *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) (SourceNode, bool) {
+	location := &SourceLocation{FilePath: filePath, Line: int(expr.StartPoint().Row) + 1}
+	switch expr.Type() {
+	case cNodeCallExpression:
+		call := p.parseCall(expr, src, filePath, packagePath, staticFunctions)
+		if call == nil {
+			return SourceNode{}, false
+		}
+		callee := call.Callee
+		return SourceNode{Type: "CALL_RESULT", CallTarget: &callee, Location: location}, true
+	case cNodeIdentifier:
+		return SourceNode{Type: "VARIABLE", Name: expr.Content(src), Location: location}, true
+	case "field_expression":
+		return SourceNode{Type: "FIELD", Name: expr.Content(src), Location: location}, true
+	}
+	return SourceNode{}, false
 }
 
 // SkipDirs returns build and dependency directories excluded from C traversal.

--- a/internal/callgraph/c_parser_test.go
+++ b/internal/callgraph/c_parser_test.go
@@ -107,3 +107,62 @@ func TestCParser_StaticFunctionsAreTranslationUnitScoped(t *testing.T) {
 		t.Fatalf("static helper calls share package %q; want translation-unit-specific identities", callPackages["one"])
 	}
 }
+
+func TestCParser_ReturnSources(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "returns.c")
+	src := `void *direct(void *value) {
+    return value;
+}
+
+EVP_CIPHER_CTX *factory(void) {
+    return EVP_CIPHER_CTX_new();
+}
+
+int unknown(int value) {
+    return value + 1;
+}
+
+void no_return(void) {
+    return;
+}
+`
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyses, err := NewCParser().ParseDirectory(dir, "example/crypto")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(analyses) != 1 {
+		t.Fatalf("analyses = %d, want 1", len(analyses))
+	}
+
+	direct := findCFunction(t, analyses[0], "direct")
+	if got := direct.ReturnSources; len(got) != 1 || got[0].Type != "VARIABLE" || got[0].Name != "value" {
+		t.Fatalf("direct ReturnSources = %#v, want VARIABLE value", got)
+	}
+
+	factory := findCFunction(t, analyses[0], "factory")
+	if got := factory.ReturnSources; len(got) != 1 || got[0].Type != "CALL_RESULT" || got[0].CallTarget == nil || got[0].CallTarget.Name != "EVP_CIPHER_CTX_new" || got[0].CallTarget.Package != "example/crypto" {
+		t.Fatalf("factory ReturnSources = %#v, want CALL_RESULT example/crypto.EVP_CIPHER_CTX_new", got)
+	}
+
+	for _, name := range []string{"unknown", "no_return"} {
+		if got := findCFunction(t, analyses[0], name).ReturnSources; len(got) != 0 {
+			t.Errorf("%s ReturnSources = %#v, want none", name, got)
+		}
+	}
+}
+
+func findCFunction(t *testing.T, analysis *FileAnalysis, name string) *FunctionDecl {
+	t.Helper()
+	for i := range analysis.Functions {
+		if analysis.Functions[i].ID.Name == name {
+			return &analysis.Functions[i]
+		}
+	}
+	t.Fatalf("function %q not found", name)
+	return nil
+}

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -181,7 +181,7 @@ type FunctionDecl struct {
 	OwnerVisibility string
 	Parameters      []FunctionParameter
 	Calls           []FunctionCall
-	// ReturnSources traces where return values originate; populated by parsers (v1: Java only).
+	// ReturnSources traces where return values originate when the parser supports it.
 	ReturnSources []SourceNode
 	// InferredReturn is the result of the post-build inference pass; nil when no inference fires.
 	InferredReturn *InferredReturn


### PR DESCRIPTION
Closes #87

## Summary
- Populate C `FunctionDecl.ReturnSources` for direct variables, fields, and resolvable factory calls.
- Keep unsupported expressions and bare returns unresolved.
- Add focused C parser coverage.

## Verification
- [x] `go test ./internal/callgraph -run '^TestCParser_ReturnSources$' -count=1`
- [x] `go test ./internal/callgraph/... -count=1`
- [x] `git diff --check`
