### PR TITLE
feat(callgraph): wire C contract resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C callgraph builds now select the contract type resolver and apply contract inference to pointer-returning functions. (#88)
 - C++ callgraph parsing now recognizes C++ source and header files, include paths, namespace-qualified and receiver calls, assignment targets, and 1-based half-open call columns. (#68)
 - Go callgraph contracts now model the legacy `github.com/golang-fips/openssl/v2` API's symmetric, KDF, public-key, and post-quantum cryptographic lifecycles. (#127)
 - Graph-fragment exports now carry complete canonical target signatures and hierarchy-proven compatible callable signatures, allowing interface-typed dependency calls to join concrete crypto entry points without fabricating call edges. (#136)

--- a/internal/callgraph/c_parser.go
+++ b/internal/callgraph/c_parser.go
@@ -149,10 +149,25 @@ func (p *CParser) parseFunction(node *sitter.Node, src []byte, filePath, package
 		OwnerName:    packagePath,
 		FunctionType: "function",
 		Parameters:   cParameters(declarator, src),
+		ReturnType:   cFunctionReturnType(node, declarator, src),
 	}
 	p.walkCalls(body, src, filePath, packagePath, staticFunctions, &decl.Calls)
 	decl.ReturnSources = p.extractReturnSources(body, src, filePath, packagePath, staticFunctions)
 	return decl
+}
+
+func cFunctionReturnType(node, declarator *sitter.Node, src []byte) string {
+	typeNode := node.ChildByFieldName("type")
+	if typeNode == nil {
+		return ""
+	}
+	returnType := strings.TrimSpace(typeNode.Content(src))
+	for current := declarator; current != nil; current = current.ChildByFieldName("declarator") {
+		if current.Type() == "pointer_declarator" {
+			returnType += "*"
+		}
+	}
+	return returnType
 }
 
 func cFunctionPackage(packagePath, filePath, name string, staticFunctions map[string]bool) string {
@@ -335,6 +350,7 @@ func (p *CParser) cReturnSource(expr *sitter.Node, src []byte, filePath, package
 			return SourceNode{}, false
 		}
 		callee := call.Callee
+		callee.Name = fmt.Sprintf("%s#%d", callee.Name, len(call.Arguments))
 		return SourceNode{Type: "CALL_RESULT", CallTarget: &callee, Location: location}, true
 	case cNodeIdentifier:
 		return SourceNode{Type: "VARIABLE", Name: expr.Content(src), Location: location}, true

--- a/internal/callgraph/c_parser_test.go
+++ b/internal/callgraph/c_parser_test.go
@@ -140,13 +140,19 @@ void no_return(void) {
 	}
 
 	direct := findCFunction(t, analyses[0], "direct")
+	if direct.ReturnType != "void*" {
+		t.Fatalf("direct ReturnType = %q, want void*", direct.ReturnType)
+	}
 	if got := direct.ReturnSources; len(got) != 1 || got[0].Type != "VARIABLE" || got[0].Name != "value" {
 		t.Fatalf("direct ReturnSources = %#v, want VARIABLE value", got)
 	}
 
 	factory := findCFunction(t, analyses[0], "factory")
-	if got := factory.ReturnSources; len(got) != 1 || got[0].Type != "CALL_RESULT" || got[0].CallTarget == nil || got[0].CallTarget.Name != "EVP_CIPHER_CTX_new" || got[0].CallTarget.Package != "example/crypto" {
-		t.Fatalf("factory ReturnSources = %#v, want CALL_RESULT example/crypto.EVP_CIPHER_CTX_new", got)
+	if factory.ReturnType != "EVP_CIPHER_CTX*" {
+		t.Fatalf("factory ReturnType = %q, want EVP_CIPHER_CTX*", factory.ReturnType)
+	}
+	if got := factory.ReturnSources; len(got) != 1 || got[0].Type != "CALL_RESULT" || got[0].CallTarget == nil || got[0].CallTarget.Name != "EVP_CIPHER_CTX_new#0" || got[0].CallTarget.Package != "example/crypto" {
+		t.Fatalf("factory ReturnSources = %#v, want CALL_RESULT example/crypto.EVP_CIPHER_CTX_new#0", got)
 	}
 
 	for _, name := range []string{"unknown", "no_return"} {

--- a/internal/callgraph/c_type_resolver.go
+++ b/internal/callgraph/c_type_resolver.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import "github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+
+// CContractTypeResolver applies return types from the C contracts KB.
+type CContractTypeResolver struct {
+	kb *contracts.KnowledgeBase
+}
+
+// NewCContractTypeResolver creates a resolver backed by the supplied KB.
+func NewCContractTypeResolver(kb *contracts.KnowledgeBase) *CContractTypeResolver {
+	return &CContractTypeResolver{kb: kb}
+}
+
+// NewCContractTypeResolverFromEmbedded loads the embedded C KB. Missing
+// contracts degrade to a no-op resolver.
+func NewCContractTypeResolverFromEmbedded() *CContractTypeResolver {
+	kb, err := contracts.LoadEmbedded("c")
+	if err != nil {
+		return NewCContractTypeResolver(nil)
+	}
+	return NewCContractTypeResolver(kb)
+}
+
+// ResolveTypes fills missing declaration return types from unconditional contracts.
+func (r *CContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) error {
+	if r.kb == nil || len(r.kb.Contracts) == 0 {
+		return nil
+	}
+	for _, fn := range graph.Functions {
+		if fn.ReturnType != "" {
+			continue
+		}
+		for _, contract := range r.kb.ContractsFor(fn.ID.String(), len(fn.Parameters)) {
+			if contract.When == nil && contract.Return.Type != "" {
+				fn.ReturnType = contract.Return.Type
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/callgraph/c_type_resolver_test.go
+++ b/internal/callgraph/c_type_resolver_test.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestCContractTypeResolver_UsesCanonicalFunctionIDs(t *testing.T) {
+	kb, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: c
+library:
+  name: test-c
+contracts:
+  - method: example/crypto.EVP_CIPHER_CTX_new
+    arity: 0
+    return:
+      type: EVP_CIPHER_CTX*
+      confidence: high
+`))
+	if err != nil {
+		t.Fatalf("load test KB: %v", err)
+	}
+	fn := &FunctionDecl{ID: FunctionID{Package: "example/crypto", Name: "EVP_CIPHER_CTX_new"}}
+
+	if err := NewCContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(fn), nil); err != nil {
+		t.Fatalf("ResolveTypes: %v", err)
+	}
+	if fn.ReturnType != "EVP_CIPHER_CTX*" {
+		t.Fatalf("ReturnType = %q, want EVP_CIPHER_CTX*", fn.ReturnType)
+	}
+
+	fn.ReturnType = "existing_type"
+	if err := NewCContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(fn), nil); err != nil {
+		t.Fatalf("ResolveTypes with existing return type: %v", err)
+	}
+	if fn.ReturnType != "existing_type" {
+		t.Fatalf("existing ReturnType was overwritten: %q", fn.ReturnType)
+	}
+}
+
+func TestCContractTypeResolver_MissingKBIsNoOp(t *testing.T) {
+	fn := &FunctionDecl{ID: FunctionID{Package: "example/crypto", Name: "factory"}}
+	if err := NewCContractTypeResolver(nil).ResolveTypes(buildTestCallGraph(fn), nil); err != nil {
+		t.Fatalf("ResolveTypes: %v", err)
+	}
+	if fn.ReturnType != "" {
+		t.Fatalf("ReturnType = %q, want empty", fn.ReturnType)
+	}
+}

--- a/internal/callgraph/inference.go
+++ b/internal/callgraph/inference.go
@@ -103,7 +103,7 @@ var inferenceTriggerTypes = map[string]struct{}{
 // return type. Returns false when the type is already specific and useful.
 func shouldInfer(declaredType string) bool {
 	_, ok := inferenceTriggerTypes[declaredType]
-	return ok
+	return ok || strings.HasSuffix(strings.TrimSpace(declaredType), "*")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/callgraph/inference_test.go
+++ b/internal/callgraph/inference_test.go
@@ -797,7 +797,7 @@ func TestShouldInfer_TriggerTypes(t *testing.T) {
 	triggers := []string{
 		"", "Object", "java.lang.Object", "byte[]", "Object[]",
 		"Key", "java.security.Key", "T", "E", "V", "?",
-		"int", "long", "boolean", "void",
+		"int", "long", "boolean", "void", "EVP_CIPHER_CTX*", "EVP_CIPHER_CTX *",
 	}
 	for _, typ := range triggers {
 		if !shouldInfer(typ) {
@@ -813,11 +813,43 @@ func TestShouldInfer_NonTriggerTypes(t *testing.T) {
 		"java.lang.String",
 		"javax.crypto.Cipher",
 		"java.security.PrivateKey",
+		"EVP_CIPHER_CTX",
 	}
 	for _, typ := range nonTriggers {
 		if shouldInfer(typ) {
 			t.Errorf("shouldInfer(%q) = true, want false", typ)
 		}
+	}
+}
+
+func TestInferReturnTypes_CPointerReturn(t *testing.T) {
+	kb, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: c
+library:
+  name: test-c
+contracts:
+  - method: example/crypto.EVP_CIPHER_CTX_new
+    arity: 0
+    return:
+      type: EVP_CIPHER_CTX*
+      confidence: high
+`))
+	if err != nil {
+		t.Fatalf("load test KB: %v", err)
+	}
+	callee := FunctionID{Package: "example/crypto", Name: "EVP_CIPHER_CTX_new#0"}
+	fn := &FunctionDecl{
+		ID:            FunctionID{Package: "example/crypto", Name: "factory"},
+		ReturnType:    "EVP_CIPHER_CTX *",
+		ReturnSources: []SourceNode{{Type: sourceNodeCallResult, CallTarget: &callee}},
+	}
+
+	if err := InferReturnTypes(buildTestCallGraph(fn), kb); err != nil {
+		t.Fatalf("InferReturnTypes: %v", err)
+	}
+	if fn.InferredReturn == nil || fn.InferredReturn.Type != "EVP_CIPHER_CTX*" || fn.InferredReturn.Origin != OriginKBDirect {
+		t.Fatalf("InferredReturn = %#v, want KB-direct EVP_CIPHER_CTX*", fn.InferredReturn)
 	}
 }
 

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -29,6 +29,8 @@ func NewParserForEcosystem(ecosystem string, opts ...ParserOption) Parser {
 // Returns nil if no type resolver is available (tree-sitter-only resolution).
 func NewTypeResolverForEcosystem(ecosystem string, javaRuntime javaruntime.Config) TypeResolver {
 	switch ecosystem {
+	case "c":
+		return NewCContractTypeResolverFromEmbedded()
 	case "go":
 		return NewGoContractTypeResolverFromEmbedded()
 	case "java":

--- a/internal/callgraph/parser_registry_extra_test.go
+++ b/internal/callgraph/parser_registry_extra_test.go
@@ -90,6 +90,9 @@ func TestNewParserForEcosystem_IncludeTestsOption(t *testing.T) {
 }
 
 func TestNewTypeResolverForEcosystem(t *testing.T) {
+	if _, ok := NewTypeResolverForEcosystem("c", javaruntime.Config{}).(*CContractTypeResolver); !ok {
+		t.Fatal("expected CContractTypeResolver")
+	}
 	if resolver := NewTypeResolverForEcosystem("java", javaruntime.Config{}); resolver == nil {
 		t.Fatal("expected Java type resolver")
 	}


### PR DESCRIPTION
Closes #88

## Summary
- Select a C contract type resolver with safe no-op fallback until C knowledge bases are embedded.
- Preserve C function return types and arity on return-call sources for exact contract lookup.
- Allow semantic inference for opaque pointer returns such as `EVP_CIPHER_CTX*`.

## Verification
- [x] `go test ./internal/callgraph/... -count=1`
- [x] `go test ./... -count=1` (Docker-backed engine tests rerun separately)
- [x] `go test ./internal/engine -count=1`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/callgraph/...`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * C callgraph analysis now resolves missing function return types using contract knowledge.
  * Improved support for pointer-returning C functions, including accurate return type inference.
  * C projects now automatically use the appropriate type resolver during analysis.
  * Call results now include argument-count information for more precise call identification.

* **Bug Fixes**
  * Corrected return type extraction for C functions with pointer declarators.

* **Tests**
  * Added coverage for C pointer return types, contract-based resolution, and resolver selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->