### PR TITLE
feat(callgraph): add mbedTLS C contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- C callgraph contracts now model the rule-covered Mbed TLS 3.6 LTS PKCS#7, LMS, public-key, TLS, and X.509 lifecycles. (#92)
 - C++ callgraph builds now populate namespace-qualified return sources and select the C++ contract type resolver. (#94)
 - C callgraph builds now load embedded schema-v2 contract knowledge bases. (#89)
 - C callgraph builds now select the C contract type resolver; pointer-returning functions can use contract inference when C knowledge bases are embedded. (#88)

--- a/internal/callgraph/contracts/c/bootstrap.yaml
+++ b/internal/callgraph/contracts/c/bootstrap.yaml
@@ -1,9 +1,0 @@
-schema_version: "2"
-ecosystem: c
-# ponytail: go:embed needs one YAML match; remove this file when the first C library KB lands.
-library:
-  name: c-bootstrap
-  description: "Bootstrap for embedded C callgraph contracts"
-
-contracts: []
-hierarchy: {}

--- a/internal/callgraph/contracts/c/mbedtls.yaml
+++ b/internal/callgraph/contracts/c/mbedtls.yaml
@@ -1,0 +1,237 @@
+schema_version: "2"
+ecosystem: c
+library:
+  name: mbedtls
+  coordinates:
+    - mbedtls
+  version_range: ">=3.6.7,<4.0.0"
+  description: "Mbed TLS 3.6 LTS public cryptographic APIs"
+
+# Inventory sources: Mbed TLS 3.6.7 public headers and crypto_rules mbedtls.yaml
+# blob 077e379cb77b02ce182623b54660796aa24efb8f. All 28 mbedtls_* symbols
+# selected by the current C rules are contracted. PSA-only symbols are outside this
+# ticket's mbedtls_* scope. covered-existing/skipped-unsupported/needs-follow-up:
+# none. Protocol and certificate lifecycle calls are included where rules exist.
+contracts:
+
+  # Leighton-Micali signatures.
+  - method: mbedtls_lms_export_public_key
+    arity: 4
+    return: {type: int, confidence: high}
+    role: output
+  - method: mbedtls_lms_generate_private_key
+    arity: 7
+    return: {type: int, confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: {property: parameterSet, derivation: argument_value}
+      - index: 2
+        name: otstype
+        role: operation-determining
+        contributes: {property: parameterSet, derivation: argument_value}
+      - index: 6
+        name: seed_size
+        role: metadata-contributing
+        contributes: {property: seedLength, derivation: argument_value}
+  - method: mbedtls_lms_import_public_key
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: key_size
+        role: metadata-contributing
+        contributes: {property: keyLength, derivation: argument_value}
+  - method: mbedtls_lms_private_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_lms_public_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_lms_sign
+    arity: 8
+    return: {type: int, confidence: high}
+    role: operation
+    parameters:
+      - index: 4
+        name: msg_size
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_lms_verify
+    arity: 5
+    return: {type: int, confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: msg_size
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+      - index: 4
+        name: sig_size
+        role: metadata-contributing
+        contributes: {property: signatureLength, derivation: argument_value}
+
+  # Public-key contexts and operations.
+  - method: mbedtls_pk_import_into_psa
+    arity: 3
+    return: {type: int, confidence: high}
+    role: factory
+  - method: mbedtls_pk_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_pk_sign
+    arity: 9
+    return: {type: int, confidence: high}
+    role: operation
+    parameters:
+      - index: 1
+        name: md_alg
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 3
+        name: hash_len
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_value}
+  - method: mbedtls_pk_verify
+    arity: 6
+    return: {type: int, confidence: high}
+    role: operation
+    parameters:
+      - index: 1
+        name: md_alg
+        role: operation-determining
+        contributes: {property: algorithm, derivation: argument_value}
+      - index: 3
+        name: hash_len
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_value}
+      - index: 5
+        name: sig_len
+        role: metadata-contributing
+        contributes: {property: signatureLength, derivation: argument_value}
+
+  # PKCS#7 signed data.
+  - method: mbedtls_pkcs7_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_pkcs7_signed_data_verify
+    arity: 4
+    return: {type: int, confidence: high}
+    role: operation
+    parameters:
+      - index: 3
+        name: datalen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_pkcs7_signed_hash_verify
+    arity: 4
+    return: {type: int, confidence: high}
+    role: operation
+    parameters:
+      - index: 3
+        name: hashlen
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_value}
+
+  # TLS context lifecycle.
+  - method: mbedtls_ssl_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_ssl_setup
+    arity: 2
+    return: {type: int, confidence: high}
+    role: config
+
+  # X.509 certificate-revocation lists.
+  - method: mbedtls_x509_crl_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_x509_crl_parse
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: buflen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_x509_crl_parse_der
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: buflen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_x509_crl_parse_file
+    arity: 2
+    return: {type: int, confidence: high}
+    role: config
+
+  # X.509 certificates.
+  - method: mbedtls_x509_crt_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_x509_crt_parse
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: buflen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_x509_crt_parse_der
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: buflen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_x509_crt_parse_file
+    arity: 2
+    return: {type: int, confidence: high}
+    role: config
+
+  # X.509 certificate-signing requests.
+  - method: mbedtls_x509_csr_init
+    arity: 1
+    return: {type: void, confidence: high}
+    role: factory
+  - method: mbedtls_x509_csr_parse
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: buflen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_x509_csr_parse_der
+    arity: 3
+    return: {type: int, confidence: high}
+    role: config
+    parameters:
+      - index: 2
+        name: buflen
+        role: metadata-contributing
+        contributes: {property: dataLength, derivation: argument_value}
+  - method: mbedtls_x509_csr_parse_file
+    arity: 2
+    return: {type: int, confidence: high}
+    role: config
+
+hierarchy: {}

--- a/internal/callgraph/contracts/c_mbedtls_test.go
+++ b/internal/callgraph/contracts/c_mbedtls_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedCIncludesMbedTLSContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("c")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(c): %v", err)
+	}
+
+	tests := []struct {
+		method, role, returnType string
+		arity                    int
+	}{
+		{"mbedtls_lms_export_public_key", "output", "int", 4},
+		{"mbedtls_lms_generate_private_key", "factory", "int", 7},
+		{"mbedtls_lms_import_public_key", "config", "int", 3},
+		{"mbedtls_lms_private_init", "factory", "void", 1},
+		{"mbedtls_lms_public_init", "factory", "void", 1},
+		{"mbedtls_lms_sign", "operation", "int", 8},
+		{"mbedtls_lms_verify", "operation", "int", 5},
+		{"mbedtls_pk_import_into_psa", "factory", "int", 3},
+		{"mbedtls_pk_init", "factory", "void", 1},
+		{"mbedtls_pk_sign", "operation", "int", 9},
+		{"mbedtls_pk_verify", "operation", "int", 6},
+		{"mbedtls_pkcs7_init", "factory", "void", 1},
+		{"mbedtls_pkcs7_signed_data_verify", "operation", "int", 4},
+		{"mbedtls_pkcs7_signed_hash_verify", "operation", "int", 4},
+		{"mbedtls_ssl_init", "factory", "void", 1},
+		{"mbedtls_ssl_setup", "config", "int", 2},
+		{"mbedtls_x509_crl_init", "factory", "void", 1},
+		{"mbedtls_x509_crl_parse", "config", "int", 3},
+		{"mbedtls_x509_crl_parse_der", "config", "int", 3},
+		{"mbedtls_x509_crl_parse_file", "config", "int", 2},
+		{"mbedtls_x509_crt_init", "factory", "void", 1},
+		{"mbedtls_x509_crt_parse", "config", "int", 3},
+		{"mbedtls_x509_crt_parse_der", "config", "int", 3},
+		{"mbedtls_x509_crt_parse_file", "config", "int", 2},
+		{"mbedtls_x509_csr_init", "factory", "void", 1},
+		{"mbedtls_x509_csr_parse", "config", "int", 3},
+		{"mbedtls_x509_csr_parse_der", "config", "int", 3},
+		{"mbedtls_x509_csr_parse_file", "config", "int", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "mbedtls" || contract.Role != tt.role || contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want mbedtls %s returning %s with high confidence", contract, tt.role, tt.returnType)
+			}
+		})
+	}
+}
+
+func TestMbedTLSParameterDerivations(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("c")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(c): %v", err)
+	}
+
+	tests := []struct {
+		method, property, role string
+		arity                  int
+		index                  int
+	}{
+		{"mbedtls_lms_generate_private_key", "parameterSet", "operation-determining", 7, 1},
+		{"mbedtls_lms_generate_private_key", "parameterSet", "operation-determining", 7, 2},
+		{"mbedtls_lms_generate_private_key", "seedLength", "metadata-contributing", 7, 6},
+		{"mbedtls_lms_import_public_key", "keyLength", "metadata-contributing", 3, 2},
+		{"mbedtls_lms_sign", "dataLength", "metadata-contributing", 8, 4},
+		{"mbedtls_lms_verify", "dataLength", "metadata-contributing", 5, 2},
+		{"mbedtls_lms_verify", "signatureLength", "metadata-contributing", 5, 4},
+		{"mbedtls_pk_sign", "algorithm", "operation-determining", 9, 1},
+		{"mbedtls_pk_sign", "digestLength", "metadata-contributing", 9, 3},
+		{"mbedtls_pk_verify", "algorithm", "operation-determining", 6, 1},
+		{"mbedtls_pk_verify", "digestLength", "metadata-contributing", 6, 3},
+		{"mbedtls_pk_verify", "signatureLength", "metadata-contributing", 6, 5},
+		{"mbedtls_pkcs7_signed_data_verify", "dataLength", "metadata-contributing", 4, 3},
+		{"mbedtls_pkcs7_signed_hash_verify", "digestLength", "metadata-contributing", 4, 3},
+		{"mbedtls_x509_crl_parse", "dataLength", "metadata-contributing", 3, 2},
+		{"mbedtls_x509_crl_parse_der", "dataLength", "metadata-contributing", 3, 2},
+		{"mbedtls_x509_crt_parse", "dataLength", "metadata-contributing", 3, 2},
+		{"mbedtls_x509_crt_parse_der", "dataLength", "metadata-contributing", 3, 2},
+		{"mbedtls_x509_csr_parse", "dataLength", "metadata-contributing", 3, 2},
+		{"mbedtls_x509_csr_parse_der", "dataLength", "metadata-contributing", 3, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method+"/"+tt.property, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			for _, parameter := range got[0].Parameters {
+				if parameter.Index != nil && *parameter.Index == tt.index && parameter.Role == tt.role && parameter.Contributes != nil && parameter.Contributes.Property == tt.property && parameter.Contributes.Derivation == "argument_value" {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want index %d with role %q contributing %q", got[0].Parameters, tt.index, tt.role, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Closes #92

## Summary

- add schema-v2 contracts for every `mbedtls_*` callable selected by the current C rules
- model factory, configuration, operation, and output lifecycles with source-backed parameter derivations
- replace the temporary C bootstrap and add exhaustive focused assertions plus an Unreleased changelog entry

## API inventory

Sources: Mbed TLS `mbedtls-3.6.7` public headers and crypto_rules mbedTLS rules blob `077e379cb77b02ce182623b54660796aa24efb8f`.

| Disposition | APIs |
|---|---|
| Contracted | 28 symbols: `mbedtls_lms_{public_init,private_init,import_public_key,export_public_key,generate_private_key,sign,verify}`; `mbedtls_pk_{init,import_into_psa,sign,verify}`; `mbedtls_pkcs7_{init,signed_data_verify,signed_hash_verify}`; `mbedtls_ssl_{init,setup}`; and the `mbedtls_x509_{crl,crt,csr}_{init,parse,parse_der,parse_file}` families |
| Covered existing | None |
| Skipped non-callable | The include-only Mbed TLS usage rule has no callable identity |
| Out of scope | PSA-only `psa_*` rules, per this ticket's `mbedtls_*` boundary |
| Skipped unsupported | None |
| Needs follow-up | None for the rule-covered Mbed TLS 3.6 LTS slice; the legacy PK/LMS surface is version-bounded below 4.0 |

## Verification

- [x] `go test ./internal/callgraph/contracts/... -count=1`
- [x] `go test ./internal/callgraph/... -count=1`
- [x] `go test ./... -count=1` (all non-Docker packages passed; Docker-backed engine tests rerun separately)
- [x] `go test ./internal/engine/... -count=1`
- [x] `make lint`
- [x] `git diff --check origin/main...HEAD`
- [x] Standards and spec self-review; all findings fixed and both re-reviews passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added callgraph coverage for Mbed TLS 3.6 LTS PKCS#7, LMS, public-key, TLS, and X.509 lifecycles.
  - Added metadata for key operations, return values, and parameter-derived properties such as key, data, signature, digest, and seed lengths.

- **Tests**
  - Added validation to confirm Mbed TLS contracts load correctly and expose the expected operation and parameter details.

- **Documentation**
  - Updated the unreleased changelog with the new Mbed TLS lifecycle coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->