### PR TITLE
feat(callgraph): load C++ contract knowledge bases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ The callgraph inference engine consumes language-agnostic YAML knowledge bases u
 internal/callgraph/contracts/
 ├── contracts.go           # loader, types, validation
 ├── c/                     # schema-v2 C callgraph contracts
+├── cpp/                   # schema-v2 C++ callgraph contracts
 ├── java/
 │   └── jdk-crypto.yaml    # JDK JCA/JCE contracts (shipped in v1)
 ├── go/                    # schema-v2 Go callgraph contracts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C++ callgraph builds now load embedded schema-v2 contract knowledge bases. (#95)
 - C++ callgraph builds now populate namespace-qualified return sources and select the C++ contract type resolver. (#94)
 - C callgraph builds now load embedded schema-v2 contract knowledge bases. (#89)
 - C callgraph builds now select the C contract type resolver; pointer-returning functions can use contract inference when C knowledge bases are embedded. (#88)

--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -29,9 +29,14 @@ var goFS embed.FS
 //go:embed c/*.yaml
 var cFS embed.FS
 
+//go:embed cpp/*.yaml
+var cppFS embed.FS
+
 const (
 	// ecosystemC is the ecosystem identifier for the C contract KB.
 	ecosystemC = "c"
+	// ecosystemCPP is the ecosystem identifier for the C++ contract KB.
+	ecosystemCPP = "cpp"
 	// ecosystemGo is the ecosystem identifier for the Go contract KB.
 	ecosystemGo = "go"
 	// ecosystemPython is the ecosystem identifier for the Python contract KB.
@@ -486,6 +491,8 @@ func embedFSFor(ecosystem string) (fs.FS, string) {
 		return &javaFS, "java"
 	case ecosystemC:
 		return &cFS, ecosystemC
+	case ecosystemCPP:
+		return &cppFS, ecosystemCPP
 	case ecosystemGo:
 		return &goFS, ecosystemGo
 	case ecosystemPython:

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -707,6 +707,16 @@ func TestLoadEmbedded_C(t *testing.T) {
 	}
 }
 
+func TestLoadEmbedded_CPP(t *testing.T) {
+	kb, err := contracts.LoadEmbedded("cpp")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(\"cpp\"): %v", err)
+	}
+	if kb.Ecosystem != "cpp" {
+		t.Fatalf("Ecosystem = %q, want cpp", kb.Ecosystem)
+	}
+}
+
 // TestContractsFor_ReturnsCorrectSlice
 // kb.ContractsFor("javax.crypto.Cipher.unwrap", 3) returns 3 conditional entries.
 func TestContractsFor_ReturnsCorrectSlice(t *testing.T) {

--- a/internal/callgraph/contracts/cpp/bootstrap.yaml
+++ b/internal/callgraph/contracts/cpp/bootstrap.yaml
@@ -1,0 +1,9 @@
+schema_version: "2"
+ecosystem: cpp
+# ponytail: go:embed needs one YAML match; remove this file when the first C++ library KB lands.
+library:
+  name: cpp-bootstrap
+  description: "Bootstrap for embedded C++ callgraph contracts"
+
+contracts: []
+hierarchy: {}


### PR DESCRIPTION
Closes #95

## Summary

- embed schema-v2 C++ callgraph contract knowledge bases
- add a temporary bootstrap KB until the first C++ library contracts land
- document the C++ contract directory and cover loading with a focused regression test

## Verification

- `go test ./internal/callgraph/contracts/... -count=1`
- `go test ./internal/callgraph/... -count=1`
- repository-pinned `golangci-lint run --new-from-rev=origin/main ./...`
- `git diff --check`
