### PR TITLE
fix(callgraph): preserve C wrapper inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- C callgraph builds now select the contract type resolver and apply contract inference to pointer-returning functions. (#88)
+- C callgraph builds now select the C contract type resolver; pointer-returning functions can use contract inference when C knowledge bases are embedded. (#88)
 - C++ callgraph parsing now recognizes C++ source and header files, include paths, namespace-qualified and receiver calls, assignment targets, and 1-based half-open call columns. (#68)
 - Go callgraph contracts now model the legacy `github.com/golang-fips/openssl/v2` API's symmetric, KDF, public-key, and post-quantum cryptographic lifecycles. (#127)
 - Graph-fragment exports now carry complete canonical target signatures and hierarchy-proven compatible callable signatures, allowing interface-typed dependency calls to join concrete crypto entry points without fabricating call edges. (#136)
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- C callgraph pointer-return inference now propagates through in-project wrapper functions while preserving arity-qualified contract lookup. (#153)
 - Rust callgraph contracts now resolve associated functions using the canonical Rust callable identity, enabling inferred return types from embedded contracts. (#74)
 - Nested-call findings now attribute matched operations and canonical call identities to the tightest source invocation instead of an enclosing call. (#134)
 - Supporting-call catalogs now preserve every callable overload deterministically instead of selecting one by traversal order. (#131)

--- a/internal/callgraph/inference.go
+++ b/internal/callgraph/inference.go
@@ -664,8 +664,15 @@ func candidateFromCallResult(
 	}
 
 	// Propagation: callee has an inferred type already.
-	calleeKey := ct.String()
-	if callee, ok := graph.Functions[calleeKey]; ok && callee.InferredReturn != nil {
+	callee := graph.Functions[ct.String()]
+	if callee == nil && arity >= 0 {
+		// C return sources carry arity for contract lookup, while C declarations
+		// keep their source identity because C has no function overloading.
+		undecorated := *ct
+		undecorated.Name = BaseFunctionName(undecorated.Name)
+		callee = graph.Functions[undecorated.String()]
+	}
+	if callee != nil && callee.InferredReturn != nil {
 		ir := callee.InferredReturn
 		if ir.Origin != OriginJoinFailed {
 			return candidate{

--- a/internal/callgraph/inference_test.go
+++ b/internal/callgraph/inference_test.go
@@ -537,6 +537,46 @@ func TestInferReturnTypes_Propagated(t *testing.T) {
 	}
 }
 
+func TestInferReturnTypes_PropagatedFromArityQualifiedCallee(t *testing.T) {
+	kb, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: c
+library:
+  name: test-c
+contracts:
+  - method: example.EVP_CIPHER_CTX_new
+    arity: 0
+    return:
+      type: EVP_CIPHER_CTX*
+      confidence: high
+`))
+	if err != nil {
+		t.Fatalf("load test KB: %v", err)
+	}
+
+	externalID := FunctionID{Package: "example", Name: "EVP_CIPHER_CTX_new#0"}
+	leafID := FunctionID{Package: "example", Name: "leaf"}
+	leaf := &FunctionDecl{
+		ID:            leafID,
+		ReturnType:    "EVP_CIPHER_CTX*",
+		ReturnSources: []SourceNode{{Type: sourceNodeCallResult, CallTarget: &externalID}},
+	}
+	wrapper := &FunctionDecl{
+		ID:            FunctionID{Package: "example", Name: "wrapper"},
+		ReturnType:    "EVP_CIPHER_CTX*",
+		Calls:         []FunctionCall{{Callee: leafID}},
+		ReturnSources: []SourceNode{{Type: sourceNodeCallResult, CallTarget: &FunctionID{Package: "example", Name: "leaf#0"}}},
+	}
+	graph := buildTestCallGraph(leaf, wrapper)
+
+	if err := InferReturnTypes(graph, kb); err != nil {
+		t.Fatalf("InferReturnTypes: %v", err)
+	}
+	if wrapper.InferredReturn == nil || wrapper.InferredReturn.Type != "EVP_CIPHER_CTX*" || wrapper.InferredReturn.Origin != OriginPropagated {
+		t.Fatalf("wrapper InferredReturn = %#v, want propagated EVP_CIPHER_CTX*", wrapper.InferredReturn)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // T4.17 — mutual recursion fixpoint
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #153

## Summary
- Preserve exact arity-qualified contract lookup for C return sources.
- Fall back to undecorated in-graph C declarations when propagating inferred wrapper returns.
- Add a regression for `wrapper -> leaf -> EVP_CIPHER_CTX_new`.

## Root cause
PR #152 added arity to C return-source targets so contract lookup could distinguish call signatures. In-graph C declarations retain source-level names because C has no function overloading, so exact propagation lookup could not find ordinary wrapper callees.

## Verification
- [x] Regression failed on merge commit `45e23b78`.
- [x] `go test ./internal/callgraph -run TestInferReturnTypes_PropagatedFromArityQualifiedCallee -count=1`
- [x] `go test ./internal/callgraph/... -count=1`
- [x] `golangci-lint run --new-from-rev=origin/main ./internal/callgraph/...`
- [x] `git diff --check`
- [x] Dual adversarial re-review found no critical or real warning findings.
