### PR TITLE
fix(callgraph): add Rust parity coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- Rust callgraph contracts now resolve associated functions using the canonical Rust callable identity, enabling inferred return types from embedded contracts. (#74)
 - Nested-call findings now attribute matched operations and canonical call identities to the tightest source invocation instead of an enclosing call. (#134)
 - Supporting-call catalogs now preserve every callable overload deterministically instead of selecting one by traversal order. (#131)
 - Stitched graph-fragment callgraph exports now retain parameter roles on supporting calls. (#130)

--- a/internal/callgraph/rust_parity_test.go
+++ b/internal/callgraph/rust_parity_test.go
@@ -1,0 +1,91 @@
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func buildRustParityGraph(t *testing.T, src string) *CallGraph {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "lib.rs"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	builder := NewBuilderForEcosystem("rust", NewRustParser())
+	builder.SetTypeResolver(NewRustContractTypeResolverFromEmbedded())
+	graph, err := builder.BuildFromDirectories([]PackageDir{{Dir: dir, ImportPath: "chacha20poly1305"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+	return graph
+}
+
+func rustGraphFunction(t *testing.T, graph *CallGraph, id FunctionID) *FunctionDecl {
+	t.Helper()
+
+	fn := graph.Functions[id.String()]
+	if fn == nil {
+		t.Fatalf("function %s not found", id.String())
+	}
+	return fn
+}
+
+func TestRustParity_ParserInferenceAndGracefulDegradation(t *testing.T) {
+	graph := buildRustParityGraph(t, `
+struct ChaCha20Poly1305;
+
+impl ChaCha20Poly1305 {
+    fn new(key: &[u8]) { let _ = key; }
+    fn encrypt(&self, nonce: &[u8], plaintext: &[u8]) { let _ = (nonce, plaintext); }
+}
+
+fn seal(key: &[u8], nonce: &[u8], plaintext: &[u8]) {
+    let cipher: ChaCha20Poly1305 = chacha20poly1305::ChaCha20Poly1305::new(key);
+    cipher.encrypt(nonce, plaintext);
+}
+
+fn relay(key: &[u8]) {
+    return ChaCha20Poly1305::new(key);
+}
+
+fn unsupported() { return; }
+`)
+
+	constructor := rustGraphFunction(t, graph, FunctionID{Package: "chacha20poly1305", Type: "ChaCha20Poly1305", Name: "new"})
+	if constructor.ReturnType != "chacha20poly1305::ChaCha20Poly1305" {
+		t.Fatalf("constructor ReturnType = %q, want contract-inferred Chacha20Poly1305", constructor.ReturnType)
+	}
+
+	seal := rustGraphFunction(t, graph, FunctionID{Package: "chacha20poly1305", Name: "seal"})
+	if len(seal.Calls) != 2 {
+		t.Fatalf("seal calls = %#v, want constructor and encrypt", seal.Calls)
+	}
+	for _, want := range []FunctionID{
+		{Package: "chacha20poly1305", Type: "ChaCha20Poly1305", Name: "new"},
+		{Package: "chacha20poly1305", Type: "ChaCha20Poly1305", Name: "encrypt"},
+	} {
+		found := false
+		for _, call := range seal.Calls {
+			if call.Callee == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("seal calls = %#v, missing %#v", seal.Calls, want)
+		}
+	}
+
+	relay := rustGraphFunction(t, graph, FunctionID{Package: "chacha20poly1305", Name: "relay"})
+	if len(relay.ReturnSources) != 1 || relay.ReturnSources[0].CallTarget == nil || relay.ReturnSources[0].CallTarget.Name != "new" {
+		t.Fatalf("relay ReturnSources = %#v, want constructor call result", relay.ReturnSources)
+	}
+
+	unsupported := rustGraphFunction(t, graph, FunctionID{Package: "chacha20poly1305", Name: "unsupported"})
+	if unsupported.InferredReturn != nil || len(unsupported.ReturnSources) != 0 {
+		t.Fatalf("unsupported function should degrade without inference: %#v", unsupported)
+	}
+}

--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -15,6 +15,7 @@ import (
 const (
 	rustNodeCallExpression      = "call_expression"
 	rustNodeExpressionStatement = "expression_statement"
+	rustNodeFieldExpression     = "field_expression"
 	rustNodeFunctionItem        = "function_item"
 )
 
@@ -497,7 +498,7 @@ func (p *RustParser) parseCallExpr(node *sitter.Node, src []byte, filePath strin
 			Line:      line,
 			Arguments: args,
 		}
-	case "field_expression":
+	case rustNodeFieldExpression:
 		// Method call like `self.encrypt(...)` or `obj.method(...)`
 		return p.parseFieldCall(funcNode, src, filePath, line, args, analysis, currentReceiverType, varTypes)
 	}

--- a/internal/callgraph/rust_type_resolver.go
+++ b/internal/callgraph/rust_type_resolver.go
@@ -3,11 +3,7 @@
 
 package callgraph
 
-import (
-	"strings"
-
-	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
-)
+import "github.com/scanoss/crypto-finder/internal/callgraph/contracts"
 
 // RustContractTypeResolver applies return types from the Rust contracts KB.
 type RustContractTypeResolver struct {
@@ -49,9 +45,8 @@ func (r *RustContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir
 }
 
 func rustFunctionFQN(fn *FunctionDecl) string {
-	parts := []string{fn.ID.Package}
 	if fn.ID.Type != "" {
-		parts = append(parts, fn.ID.Type)
+		return fn.ID.Package + "::" + fn.ID.Type + "." + fn.ID.Name
 	}
-	return strings.Join(append(parts, fn.ID.Name), "::")
+	return fn.ID.Package + "::" + fn.ID.Name
 }

--- a/internal/callgraph/rust_type_resolver_test.go
+++ b/internal/callgraph/rust_type_resolver_test.go
@@ -23,7 +23,7 @@ ecosystem: rust
 library:
   name: test-rust
 contracts:
-  - method: ring::aead::LessSafeKey::new
+  - method: ring::aead::LessSafeKey.new
     arity: 1
     return:
       type: ring::aead::LessSafeKey


### PR DESCRIPTION
Closes #74

## Summary
- Add an end-to-end Rust parser, return-source, contract-resolution, and graceful-degradation parity fixture.
- Fix associated-function contract lookups to match the canonical Rust contract identity.
- Document the corrected inferred-return behavior in the Unreleased changelog.

## Verification
- [x] `GOCACHE=/tmp/crypto-finder-gocache go test ./internal/callgraph -run '^TestRustParity_ParserInferenceAndGracefulDegradation$' -count=1`\n- [x] `GOCACHE=/tmp/crypto-finder-gocache go test ./internal/callgraph/... -count=1`\n- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rust call-graph contract resolution for associated functions by using their canonical callable identity.
  - Rust return types can now be inferred from embedded contracts in additional constructor-like call scenarios.
  - Unsupported Rust patterns continue to degrade gracefully without producing incorrect inferred return types.

- **Tests**
  - Added coverage for Rust return-type inference, call relationships, return origins, and graceful handling of unsupported cases.

- **Documentation**
  - Updated the unreleased changelog with the Rust call-graph resolution fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->