### PR TITLE
feat(callgraph): load C contract knowledge bases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ The callgraph inference engine consumes language-agnostic YAML knowledge bases u
 ```
 internal/callgraph/contracts/
 ├── contracts.go           # loader, types, validation
+├── c/                     # schema-v2 C callgraph contracts
 ├── java/
 │   └── jdk-crypto.yaml    # JDK JCA/JCE contracts (shipped in v1)
 ├── go/                    # schema-v2 Go callgraph contracts
@@ -77,7 +78,8 @@ internal/callgraph/contracts/
 ```
 
 **One YAML file = one library version**. Adding a new library is a new YAML, not a code
-change. The loader (`contracts.LoadEmbedded(ecosystem)`) discovers all `*.yaml` files in
+change. A new ecosystem may temporarily use one empty `<ecosystem>-bootstrap` YAML because
+`go:embed` requires a matching file; remove it when the first library KB lands. The loader (`contracts.LoadEmbedded(ecosystem)`) discovers all `*.yaml` files in
 the ecosystem directory, validates each, and merges them via `contracts.Merge()` with
 conflict-detection rules:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C callgraph builds now load embedded schema-v2 contract knowledge bases. (#89)
 - C callgraph builds now select the C contract type resolver; pointer-returning functions can use contract inference when C knowledge bases are embedded. (#88)
 - C++ callgraph parsing now recognizes C++ source and header files, include paths, namespace-qualified and receiver calls, assignment targets, and 1-based half-open call columns. (#68)
 - Go callgraph contracts now model the legacy `github.com/golang-fips/openssl/v2` API's symmetric, KDF, public-key, and post-quantum cryptographic lifecycles. (#127)

--- a/internal/callgraph/contracts/c/bootstrap.yaml
+++ b/internal/callgraph/contracts/c/bootstrap.yaml
@@ -1,0 +1,9 @@
+schema_version: "2"
+ecosystem: c
+# ponytail: go:embed needs one YAML match; remove this file when the first C library KB lands.
+library:
+  name: c-bootstrap
+  description: "Bootstrap for embedded C callgraph contracts"
+
+contracts: []
+hierarchy: {}

--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -26,7 +26,12 @@ var rustFS embed.FS
 //go:embed go/*.yaml
 var goFS embed.FS
 
+//go:embed c/*.yaml
+var cFS embed.FS
+
 const (
+	// ecosystemC is the ecosystem identifier for the C contract KB.
+	ecosystemC = "c"
 	// ecosystemGo is the ecosystem identifier for the Go contract KB.
 	ecosystemGo = "go"
 	// ecosystemPython is the ecosystem identifier for the Python contract KB.
@@ -464,6 +469,8 @@ func embedFSFor(ecosystem string) (fs.FS, string) {
 	switch ecosystem {
 	case "java":
 		return &javaFS, "java"
+	case ecosystemC:
+		return &cFS, ecosystemC
 	case ecosystemGo:
 		return &goFS, ecosystemGo
 	case ecosystemPython:

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -697,6 +697,16 @@ func TestLoadEmbedded_Go(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_C(t *testing.T) {
+	kb, err := contracts.LoadEmbedded("c")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(\"c\"): %v", err)
+	}
+	if kb.Ecosystem != "c" {
+		t.Fatalf("Ecosystem = %q, want c", kb.Ecosystem)
+	}
+}
+
 // TestContractsFor_ReturnsCorrectSlice
 // kb.ContractsFor("javax.crypto.Cipher.unwrap", 3) returns 3 conditional entries.
 func TestContractsFor_ReturnsCorrectSlice(t *testing.T) {


### PR DESCRIPTION
## Summary

- embed and route schema-v2 C contract knowledge bases
- add a temporary empty C bootstrap KB until the first C library contract lands
- document the C KB layout and cover `LoadEmbedded("c")`

Closes #89

## Testing

- `go test ./internal/callgraph/contracts/...`
- `go test ./internal/callgraph/...`
- `go test ./...`
- `golangci-lint run --new-from-rev origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading embedded C callgraph contract knowledge bases.
  * Added an initial C schema-v2 bootstrap contract for ecosystem setup.

* **Documentation**
  * Updated the knowledge-base layout guidance for C contracts and bootstrap files.
  * Added the C callgraph contract support to the unreleased changelog.

* **Tests**
  * Added coverage confirming C contract knowledge bases load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->