### PR TITLE
feat(callgraph): add OpenSSL EVP contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C callgraph inference now models OpenSSL EVP cipher, digest, KDF, MAC, public-key, KEM, and signature APIs selected by the shipped C detection rules. (#90)
 - C++ callgraph builds now populate namespace-qualified return sources and select the C++ contract type resolver. (#94)
 - C callgraph builds now load embedded schema-v2 contract knowledge bases. (#89)
 - C callgraph builds now select the C contract type resolver; pointer-returning functions can use contract inference when C knowledge bases are embedded. (#88)

--- a/internal/callgraph/contracts/c/bootstrap.yaml
+++ b/internal/callgraph/contracts/c/bootstrap.yaml
@@ -1,9 +1,0 @@
-schema_version: "2"
-ecosystem: c
-# ponytail: go:embed needs one YAML match; remove this file when the first C library KB lands.
-library:
-  name: c-bootstrap
-  description: "Bootstrap for embedded C callgraph contracts"
-
-contracts: []
-hierarchy: {}

--- a/internal/callgraph/contracts/c/openssl-evp.yaml
+++ b/internal/callgraph/contracts/c/openssl-evp.yaml
@@ -1,0 +1,803 @@
+schema_version: "2"
+ecosystem: c
+library:
+  name: openssl-evp
+  coordinates:
+    - openssl:libcrypto
+  description: "OpenSSL EVP high-level cryptographic APIs"
+
+# Inventory sources: OpenSSL 3.6.2 public headers and crypto_rules commit
+# 39597ad26c0a968aa927592ca8ac29698018dea1. The list is limited to callable
+# OpenSSL EVP APIs selected by the current C detection rules.
+contracts:
+
+  # Cipher algorithm factories.
+  - method: EVP_aes_128_cbc
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_ccm
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_ctr
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_ecb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_cfb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_gcm
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_ofb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_128_xts
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_cbc
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_ccm
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_ctr
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_ecb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_cfb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_gcm
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_192_ofb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_cbc
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_ccm
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_ctr
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_ecb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_cfb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_gcm
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_ofb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_aes_256_xts
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_cbc
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_ecb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_cfb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_ofb
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_ede
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_ede_cbc
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_ede3
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_des_ede3_cbc
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_rc4
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_rc4_40
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+  - method: EVP_rc4_hmac_md5
+    arity: 0
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+
+  # Cipher selection and initialization.
+  - method: EVP_get_cipherbyname
+    arity: 1
+    return: {type: "const EVP_CIPHER*", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: name
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_CIPHER_fetch
+    arity: 3
+    return: {type: "EVP_CIPHER*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_CipherInit_ex
+    arity: 6
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: cipher
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_EncryptInit_ex
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: cipher
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_DecryptInit_ex
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: cipher
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+
+  # Digest algorithm factories.
+  - method: EVP_blake2b512
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_blake2s256
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_md4
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_md5
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_ripemd160
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha1
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha224
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha256
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha384
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha512
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha3_224
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha3_256
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha3_384
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sha3_512
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_shake128
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_shake256
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_sm3
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+  - method: EVP_whirlpool
+    arity: 0
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+
+  # Digest selection and operations.
+  - method: EVP_get_digestbyname
+    arity: 1
+    return: {type: "const EVP_MD*", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: name
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_MD_fetch
+    arity: 3
+    return: {type: "EVP_MD*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_DigestInit
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_DigestInit_ex
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_DigestInit_ex2
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_Digest
+    arity: 6
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 1
+        name: count
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+      - index: 4
+        name: type
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_Q_digest
+    arity: 7
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 1
+        name: name
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 4
+        name: datalen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+
+  # KDF and MAC selection.
+  - method: EVP_KDF_fetch
+    arity: 3
+    return: {type: "EVP_KDF*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_MAC_fetch
+    arity: 3
+    return: {type: "EVP_MAC*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PBE_scrypt
+    arity: 10
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 1
+        name: passlen
+        role: metadata-contributing
+        contributes: {property: passwordLength, derivation: argument_value}
+      - index: 3
+        name: saltlen
+        role: metadata-contributing
+        contributes: {property: saltLength, derivation: argument_value}
+      - index: 4
+        name: N
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+      - index: 5
+        name: r
+        role: metadata-contributing
+        contributes: {property: blockSize, derivation: argument_value}
+      - index: 6
+        name: p
+        role: metadata-contributing
+        contributes: {property: parallelism, derivation: argument_value}
+      - index: 9
+        name: keylen
+        role: metadata-contributing
+        contributes: {property: outputLength, derivation: argument_value}
+  - method: PKCS5_PBKDF2_HMAC
+    arity: 8
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 1
+        name: passlen
+        role: metadata-contributing
+        contributes: {property: passwordLength, derivation: argument_value}
+      - index: 3
+        name: saltlen
+        role: metadata-contributing
+        contributes: {property: saltLength, derivation: argument_value}
+      - index: 4
+        name: iter
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+      - index: 6
+        name: keylen
+        role: metadata-contributing
+        contributes: {property: outputLength, derivation: argument_value}
+      - index: 5
+        name: digest
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+
+  # Public-key, KEM, and signature selection.
+  - method: EVP_PKEY_CTX_new_id
+    arity: 2
+    return: {type: "EVP_PKEY_CTX*", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: id
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PKEY_CTX_new_from_name
+    arity: 3
+    return: {type: "EVP_PKEY_CTX*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: name
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PKEY_Q_keygen
+    arity: 3
+    return: {type: "EVP_PKEY*", confidence: high}
+    role: factory
+    parameters:
+      - index: 2
+        name: type
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PKEY_Q_keygen
+    arity: 4
+    return: {type: "EVP_PKEY*", confidence: high}
+    role: factory
+    parameters:
+      - index: 2
+        name: type
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 3
+        name: parameter
+        role: metadata-contributing
+        contributes: {property: parameterSet, derivation: argument_value}
+  - method: EVP_KEM_fetch
+    arity: 3
+    return: {type: "EVP_KEM*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_SIGNATURE_fetch
+    arity: 3
+    return: {type: "EVP_SIGNATURE*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PKEY_new_raw_private_key_ex
+    arity: 5
+    return: {type: "EVP_PKEY*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: keytype
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 4
+        name: len
+        role: metadata-contributing
+        contributes: {property: keyLength, derivation: argument_value}
+  - method: EVP_PKEY_new_raw_public_key_ex
+    arity: 5
+    return: {type: "EVP_PKEY*", confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: keytype
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 4
+        name: len
+        role: metadata-contributing
+        contributes: {property: keyLength, derivation: argument_value}
+  - method: EVP_PKEY_get_raw_private_key
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: output
+  - method: EVP_PKEY_get_raw_public_key
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: output
+  - method: EVP_PKEY_sign_message_init
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PKEY_verify_message_init
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_PKEY_CTX_set_rsa_padding
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: padding
+        role: operation-determining
+        contributes: {property: padding, derivation: argument_value}
+  - method: EVP_PKEY_CTX_set_rsa_pss_saltlen
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: saltlen
+        role: metadata-contributing
+        contributes: {property: saltLength, derivation: argument_value}
+  - method: EVP_PKEY_CTX_set_rsa_mgf1_md
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 1
+        name: digest
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+
+  # Stateful EVP lifecycles around the rule-selected factories and initializers.
+  - method: EVP_CIPHER_CTX_new
+    arity: 0
+    return: {type: "EVP_CIPHER_CTX*", confidence: high}
+    role: factory
+  - method: EVP_EncryptUpdate
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: inl
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_EncryptFinal_ex
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+  - method: EVP_DecryptUpdate
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: inl
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_DecryptFinal_ex
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+  - method: EVP_CipherUpdate
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: inl
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_CipherFinal_ex
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+
+  - method: EVP_MD_CTX_new
+    arity: 0
+    return: {type: "EVP_MD_CTX*", confidence: high}
+    role: factory
+  - method: EVP_DigestUpdate
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: count
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_DigestFinal_ex
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+  - method: EVP_DigestFinalXOF
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: outlen
+        role: metadata-contributing
+        contributes: {property: outputLength, derivation: argument_value}
+
+  - method: EVP_MAC_CTX_new
+    arity: 1
+    return: {type: "EVP_MAC_CTX*", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: mac
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_MAC_init
+    arity: 4
+    return: {type: "int", confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: keylen
+        role: metadata-contributing
+        contributes: {property: keyLength, derivation: argument_value}
+  - method: EVP_MAC_update
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: datalen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_MAC_final
+    arity: 4
+    return: {type: "int", confidence: high}
+    role: operation
+
+  - method: EVP_KDF_CTX_new
+    arity: 1
+    return: {type: "EVP_KDF_CTX*", confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: kdf
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+  - method: EVP_KDF_derive
+    arity: 4
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: keylen
+        role: metadata-contributing
+        contributes: {property: outputLength, derivation: argument_value}
+
+  - method: EVP_PKEY_keygen_init
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_keygen
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: operation
+  - method: EVP_PKEY_sign_init
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_sign
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: tbslen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_PKEY_verify_init
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_verify
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: siglen
+        role: metadata-contributing
+        contributes: {property: signatureLength, derivation: argument_value}
+      - index: 4
+        name: tbslen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_PKEY_sign_message_update
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: inlen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_PKEY_sign_message_final
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+  - method: EVP_PKEY_verify_message_update
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: inlen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_PKEY_verify_message_final
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: operation
+
+  - method: EVP_PKEY_encrypt_init
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_encrypt
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: inlen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_PKEY_decrypt_init
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_decrypt
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: inlen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: EVP_PKEY_derive_init
+    arity: 1
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_derive_set_peer
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_derive
+    arity: 3
+    return: {type: "int", confidence: high}
+    role: operation
+
+  - method: EVP_PKEY_encapsulate_init
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_encapsulate
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+  - method: EVP_PKEY_decapsulate_init
+    arity: 2
+    return: {type: "int", confidence: high}
+    role: config
+  - method: EVP_PKEY_decapsulate
+    arity: 5
+    return: {type: "int", confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/c_openssl_evp_test.go
+++ b/internal/callgraph/contracts/c_openssl_evp_test.go
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedCIncludesOpenSSLEVPContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("c")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(c): %v", err)
+	}
+
+	tests := []struct {
+		method, returnType, role, property string
+		arity                              int
+	}{
+		{"EVP_aes_256_gcm", "const EVP_CIPHER*", "factory", "", 0},
+		{"EVP_CIPHER_fetch", "EVP_CIPHER*", "factory", "algorithm", 3},
+		{"EVP_CipherInit_ex", "int", "config", "algorithm", 6},
+		{"EVP_sha256", "const EVP_MD*", "factory", "", 0},
+		{"EVP_DigestInit_ex2", "int", "config", "algorithm", 3},
+		{"EVP_Digest", "int", "operation", "algorithm", 6},
+		{"EVP_PKEY_CTX_new_from_name", "EVP_PKEY_CTX*", "factory", "algorithm", 3},
+		{"EVP_PKEY_Q_keygen", "EVP_PKEY*", "factory", "algorithm", 4},
+		{"EVP_PKEY_CTX_set_rsa_pss_saltlen", "int", "config", "saltLength", 2},
+		{"EVP_PBE_scrypt", "int", "operation", "iterations", 10},
+		{"EVP_DigestFinal_ex", "int", "operation", "", 3},
+		{"EVP_PKEY_get_raw_public_key", "int", "output", "", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "openssl-evp" || contract.Return.Type != tt.returnType ||
+				contract.Return.Confidence != "high" || contract.Role != tt.role {
+				t.Fatalf("contract = %#v, want openssl-evp %s %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}
+
+func TestOpenSSLEVPParameterRoles(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("c")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(c): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property, derivation string
+		arity, index                       int
+	}{
+		{"PKCS5_PBKDF2_HMAC", "operation-determining", "algorithm", "argument_value", 8, 5},
+		{"PKCS5_PBKDF2_HMAC", "metadata-contributing", "outputLength", "argument_value", 8, 6},
+		{"EVP_CipherInit_ex", "operation-determining", "algorithm", "argument_value", 6, 1},
+		{"EVP_PKEY_Q_keygen", "operation-determining", "algorithm", "argument_value", 4, 2},
+		{"EVP_PKEY_Q_keygen", "metadata-contributing", "parameterSet", "argument_value", 4, 3},
+		{"EVP_PBE_scrypt", "metadata-contributing", "iterations", "argument_value", 10, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+"/"+tt.property, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			for _, parameter := range got[0].Parameters {
+				if parameter.Index != nil && *parameter.Index == tt.index && parameter.Role == tt.role &&
+					parameter.Contributes != nil && parameter.Contributes.Property == tt.property &&
+					parameter.Contributes.Derivation == tt.derivation {
+					return
+				}
+			}
+			t.Fatalf("parameters = %#v, want index=%d role=%s contribution=%s/%s",
+				got[0].Parameters, tt.index, tt.role, tt.property, tt.derivation)
+		})
+	}
+}


### PR DESCRIPTION
Closes #90

## Summary

- add 121 schema-v2 OpenSSL EVP C contracts with exact public call arities
- classify factory/config/operation/output lifecycles and supported parameter derivations
- replace the temporary C bootstrap with the first real C library KB and add focused assertions

## API inventory and dispositions

Primary sources: OpenSSL 3.6.2 public headers and `scanoss/crypto_rules` commit `39597ad26c0a968aa927592ca8ac29698018dea1`.

| Current rule API scope | Disposition |
|---|---|
| `EVP_aes_{128,192,256}_{cbc,ccm,ctr,ecb,cfb,gcm,ofb}` and `EVP_aes_{128,256}_xts` | contracted, arity 0 |
| `EVP_des_{cbc,ecb,cfb,ofb}`, `EVP_des_ede`, `EVP_des_ede_cbc`, `EVP_des_ede3`, `EVP_des_ede3_cbc` | contracted, arity 0 |
| `EVP_rc4`, `EVP_rc4_40`, `EVP_rc4_hmac_md5` | contracted, arity 0 |
| `EVP_get_cipherbyname`, `EVP_CIPHER_fetch`, `EVP_CipherInit_ex`, `EVP_EncryptInit_ex`, `EVP_DecryptInit_ex` | contracted with exact arity and algorithm selector role |
| `EVP_blake2b512`, `EVP_blake2s256`, `EVP_md4`, `EVP_md5`, `EVP_ripemd160`, `EVP_sha1`, `EVP_sha224`, `EVP_sha256`, `EVP_sha384`, `EVP_sha512`, `EVP_sha3_{224,256,384,512}`, `EVP_shake{128,256}`, `EVP_sm3`, `EVP_whirlpool` | contracted, arity 0 |
| `EVP_get_digestbyname`, `EVP_MD_fetch`, `EVP_DigestInit`, `EVP_DigestInit_ex`, `EVP_DigestInit_ex2`, `EVP_Digest`, `EVP_Q_digest` | contracted with exact arity and supported algorithm/length roles |
| `EVP_KDF_fetch`, `EVP_MAC_fetch`, `EVP_PBE_scrypt`, `PKCS5_PBKDF2_HMAC` | contracted with exact arity and supported KDF/MAC parameters |
| `EVP_PKEY_CTX_new_id`, `EVP_PKEY_CTX_new_from_name`, `EVP_PKEY_Q_keygen`, `EVP_KEM_fetch`, `EVP_SIGNATURE_fetch` | contracted; `EVP_PKEY_Q_keygen` covers the documented 3- and 4-argument rule shapes, including the fourth parameter set/key-size argument |
| `EVP_PKEY_new_raw_private_key_ex`, `EVP_PKEY_new_raw_public_key_ex`, `EVP_PKEY_sign_message_init`, `EVP_PKEY_verify_message_init` | contracted with exact arity and supported key/algorithm parameters |
| `EVP_PKEY_get_raw_private_key`, `EVP_PKEY_get_raw_public_key` | contracted as raw-key output extraction calls |
| `EVP_PKEY_CTX_set_rsa_padding`, `EVP_PKEY_CTX_set_rsa_pss_saltlen`, `EVP_PKEY_CTX_set_rsa_mgf1_md` | contracted as configuration calls |
| `EVP_CIPHER_CTX_new`, cipher update/final calls, `EVP_MD_CTX_new`, digest update/final calls, `EVP_MAC_CTX_new`/init/update/final, `EVP_KDF_CTX_new`/derive, PKEY keygen/encrypt/decrypt/derive/sign/verify/message/KEM operations | contracted lifecycle support around current rule anchors |
| `EVP_PKEY_{DH,DHX,DSA,EC,ED25519,ED448,RSA,RSA_PSS,SM2,X25519,X448}` and `EVP_MD` | skipped-non-callable constants/type token |
| regex fragments `EVP_aes_` and `EVP_sha` | covered by the expanded callable rows above |
| `EVP_aes_192_xts` | skipped-unsupported, no OpenSSL 3.6.2 public symbol despite the broad rule regex |
| variadic `EVP_PKEY_Q_keygen` shapes above arity 4 | skipped-unsupported by exact-arity C contracts; current rule-covered algorithms use arity 3 or 4 |
| legacy `HMAC`, `HMAC_Init`, `HMAC_Init_ex`, `RSA_generate_key`, and `SSL_*_set1_groups_list` | needs-follow-up, outside this EVP/libcrypto contract slice |

## Review workload

Size exception: the diff exceeds 400 lines because it is one declarative library inventory with repetitive schema-v2 entries. Splitting it would make the API disposition audit and conflict validation non-atomic. This repository has no `size:exception` label.

## Verification

- `go test ./internal/callgraph/contracts/... -count=1`
- `go test ./internal/callgraph/... -count=1`
- all non-engine Go packages
- Docker-backed `go test ./internal/engine -count=1`
- changed-package `golangci-lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded C callgraph inference for OpenSSL EVP cipher, digest, KDF, MAC, public-key, KEM, and signature APIs.
  * Added tracking for algorithm selection, cryptographic operations, parameter-derived properties, and lifecycle flows.

* **Tests**
  * Added coverage verifying OpenSSL EVP contract loading, return metadata, parameter roles, and derived properties.

* **Documentation**
  * Updated the unreleased changelog with the expanded OpenSSL EVP coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->