### PR TITLE
feat(callgraph): wire C++ return inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C++ callgraph builds now populate namespace-qualified return sources and select the C++ contract type resolver. (#94)
 - C callgraph builds now load embedded schema-v2 contract knowledge bases. (#89)
 - C callgraph builds now select the C contract type resolver; pointer-returning functions can use contract inference when C knowledge bases are embedded. (#88)
 - C++ callgraph parsing now recognizes C++ source and header files, include paths, namespace-qualified and receiver calls, assignment targets, and 1-based half-open call columns. (#68)

--- a/internal/callgraph/cpp_parser.go
+++ b/internal/callgraph/cpp_parser.go
@@ -142,6 +142,7 @@ func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packa
 		Parameters:   cParameters(declarator, src),
 	}
 	p.walkCalls(body, src, filePath, packagePath, staticFunctions, &decl.Calls)
+	decl.ReturnSources = p.extractReturnSources(body, src, filePath, packagePath, staticFunctions)
 	return decl
 }
 
@@ -217,6 +218,48 @@ func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePa
 		return nil
 	}
 	return call
+}
+
+func (p *CPPParser) extractReturnSources(body *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) []SourceNode {
+	var sources []SourceNode
+	p.walkReturnSources(body, src, filePath, packagePath, staticFunctions, &sources)
+	return sources
+}
+
+func (p *CPPParser) walkReturnSources(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, sources *[]SourceNode) {
+	if node.Type() == "lambda_expression" {
+		return
+	}
+	if node.Type() == cNodeReturnStatement {
+		if expr := cReturnExpression(node); expr != nil {
+			if source, ok := p.returnSource(expr, src, filePath, packagePath, staticFunctions); ok {
+				*sources = append(*sources, source)
+			}
+		}
+		return
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkReturnSources(node.Child(i), src, filePath, packagePath, staticFunctions, sources)
+	}
+}
+
+func (p *CPPParser) returnSource(expr *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) (SourceNode, bool) {
+	location := &SourceLocation{FilePath: filePath, Line: int(expr.StartPoint().Row) + 1}
+	switch expr.Type() {
+	case cNodeCallExpression:
+		call := p.parseCall(expr, src, filePath, packagePath, staticFunctions)
+		if call == nil {
+			return SourceNode{}, false
+		}
+		callee := call.Callee
+		callee.Name = fmt.Sprintf("%s#%d", callee.Name, len(call.Arguments))
+		return SourceNode{Type: sourceNodeCallResult, CallTarget: &callee, Location: location}, true
+	case cNodeIdentifier:
+		return SourceNode{Type: sourceNodeVariable, Name: expr.Content(src), Location: location}, true
+	case fieldExpressionNode:
+		return SourceNode{Type: sourceNodeField, Name: expr.Content(src), Location: location}, true
+	}
+	return SourceNode{}, false
 }
 
 func cppCallChainContext(node *sitter.Node, src []byte) (chainID, assignedVar string) {

--- a/internal/callgraph/cpp_parser_test.go
+++ b/internal/callgraph/cpp_parser_test.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
 )
 
 func TestCPPParser_ParseDirectory(t *testing.T) {
@@ -192,6 +194,45 @@ void Botan::caller() {
 	caller := (FunctionID{Package: "example/crypto", Type: "Botan", Name: "caller"}).String()
 	if !containsString(graph.Callers[target], caller) {
 		t.Fatalf("Callers[%q] = %#v, want %q", target, graph.Callers[target], caller)
+	}
+}
+
+func TestCPPParser_NamespaceQualifiedReturnSource(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "crypto.cpp")
+	src := `auto build_hash() {
+	    auto ignored = []() { return CryptoPP::SHA256(); };
+	    return Botan::HashFunction::create("SHA-256");
+}
+`
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	analyses, err := NewCPPParser().ParseDirectory(dir, "example/crypto")
+	if err != nil {
+		t.Fatalf("ParseDirectory error: %v", err)
+	}
+	if len(analyses) != 1 || len(analyses[0].Functions) != 1 {
+		t.Fatalf("analyses = %#v, want one function", analyses)
+	}
+
+	fn := &analyses[0].Functions[0]
+	sources := fn.ReturnSources
+	want := FunctionID{Package: "example/crypto", Type: "Botan::HashFunction", Name: "create#1"}
+	if len(sources) != 1 || sources[0].Type != sourceNodeCallResult || sources[0].CallTarget == nil || *sources[0].CallTarget != want {
+		t.Fatalf("ReturnSources = %#v, want one call result for %v", sources, want)
+	}
+	kb := &contracts.KnowledgeBase{Contracts: map[string][]contracts.Contract{
+		"example/crypto.Botan::HashFunction.create#1": {{
+			Return: contracts.ContractReturn{Type: "Botan::HashFunction", Confidence: ConfidenceHigh},
+		}},
+	}}
+	if err := InferReturnTypes(buildTestCallGraph(fn), kb); err != nil {
+		t.Fatalf("InferReturnTypes error: %v", err)
+	}
+	if fn.InferredReturn == nil || fn.InferredReturn.Type != "Botan::HashFunction" {
+		t.Fatalf("InferredReturn = %#v, want Botan::HashFunction", fn.InferredReturn)
 	}
 }
 

--- a/internal/callgraph/cpp_type_resolver.go
+++ b/internal/callgraph/cpp_type_resolver.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import "github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+
+// CPPContractTypeResolver applies return types from the C++ contracts KB.
+type CPPContractTypeResolver struct {
+	kb *contracts.KnowledgeBase
+}
+
+// NewCPPContractTypeResolver creates a resolver backed by the supplied KB.
+func NewCPPContractTypeResolver(kb *contracts.KnowledgeBase) *CPPContractTypeResolver {
+	return &CPPContractTypeResolver{kb: kb}
+}
+
+// NewCPPContractTypeResolverFromEmbedded loads the embedded C++ KB. Until the
+// first C++ contracts land, the empty KB makes this a no-op resolver.
+func NewCPPContractTypeResolverFromEmbedded() *CPPContractTypeResolver {
+	kb, err := contracts.LoadEmbedded("cpp")
+	if err != nil {
+		return NewCPPContractTypeResolver(nil)
+	}
+	return NewCPPContractTypeResolver(kb)
+}
+
+// ResolveTypes fills missing declaration return types from unconditional contracts.
+func (r *CPPContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) error {
+	if r.kb == nil || len(r.kb.Contracts) == 0 {
+		return nil
+	}
+	for _, fn := range graph.Functions {
+		if fn.ReturnType != "" {
+			continue
+		}
+		method, _ := splitMethodArity(&fn.ID)
+		for _, contract := range r.kb.ContractsFor(method, len(fn.Parameters)) {
+			if contract.When == nil && contract.Return.Type != "" {
+				fn.ReturnType = contract.Return.Type
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/callgraph/cpp_type_resolver_test.go
+++ b/internal/callgraph/cpp_type_resolver_test.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestCPPContractTypeResolver_UsesCanonicalFunctionIDs(t *testing.T) {
+	kb := &contracts.KnowledgeBase{
+		Ecosystem: "cpp",
+		Contracts: map[string][]contracts.Contract{
+			"example/crypto.Botan::HashFunction.create#1": {{
+				Return: contracts.ContractReturn{Type: "Botan::HashFunction", Confidence: "high"},
+			}},
+		},
+	}
+	fn := &FunctionDecl{
+		ID:         FunctionID{Package: "example/crypto", Type: "Botan::HashFunction", Name: "create"},
+		Parameters: []FunctionParameter{{Name: "algorithm"}},
+	}
+
+	if err := NewCPPContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(fn), nil); err != nil {
+		t.Fatalf("ResolveTypes error: %v", err)
+	}
+	if fn.ReturnType != "Botan::HashFunction" {
+		t.Fatalf("ReturnType = %q, want Botan::HashFunction", fn.ReturnType)
+	}
+}

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -31,6 +31,8 @@ func NewTypeResolverForEcosystem(ecosystem string, javaRuntime javaruntime.Confi
 	switch ecosystem {
 	case "c":
 		return NewCContractTypeResolverFromEmbedded()
+	case "cpp", "c++":
+		return NewCPPContractTypeResolverFromEmbedded()
 	case "go":
 		return NewGoContractTypeResolverFromEmbedded()
 	case "java":

--- a/internal/callgraph/parser_registry_extra_test.go
+++ b/internal/callgraph/parser_registry_extra_test.go
@@ -93,6 +93,11 @@ func TestNewTypeResolverForEcosystem(t *testing.T) {
 	if _, ok := NewTypeResolverForEcosystem("c", javaruntime.Config{}).(*CContractTypeResolver); !ok {
 		t.Fatal("expected CContractTypeResolver")
 	}
+	for _, ecosystem := range []string{"cpp", "c++"} {
+		if _, ok := NewTypeResolverForEcosystem(ecosystem, javaruntime.Config{}).(*CPPContractTypeResolver); !ok {
+			t.Fatalf("expected CPPContractTypeResolver for %q", ecosystem)
+		}
+	}
 	if resolver := NewTypeResolverForEcosystem("java", javaruntime.Config{}); resolver == nil {
 		t.Fatal("expected Java type resolver")
 	}


### PR DESCRIPTION
## Summary

- populate C++ return sources for namespace-qualified calls without leaking nested lambda returns
- keep `auto` wrappers eligible for contract-based inferred return types
- select the C++ contract resolver for both `cpp` and `c++` ecosystems

Closes #94

## Verification

- `go test ./internal/callgraph/... -count=1`
- all non-engine packages via `go test -count=1`
- `go test ./internal/engine -count=1` with Docker-backed PostgreSQL tests
- `golangci-lint run --new-from-rev=origin/main ./internal/callgraph/...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * C++ callgraph builds now capture namespace-qualified return sources, including returned function calls, variables, and fields.
  * C++ return types can now be inferred from available contract information.
  * C++ ecosystems are supported through both `cpp` and `c++` configurations.

* **Bug Fixes**
  * Improved attribution of return values from C++ functions, including calls with arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->