### PR TITLE
fix(callgraph): stabilize C++ contract identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- C++ callgraph contracts now match namespace-qualified library calls independently of the scanned project path and resolve simple typed receiver calls without overriding project-local declarations. (#163)
 - C callgraph contracts now match global library symbols independently of the scanned project's package path while preserving exact project-qualified matches. (#156)
 - C callgraph pointer-return inference now propagates through in-project wrapper functions while preserving arity-qualified contract lookup. (#153)
 - Rust callgraph contracts now resolve associated functions using the canonical Rust callable identity, enabling inferred return types from embedded contracts. (#74)

--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -103,9 +103,11 @@ func (b *Builder) PackageSeparator() string {
 func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) (*CallGraph, error) {
 	buildStart := time.Now()
 	graph := &CallGraph{
-		Functions:       make(map[string]*FunctionDecl),
-		Callers:         make(map[string][]string),
-		EdgeResolutions: make(map[string]EdgeResolution),
+		Functions:                make(map[string]*FunctionDecl),
+		Callers:                  make(map[string][]string),
+		EdgeResolutions:          make(map[string]EdgeResolution),
+		ProjectDeclaredTypes:     make(map[string]bool),
+		ProjectDeclaredFunctions: make(map[string]bool),
 	}
 
 	// Phase 1: Parse source files only for packages that need full analysis
@@ -116,6 +118,9 @@ func (b *Builder) BuildFromDirectories(packages, typeOnlyPackages []PackageDir) 
 			log.Debug().Err(err).Str("package", pkg.ImportPath).Msg("Failed to analyze package")
 			continue
 		}
+	}
+	if b.ecosystem == ecosystemCPP {
+		markCPPProjectLocalCalls(graph)
 	}
 	sourceParseDuration := time.Since(sourceParseStart)
 
@@ -204,7 +209,7 @@ func (b *Builder) analyzePackage(pkg PackageDir, graph *CallGraph) error {
 	cloner, ok := b.parser.(ParserCloner)
 	workers := runtime.GOMAXPROCS(0)
 	if !ok || workers <= 1 {
-		return b.analyzeDir(pkg.Dir, pkg.ImportPath, graph)
+		return b.analyzeDir(pkg.Dir, pkg.ImportPath, graph, pkg.Version == "")
 	}
 	return b.analyzePackageParallel(pkg, graph, cloner, workers)
 }
@@ -281,24 +286,31 @@ func (b *Builder) analyzePackageParallel(pkg PackageDir, graph *CallGraph, clone
 			log.Debug().Err(errs[i]).Str("dir", work[i].dir).Msg("Failed to analyze subdirectory")
 			continue
 		}
-		b.addAnalyses(graph, results[i])
+		b.addAnalyses(graph, results[i], pkg.Version == "")
 	}
 	return nil
 }
 
-func (b *Builder) analyzeDir(dir, importPath string, graph *CallGraph) error {
+func (b *Builder) analyzeDir(dir, importPath string, graph *CallGraph, projectLocal bool) error {
 	analyses, err := b.parser.ParseDirectory(dir, importPath)
 	if err != nil {
 		return err
 	}
 
-	b.addAnalyses(graph, analyses)
-	b.analyzeSubdirs(dir, importPath, graph)
+	b.addAnalyses(graph, analyses, projectLocal)
+	b.analyzeSubdirs(dir, importPath, graph, projectLocal)
 	return nil
 }
 
-func (b *Builder) addAnalyses(graph *CallGraph, analyses []*FileAnalysis) {
+func (b *Builder) addAnalyses(graph *CallGraph, analyses []*FileAnalysis, projectLocal bool) {
 	for _, analysis := range analyses {
+		if b.ecosystem == ecosystemCPP {
+			if projectLocal {
+				addCPPProjectDeclarations(graph, analysis)
+			} else {
+				clearCPPDependencyLocalLinkage(analysis)
+			}
+		}
 		for i := range analysis.Functions {
 			fn := &analysis.Functions[i]
 			key := fn.ID.String()
@@ -315,7 +327,54 @@ func (b *Builder) addAnalyses(graph *CallGraph, analyses []*FileAnalysis) {
 	}
 }
 
-func (b *Builder) analyzeSubdirs(dir, importPath string, graph *CallGraph) {
+func clearCPPDependencyLocalLinkage(analysis *FileAnalysis) {
+	for i := range analysis.Functions {
+		fn := &analysis.Functions[i]
+		for j := range fn.Calls {
+			if fn.Calls[j].Callee.Type != "" {
+				fn.Calls[j].Callee.Linkage = ""
+			}
+		}
+		for j := range fn.ReturnSources {
+			target := fn.ReturnSources[j].CallTarget
+			if target != nil && target.Type != "" {
+				target.Linkage = ""
+			}
+		}
+	}
+}
+
+func addCPPProjectDeclarations(graph *CallGraph, analysis *FileAnalysis) {
+	for typeName := range analysis.DeclaredTypes {
+		graph.ProjectDeclaredTypes[typeName] = true
+	}
+	for i := range analysis.Functions {
+		if method := cppContractMethod(&analysis.Functions[i].ID); method != "" {
+			graph.ProjectDeclaredFunctions[method] = true
+		}
+	}
+}
+
+func markCPPProjectLocalCalls(graph *CallGraph) {
+	for _, fn := range graph.Functions {
+		for i := range fn.Calls {
+			markCPPProjectLocalTarget(&fn.Calls[i].Callee, graph.ProjectDeclaredTypes, graph.ProjectDeclaredFunctions)
+		}
+		for i := range fn.ReturnSources {
+			if fn.ReturnSources[i].CallTarget != nil {
+				markCPPProjectLocalTarget(fn.ReturnSources[i].CallTarget, graph.ProjectDeclaredTypes, graph.ProjectDeclaredFunctions)
+			}
+		}
+	}
+}
+
+func markCPPProjectLocalTarget(target *FunctionID, declaredTypes, declaredFunctions map[string]bool) {
+	if declaredTypes[target.Type] || declaredTypes[target.Type+"::"+BaseFunctionName(target.Name)] || declaredFunctions[cppContractMethod(target)] {
+		target.Linkage = LinkageInternal
+	}
+}
+
+func (b *Builder) analyzeSubdirs(dir, importPath string, graph *CallGraph, projectLocal bool) {
 	// Recurse into subdirectories
 	entries, readErr := os.ReadDir(dir)
 	if readErr != nil {
@@ -334,7 +393,7 @@ func (b *Builder) analyzeSubdirs(dir, importPath string, graph *CallGraph) {
 		}
 		subDir := filepath.Join(dir, name)
 		subImportPath := b.parser.SubPackagePath(importPath, name)
-		if err := b.analyzeDir(subDir, subImportPath, graph); err != nil {
+		if err := b.analyzeDir(subDir, subImportPath, graph, projectLocal); err != nil {
 			log.Debug().Err(err).Str("dir", subDir).Msg("Failed to analyze subdirectory")
 		}
 	}
@@ -1094,8 +1153,16 @@ func resolveChainCalleesInFunction(graph *CallGraph, callerKey string, fn *Funct
 
 func resolveChainLinkCallees(graph *CallGraph, callerKey string, fn *FunctionDecl, idxs []int, kb *contracts.KnowledgeBase) int {
 	// Seed the receiver type from the root (innermost) link's KB return type.
-	rootFQN, rootArity := splitMethodArity(&fn.Calls[idxs[0]].Callee)
-	currentType := unconditionalContractReturn(kb.ContractsForTolerant(rootFQN, rootArity))
+	rootCall := &fn.Calls[idxs[0]]
+	rootFQN, rootArity := splitMethodArity(&rootCall.Callee)
+	if kb.Ecosystem == ecosystemCPP && rootArity < 0 {
+		rootArity = len(rootCall.Arguments)
+	}
+	rootContracts := kb.ContractsForTolerant(rootFQN, rootArity)
+	if len(rootContracts) == 0 && kb.Ecosystem == ecosystemCPP && rootCall.Callee.Type != "" && rootCall.Callee.Linkage != LinkageInternal && callResultCallee(graph, &rootCall.Callee, rootArity) == nil {
+		rootContracts = kb.ContractsFor(cppContractMethod(&rootCall.Callee), rootArity)
+	}
+	currentType := unconditionalContractReturn(rootContracts)
 
 	resolved := 0
 	for pos := 1; pos < len(idxs); pos++ {
@@ -1104,6 +1171,9 @@ func resolveChainLinkCallees(graph *CallGraph, callerKey string, fn *FunctionDec
 		}
 		call := &fn.Calls[idxs[pos]]
 		base, arity := methodBaseArity(call.Callee.Name)
+		if kb.Ecosystem == ecosystemCPP && arity < 0 {
+			arity = len(call.Arguments)
+		}
 		ctrs := kb.ContractsForTolerant(currentType+"."+base, arity)
 		if len(ctrs) == 0 {
 			break // not a known method of the propagated type; stop, do not guess

--- a/internal/callgraph/cpp_contract_identity_test.go
+++ b/internal/callgraph/cpp_contract_identity_test.go
@@ -1,0 +1,270 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestCPPContractInferenceUsesProjectIndependentQualifiedIdentity(t *testing.T) {
+	t.Parallel()
+
+	kb := &contracts.KnowledgeBase{Ecosystem: ecosystemCPP, Contracts: map[string][]contracts.Contract{
+		"CryptoPP.SHA256#0": {{Return: contracts.ContractReturn{Type: "CryptoPP::SHA256", Confidence: "high"}}},
+	}}
+	for _, pkg := range []string{"app/one", "app/two"} {
+		t.Run(pkg, func(t *testing.T) {
+			t.Parallel()
+			target := FunctionID{Package: pkg, Type: "CryptoPP", Name: "SHA256#0"}
+			wrapper := &FunctionDecl{
+				ID:            FunctionID{Package: pkg, Name: "digest"},
+				ReturnSources: []SourceNode{{Type: sourceNodeCallResult, CallTarget: &target}},
+			}
+			if err := InferReturnTypes(buildTestCallGraph(wrapper), kb); err != nil {
+				t.Fatal(err)
+			}
+			if wrapper.InferredReturn == nil || wrapper.InferredReturn.Type != "CryptoPP::SHA256" {
+				t.Fatalf("InferredReturn = %#v, want project-independent Crypto++ contract", wrapper.InferredReturn)
+			}
+		})
+	}
+}
+
+func TestCPPContractInferencePreservesLocalQualifiedDeclaration(t *testing.T) {
+	t.Parallel()
+
+	kb := &contracts.KnowledgeBase{Ecosystem: ecosystemCPP, Contracts: map[string][]contracts.Contract{
+		"CryptoPP.SHA256#0": {{Return: contracts.ContractReturn{Type: "CryptoPP::SHA256", Confidence: "high"}}},
+	}}
+	target := FunctionID{Package: "app", Type: "CryptoPP", Name: "SHA256#0"}
+	localID := FunctionID{Package: "app", Type: "CryptoPP", Name: "SHA256"}
+	wrapper := &FunctionDecl{
+		ID:            FunctionID{Package: "app", Name: "digest"},
+		ReturnSources: []SourceNode{{Type: sourceNodeCallResult, CallTarget: &target}},
+	}
+	graph := buildTestCallGraph(wrapper, &FunctionDecl{ID: localID})
+	if err := InferReturnTypes(graph, kb); err != nil {
+		t.Fatal(err)
+	}
+	if wrapper.InferredReturn != nil {
+		t.Fatalf("InferredReturn = %#v, want local declaration to suppress library fallback", wrapper.InferredReturn)
+	}
+}
+
+func TestCPPParserResolvesTypedReceiverIdentity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := `void digest(const CryptoPP::byte *in, size_t len, CryptoPP::byte *out) {
+    CryptoPP::SHA256 hash;
+    hash.Update(in, len);
+	{
+		Local::SHA256 hash;
+		hash.Final(out);
+	}
+}`
+	if err := os.WriteFile(filepath.Join(dir, "digest.cpp"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewCPPParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := analyses[0].Functions[0].Calls
+	if len(calls) != 2 || calls[0].Callee.Type != "CryptoPP::SHA256" || calls[1].Callee.Type != "Local::SHA256" {
+		t.Fatalf("calls = %#v, want lexical receiver types", calls)
+	}
+}
+
+func TestCPPParserPreservesInlineLocalTypePrecedence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := `namespace CryptoPP {
+class SHA256 {
+public:
+    void Update(const void *, int) {}
+};
+}
+void digest(const void *input, int length) {
+    CryptoPP::SHA256 hash;
+    hash.Update(input, length);
+}`
+	if err := os.WriteFile(filepath.Join(dir, "local.cpp"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graph, err := NewBuilderForEcosystem(ecosystemCPP, NewCPPParser()).BuildFromDirectories([]PackageDir{{Dir: dir, ImportPath: "app"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	method := FunctionID{Package: "app", Type: "CryptoPP::SHA256", Name: "Update"}
+	if graph.Functions[method.String()] == nil {
+		t.Fatalf("functions = %#v, want inline %s", graph.Functions, method.String())
+	}
+	digest := graph.Functions[(FunctionID{Package: "app", Name: "digest"}).String()]
+	if len(digest.Calls) != 1 || digest.Calls[0].Callee.Linkage != LinkageInternal {
+		t.Fatalf("digest calls = %#v, want project-local receiver", digest.Calls)
+	}
+}
+
+func TestCPPParserPreservesCrossFileLocalTypePrecedence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	header := `namespace CryptoPP {
+class SHA256 {
+public:
+    void Update(const void *, int);
+};
+}`
+	source := `void digest(const void *input, int length) {
+    CryptoPP::SHA256 hash;
+    hash.Update(input, length);
+}`
+	for name, content := range map[string]string{"local.hpp": header, "digest.cpp": source} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	graph, err := NewBuilderForEcosystem(ecosystemCPP, NewCPPParser()).BuildFromDirectories([]PackageDir{{Dir: dir, ImportPath: "app"}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := graph.Functions[(FunctionID{Package: "app", Name: "digest"}).String()]
+	if len(digest.Calls) != 1 || digest.Calls[0].Callee.Linkage != LinkageInternal {
+		t.Fatalf("digest calls = %#v, want header-declared project-local receiver", digest.Calls)
+	}
+}
+
+func TestCPPParserPreservesCrossPackageLocalNamespaceFunction(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	libDir := filepath.Join(root, "lib")
+	appDir := filepath.Join(root, "app")
+	for _, dir := range []string{libDir, appDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "local.cpp"), []byte(`namespace CryptoPP { int SHA256() { return 7; } }`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "digest.cpp"), []byte(`int digest() { return CryptoPP::SHA256(); }`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graph, err := NewBuilderForEcosystem(ecosystemCPP, NewCPPParser()).BuildFromDirectories([]PackageDir{
+		{Dir: libDir, ImportPath: "project/lib"},
+		{Dir: appDir, ImportPath: "project/app"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := graph.Functions[(FunctionID{Package: "project/app", Name: "digest"}).String()]
+	if len(digest.Calls) != 1 || digest.Calls[0].Callee.Linkage != LinkageInternal {
+		t.Fatalf("digest calls = %#v, want cross-package project-local namespace function", digest.Calls)
+	}
+	if len(digest.ReturnSources) != 1 || digest.ReturnSources[0].CallTarget == nil || digest.ReturnSources[0].CallTarget.Linkage != LinkageInternal {
+		t.Fatalf("digest return sources = %#v, want cross-package project-local namespace function", digest.ReturnSources)
+	}
+}
+
+func TestCPPParserDoesNotTreatDependencyTypesAsProjectLocal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dependency")
+	appDir := filepath.Join(root, "app")
+	for _, dir := range []string{depDir, appDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dependency := `namespace CryptoPP { class SHA256 {}; }
+auto dependencyDigest() { return CryptoPP::SHA256(); }`
+	if err := os.WriteFile(filepath.Join(depDir, "sha.cpp"), []byte(dependency), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "digest.cpp"), []byte(`auto digest() { return CryptoPP::SHA256(); }`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	graph, err := NewBuilderForEcosystem(ecosystemCPP, NewCPPParser()).BuildFromDirectories([]PackageDir{
+		{Dir: appDir, ImportPath: "app"},
+		{Dir: depDir, ImportPath: "cryptopp", Version: "8.9.0"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := graph.Functions[(FunctionID{Package: "app", Name: "digest"}).String()]
+	if len(digest.Calls) != 1 || digest.Calls[0].Callee.Linkage == LinkageInternal {
+		t.Fatalf("digest calls = %#v, want versioned dependency receiver to remain external", digest.Calls)
+	}
+	dependencyDigest := graph.Functions[(FunctionID{Package: "cryptopp", Name: "dependencyDigest"}).String()]
+	if len(dependencyDigest.Calls) != 1 || dependencyDigest.Calls[0].Callee.Linkage == LinkageInternal {
+		t.Fatalf("dependency calls = %#v, want versioned dependency self-call to remain external", dependencyDigest.Calls)
+	}
+}
+
+func TestCPPParserNormalizesGlobalQualifierOnReceiverTypes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	src := `void update(::CryptoPP::SHA256 &hash, const void *input) {
+    hash.Update(input);
+}
+void digest(const void *input) {
+    ::CryptoPP::SHA256 hash;
+    hash.Update(input);
+}`
+	if err := os.WriteFile(filepath.Join(dir, "global.cpp"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewCPPParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, function := range analyses[0].Functions {
+		if len(function.Calls) != 1 || function.Calls[0].Callee.Type != "CryptoPP::SHA256" {
+			t.Fatalf("%s parameters = %#v calls = %#v, want normalized receiver type", function.ID, function.Parameters, function.Calls)
+		}
+	}
+}
+
+func TestCPPContractResolutionUsesCallArityAndGlobalQualifier(t *testing.T) {
+	t.Parallel()
+
+	kb := &contracts.KnowledgeBase{Ecosystem: ecosystemCPP, Contracts: map[string][]contracts.Contract{
+		"CryptoPP.SHA256#0":         {{Return: contracts.ContractReturn{Type: "CryptoPP::SHA256", Confidence: "high"}}},
+		"CryptoPP::SHA256.Update#1": {{Return: contracts.ContractReturn{Type: "CryptoPP::SHA256", Confidence: "high"}}},
+	}}
+	fn := &FunctionDecl{
+		ID: FunctionID{Package: "app", Name: "digest"},
+		Calls: []FunctionCall{
+			{Callee: FunctionID{Package: "app", Type: "CryptoPP", Name: "SHA256"}, Arguments: nil, ChainID: "1", Raw: "::CryptoPP::SHA256"},
+			{Callee: FunctionID{Package: "app", Name: "Update"}, Arguments: []string{"input"}, ChainID: "1", Raw: "::CryptoPP::SHA256().Update"},
+		},
+	}
+	graph := buildTestCallGraph(fn)
+	resolveFluentChainCalleesByContract(graph, kb)
+	if fn.Calls[1].Callee.Type != "CryptoPP::SHA256" {
+		t.Fatalf("resolved call = %#v, want arity-aware CryptoPP::SHA256.Update", fn.Calls[1])
+	}
+
+	dir := t.TempDir()
+	src := `auto digest() { return ::CryptoPP::SHA256(); }`
+	if err := os.WriteFile(filepath.Join(dir, "global.cpp"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewCPPParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := analyses[0].Functions[0].Calls[0].Callee.Type; got != "CryptoPP" {
+		t.Fatalf("global qualifier type = %q, want CryptoPP", got)
+	}
+}

--- a/internal/callgraph/cpp_parser.go
+++ b/internal/callgraph/cpp_parser.go
@@ -3,6 +3,7 @@ package callgraph
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,25 +77,59 @@ func (p *CPPParser) parseFile(filePath, packagePath string) (*FileAnalysis, erro
 	}
 	defer tree.Close()
 
-	analysis := &FileAnalysis{FilePath: filePath, PackageName: packagePath, PackagePath: packagePath, Imports: make(map[string]string)}
+	analysis := &FileAnalysis{
+		FilePath:      filePath,
+		PackageName:   packagePath,
+		PackagePath:   packagePath,
+		Imports:       make(map[string]string),
+		DeclaredTypes: make(map[string]bool),
+	}
 	staticFunctions := make(map[string]bool)
 	collectCPPStaticFunctions(tree.RootNode(), src, staticFunctions)
-	p.walkFile(tree.RootNode(), src, filePath, packagePath, staticFunctions, analysis)
+	collectCPPDeclaredTypes(tree.RootNode(), src, "", analysis.DeclaredTypes)
+	p.walkFile(tree.RootNode(), src, filePath, packagePath, "", staticFunctions, analysis.DeclaredTypes, analysis)
 	return analysis, nil
 }
 
-func (p *CPPParser) walkFile(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, analysis *FileAnalysis) {
+func (p *CPPParser) walkFile(node *sitter.Node, src []byte, filePath, packagePath, scope string, staticFunctions, localTypes map[string]bool, analysis *FileAnalysis) {
 	switch node.Type() {
 	case "preproc_include":
 		p.extractInclude(node, src, analysis)
 	case cppNodeFunctionDefinition:
-		if decl := p.parseFunction(node, src, filePath, packagePath, staticFunctions); decl != nil {
+		if decl := p.parseFunction(node, src, filePath, packagePath, scope, staticFunctions, localTypes); decl != nil {
 			analysis.Functions = append(analysis.Functions, *decl)
 		}
 		return
 	}
+	scope = cppNestedScope(node, src, scope)
 	for i := 0; i < int(node.ChildCount()); i++ {
-		p.walkFile(node.Child(i), src, filePath, packagePath, staticFunctions, analysis)
+		p.walkFile(node.Child(i), src, filePath, packagePath, scope, staticFunctions, localTypes, analysis)
+	}
+}
+
+func collectCPPDeclaredTypes(node *sitter.Node, src []byte, scope string, result map[string]bool) {
+	nextScope := cppNestedScope(node, src, scope)
+	if nextScope != scope && (node.Type() == "class_specifier" || node.Type() == "struct_specifier") {
+		result[nextScope] = true
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		collectCPPDeclaredTypes(node.Child(i), src, nextScope, result)
+	}
+}
+
+func cppNestedScope(node *sitter.Node, src []byte, scope string) string {
+	switch node.Type() {
+	case "namespace_definition", "class_specifier", "struct_specifier":
+		name := node.ChildByFieldName("name")
+		if name == nil || name.Content(src) == "" {
+			return scope
+		}
+		if scope == "" {
+			return strings.TrimPrefix(name.Content(src), "::")
+		}
+		return scope + "::" + name.Content(src)
+	default:
+		return scope
 	}
 }
 
@@ -124,9 +159,12 @@ func (p *CPPParser) extractInclude(node *sitter.Node, src []byte, analysis *File
 	}
 }
 
-func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) *FunctionDecl {
+func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packagePath, scope string, staticFunctions, localTypes map[string]bool) *FunctionDecl {
 	declarator := node.ChildByFieldName("declarator")
 	name, typeName := cppDeclaratorIdentity(declarator, src)
+	if typeName == "" {
+		typeName = scope
+	}
 	body := node.ChildByFieldName("body")
 	if name == "" || body == nil {
 		return nil
@@ -139,11 +177,86 @@ func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packa
 		OwnerType:    "module",
 		OwnerName:    packagePath,
 		FunctionType: "function",
-		Parameters:   cParameters(declarator, src),
+		Parameters:   cppParameters(declarator, src),
 	}
-	p.walkCalls(body, src, filePath, packagePath, staticFunctions, &decl.Calls)
-	decl.ReturnSources = p.extractReturnSources(body, src, filePath, packagePath, staticFunctions)
+	variableTypes := cppVariableTypes(decl.Parameters)
+	p.walkCalls(body, src, filePath, packagePath, staticFunctions, localTypes, variableTypes, &decl.Calls)
+	decl.ReturnSources = p.extractReturnSources(body, src, filePath, packagePath, staticFunctions, localTypes, variableTypes)
 	return decl
+}
+
+func cppVariableTypes(parameters []FunctionParameter) map[string]string {
+	types := make(map[string]string)
+	for _, parameter := range parameters {
+		if parameter.Name != "" && parameter.Type != "" {
+			types[parameter.Name] = cppCanonicalType(parameter.Type)
+		}
+	}
+	return types
+}
+
+func recordCPPDeclarationTypes(node *sitter.Node, src []byte, types map[string]string) {
+	typeNode := node.ChildByFieldName("type")
+	if typeNode == nil {
+		return
+	}
+	typeName := cppCanonicalType(typeNode.Content(src))
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if sameSyntaxNode(child, typeNode) {
+			continue
+		}
+		if name := cDeclaratorName(child, src); name != "" {
+			types[name] = typeName
+		}
+	}
+}
+
+func cppParameters(declarator *sitter.Node, src []byte) []FunctionParameter {
+	result := cParameters(declarator, src)
+	parameters := cDescendantByType(declarator, cNodeParameterList)
+	if parameters == nil || len(result) == 0 {
+		return result
+	}
+
+	resultIndex := 0
+	for i := 0; i < int(parameters.NamedChildCount()); i++ {
+		parameter := parameters.NamedChild(i)
+		if parameter.Type() != "parameter_declaration" {
+			continue
+		}
+		if resultIndex >= len(result) {
+			break
+		}
+		result[resultIndex].Type = cppCanonicalType(result[resultIndex].Type)
+		if result[resultIndex].Name == "" {
+			result[resultIndex].Name = cppVariableDeclaratorName(parameter.ChildByFieldName("declarator"), src)
+		}
+		resultIndex++
+	}
+	return result
+}
+
+func cppVariableDeclaratorName(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	if node.Type() == cNodeIdentifier {
+		return node.Content(src)
+	}
+	if declarator := node.ChildByFieldName("declarator"); declarator != nil {
+		return cppVariableDeclaratorName(declarator, src)
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		if name := cppVariableDeclaratorName(node.NamedChild(i), src); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func cppCanonicalType(typeName string) string {
+	return strings.TrimPrefix(strings.TrimSpace(typeName), "::")
 }
 
 func cppDeclaratorName(node *sitter.Node, src []byte) string {
@@ -156,28 +269,43 @@ func cppDeclaratorIdentity(node *sitter.Node, src []byte) (name, typeName string
 		return "", ""
 	}
 	switch node.Type() {
-	case cNodeIdentifier:
+	case cNodeIdentifier, "field_identifier":
 		return node.Content(src), ""
 	case "qualified_identifier":
-		parts := strings.Split(node.Content(src), "::")
+		parts := strings.Split(strings.TrimPrefix(node.Content(src), "::"), "::")
 		return parts[len(parts)-1], strings.Join(parts[:len(parts)-1], "::")
 	default:
 		return cppDeclaratorIdentity(node.ChildByFieldName("declarator"), src)
 	}
 }
 
-func (p *CPPParser) walkCalls(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, calls *[]FunctionCall) {
+func (p *CPPParser) walkCalls(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions, localTypes map[string]bool, variableTypes map[string]string, calls *[]FunctionCall) {
+	if cppIntroducesVariableScope(node.Type()) {
+		variableTypes = maps.Clone(variableTypes)
+	}
+	if node.Type() == "declaration" {
+		recordCPPDeclarationTypes(node, src, variableTypes)
+	}
 	if node.Type() == cNodeCallExpression {
-		if call := p.parseCall(node, src, filePath, packagePath, staticFunctions); call != nil {
+		if call := p.parseCall(node, src, filePath, packagePath, staticFunctions, localTypes, variableTypes); call != nil {
 			*calls = append(*calls, *call)
 		}
 	}
 	for i := 0; i < int(node.ChildCount()); i++ {
-		p.walkCalls(node.Child(i), src, filePath, packagePath, staticFunctions, calls)
+		p.walkCalls(node.Child(i), src, filePath, packagePath, staticFunctions, localTypes, variableTypes, calls)
 	}
 }
 
-func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) *FunctionCall {
+func cppIntroducesVariableScope(nodeType string) bool {
+	switch nodeType {
+	case "compound_statement", "if_statement", "switch_statement", "for_statement", "while_statement", "do_statement", "catch_clause", lambdaExpressionNode:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions, localTypes map[string]bool, variableTypes map[string]string) *FunctionCall {
 	function := node.ChildByFieldName("function")
 	if function == nil {
 		return nil
@@ -206,48 +334,61 @@ func (p *CPPParser) parseCall(node *sitter.Node, src []byte, filePath, packagePa
 		call.Callee.Name = field.Content(src)
 		if argument != nil && argument.Type() == cNodeIdentifier {
 			call.ReceiverVar = argument.Content(src)
+			call.Callee.Type = variableTypes[call.ReceiverVar]
+			if localTypes[call.Callee.Type] {
+				call.Callee.Linkage = LinkageInternal
+			}
 		}
 	case "qualified_identifier":
-		parts := strings.Split(function.Content(src), "::")
+		parts := strings.Split(strings.TrimPrefix(function.Content(src), "::"), "::")
 		if len(parts) < 2 {
 			return nil
 		}
 		call.Callee.Name = parts[len(parts)-1]
 		call.Callee.Type = strings.Join(parts[:len(parts)-1], "::")
+		if localTypes[call.Callee.Type+"::"+call.Callee.Name] {
+			call.Callee.Linkage = LinkageInternal
+		}
 	default:
 		return nil
 	}
 	return call
 }
 
-func (p *CPPParser) extractReturnSources(body *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) []SourceNode {
+func (p *CPPParser) extractReturnSources(body *sitter.Node, src []byte, filePath, packagePath string, staticFunctions, localTypes map[string]bool, variableTypes map[string]string) []SourceNode {
 	var sources []SourceNode
-	p.walkReturnSources(body, src, filePath, packagePath, staticFunctions, &sources)
+	p.walkReturnSources(body, src, filePath, packagePath, staticFunctions, localTypes, variableTypes, &sources)
 	return sources
 }
 
-func (p *CPPParser) walkReturnSources(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool, sources *[]SourceNode) {
-	if node.Type() == "lambda_expression" {
+func (p *CPPParser) walkReturnSources(node *sitter.Node, src []byte, filePath, packagePath string, staticFunctions, localTypes map[string]bool, variableTypes map[string]string, sources *[]SourceNode) {
+	if node.Type() == lambdaExpressionNode {
 		return
+	}
+	if cppIntroducesVariableScope(node.Type()) {
+		variableTypes = maps.Clone(variableTypes)
+	}
+	if node.Type() == "declaration" {
+		recordCPPDeclarationTypes(node, src, variableTypes)
 	}
 	if node.Type() == cNodeReturnStatement {
 		if expr := cReturnExpression(node); expr != nil {
-			if source, ok := p.returnSource(expr, src, filePath, packagePath, staticFunctions); ok {
+			if source, ok := p.returnSource(expr, src, filePath, packagePath, staticFunctions, localTypes, variableTypes); ok {
 				*sources = append(*sources, source)
 			}
 		}
 		return
 	}
 	for i := 0; i < int(node.ChildCount()); i++ {
-		p.walkReturnSources(node.Child(i), src, filePath, packagePath, staticFunctions, sources)
+		p.walkReturnSources(node.Child(i), src, filePath, packagePath, staticFunctions, localTypes, variableTypes, sources)
 	}
 }
 
-func (p *CPPParser) returnSource(expr *sitter.Node, src []byte, filePath, packagePath string, staticFunctions map[string]bool) (SourceNode, bool) {
+func (p *CPPParser) returnSource(expr *sitter.Node, src []byte, filePath, packagePath string, staticFunctions, localTypes map[string]bool, variableTypes map[string]string) (SourceNode, bool) {
 	location := &SourceLocation{FilePath: filePath, Line: int(expr.StartPoint().Row) + 1}
 	switch expr.Type() {
 	case cNodeCallExpression:
-		call := p.parseCall(expr, src, filePath, packagePath, staticFunctions)
+		call := p.parseCall(expr, src, filePath, packagePath, staticFunctions, localTypes, variableTypes)
 		if call == nil {
 			return SourceNode{}, false
 		}

--- a/internal/callgraph/inference.go
+++ b/internal/callgraph/inference.go
@@ -657,11 +657,12 @@ func candidateFromCallResult(
 	// splitMethodArity extracts the FQN (without arity) and the arity integer.
 	// C alone retries a bare global symbol; other ecosystems preserve exact lookup.
 	methodFQN, arity := splitMethodArity(ct)
-	ctrs := kb.ContractsFor(methodFQN, arity)
 	callee := callResultCallee(graph, ct, arity)
+	ctrs := kb.ContractsFor(methodFQN, arity)
 	if len(ctrs) == 0 && kb.Ecosystem == "c" {
 		ctrs = kb.ContractsForCFunction(methodFQN, arity, ct.Linkage == LinkageExternal && callee == nil)
 	}
+	ctrs = cppExternalContracts(kb, ct, arity, callee, ctrs)
 
 	if len(ctrs) > 0 {
 		return candidateFromKBContracts(ctrs, src, kb)
@@ -833,4 +834,18 @@ func splitMethodArity(id *FunctionID) (string, int) {
 		return id.Package + "." + id.Type + "." + base, arity
 	}
 	return id.Package + "." + base, arity
+}
+
+func cppContractMethod(id *FunctionID) string {
+	if id == nil || id.Type == "" {
+		return ""
+	}
+	return id.Type + "." + BaseFunctionName(id.Name)
+}
+
+func cppExternalContracts(kb *contracts.KnowledgeBase, id *FunctionID, arity int, callee *FunctionDecl, current []contracts.Contract) []contracts.Contract {
+	if len(current) > 0 || kb.Ecosystem != ecosystemCPP || id.Type == "" || id.Linkage == LinkageInternal || callee != nil {
+		return current
+	}
+	return kb.ContractsFor(cppContractMethod(id), arity)
 }

--- a/internal/callgraph/java_parser.go
+++ b/internal/callgraph/java_parser.go
@@ -2466,7 +2466,7 @@ func (p *JavaParser) walkForReturnSources(
 	}
 
 	switch node.Type() {
-	case "lambda_expression":
+	case lambdaExpressionNode:
 		// TODO(callgraph-inferred-types v2): walk lambda return statements.
 		// In v1, we must NOT attribute lambda return values to the outer function.
 		// Do not descend.

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -2,13 +2,18 @@ package callgraph
 
 import "github.com/scanoss/crypto-finder/internal/javaruntime"
 
+const (
+	ecosystemCPP         = "cpp"
+	lambdaExpressionNode = "lambda_expression"
+)
+
 // NewParserForEcosystem returns the call graph parser for the given ecosystem.
 // Returns nil if no parser is available for the ecosystem.
 func NewParserForEcosystem(ecosystem string, opts ...ParserOption) Parser {
 	switch ecosystem {
 	case "c":
 		return NewCParser(opts...)
-	case "cpp", "c++":
+	case ecosystemCPP, "c++":
 		return NewCPPParser(opts...)
 	case "go":
 		return NewGoParser(opts...)
@@ -31,7 +36,7 @@ func NewTypeResolverForEcosystem(ecosystem string, javaRuntime javaruntime.Confi
 	switch ecosystem {
 	case "c":
 		return NewCContractTypeResolverFromEmbedded()
-	case "cpp", "c++":
+	case ecosystemCPP, "c++":
 		return NewCPPContractTypeResolverFromEmbedded()
 	case "go":
 		return NewGoContractTypeResolverFromEmbedded()

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -293,6 +293,7 @@ type FileAnalysis struct {
 	FromImports           map[string]bool   // symbols introduced via `from X import Y` (Python only)
 	WildcardImports       []string          // wildcard import prefixes (e.g., "java.security")
 	StaticWildcardImports []string          // static wildcard owner types (e.g., "java.util.Collections")
+	DeclaredTypes         map[string]bool   // source-declared fully qualified types (C++ only)
 	Functions             []FunctionDecl
 }
 
@@ -314,6 +315,12 @@ type CallGraph struct {
 	// JavaPlatformSignatures records whether Java platform signatures from the
 	// pinned runtime were available and used for this graph build.
 	JavaPlatformSignatures *JavaPlatformSignatureMetadata
+	// ProjectDeclaredTypes and ProjectDeclaredFunctions record stable C++
+	// identities owned by unversioned workspace packages. They keep external
+	// contract fallback from overriding project code without hiding contracts
+	// for source-parsed dependencies.
+	ProjectDeclaredTypes     map[string]bool
+	ProjectDeclaredFunctions map[string]bool
 	// EdgeResolutions records how each caller->callee call-site/dispatch variant
 	// was resolved. Keyed by EdgeResolutionKey(callerKey, calleeKey, resolution).
 	// An edge with no entry is an exact, directly-resolved source call. Consumers

--- a/internal/scan/cpp_contract_identity_test.go
+++ b/internal/scan/cpp_contract_identity_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scan
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestCPPContractRolesUseProjectIndependentQualifiedIdentity(t *testing.T) {
+	t.Parallel()
+
+	kb := &contracts.KnowledgeBase{Ecosystem: "cpp", Contracts: map[string][]contracts.Contract{
+		"CryptoPP::SHA256.Update#2": {{
+			Role: "config",
+			Parameters: []contracts.ParameterContract{{
+				Index: intPtr(1), Role: "metadata-contributing",
+				Contributes: &contracts.Contribution{Property: "inputLength", Derivation: "argument_value"},
+			}},
+		}},
+	}}
+	call := &callgraph.FunctionCall{
+		Callee:    callgraph.FunctionID{Package: "app", Type: "CryptoPP::SHA256", Name: "Update"},
+		Arguments: []string{"input", "length"},
+		FilePath:  "digest.cpp",
+		Line:      3,
+	}
+	ctx := &exportBuildContext{kb: kb, graph: &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{}}}
+
+	support := buildDerivedSupportingCall(ctx, &callgraph.FunctionDecl{ID: callgraph.FunctionID{Package: "app", Name: "digest"}}, call)
+	if support.Category != "config" || support.SupportingCall == nil || len(support.SupportingCall.ParameterRoles) != 1 {
+		t.Fatalf("support = %#v, want role and parameter contract", support)
+	}
+}
+
+func TestCPPContractRolesPreserveLocalQualifiedDeclaration(t *testing.T) {
+	t.Parallel()
+
+	kb := &contracts.KnowledgeBase{Ecosystem: "cpp", Contracts: map[string][]contracts.Contract{
+		"CryptoPP::SHA256.Update#2": {{Role: "config"}},
+	}}
+	call := &callgraph.FunctionCall{Callee: callgraph.FunctionID{Package: "app", Type: "CryptoPP::SHA256", Name: "Update"}}
+	ctx := &exportBuildContext{kb: kb, graph: &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		call.Callee.String(): {ID: call.Callee},
+	}}}
+
+	if matches := contractMatchesForCall(ctx, call, 2); len(matches) != 0 {
+		t.Fatalf("matches = %#v, want local declaration to suppress library fallback", matches)
+	}
+}

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -966,7 +966,11 @@ func contractMatchesForCall(ctx *exportBuildContext, call *callgraph.FunctionCal
 	}
 	fqn := fullFunctionName(call.Callee)
 	if ctx.kb.Ecosystem != "c" {
-		return ctx.kb.ContractsForTolerant(fqn, arity)
+		matches := ctx.kb.ContractsForTolerant(fqn, arity)
+		if len(matches) == 0 && ctx.kb.Ecosystem == "cpp" && call.Callee.Type != "" && call.Callee.Linkage != callgraph.LinkageInternal && !hasCallDeclaration(ctx.graph, call.Callee) {
+			return ctx.kb.ContractsForTolerant(call.Callee.Type+"."+callgraph.BaseFunctionName(call.Callee.Name), arity)
+		}
+		return matches
 	}
 	if exact := ctx.kb.ContractsFor(fqn, arity); len(exact) > 0 {
 		return exact
@@ -976,6 +980,17 @@ func contractMatchesForCall(ctx *exportBuildContext, call *callgraph.FunctionCal
 	}
 	externalGlobal := call.Callee.Linkage == callgraph.LinkageExternal && ctx.graph.Functions[call.Callee.String()] == nil
 	return ctx.kb.ContractsForCFunction(fqn, arity, externalGlobal)
+}
+
+func hasCallDeclaration(graph *callgraph.CallGraph, id callgraph.FunctionID) bool {
+	if graph == nil {
+		return false
+	}
+	if graph.Functions[id.String()] != nil {
+		return true
+	}
+	id.Name = callgraph.BaseFunctionName(id.Name)
+	return graph.Functions[id.String()] != nil
 }
 
 func flattenReachableSupportingCalls(values map[string]callGraphReachableSupportingCall) []callGraphReachableSupportingCall {
@@ -1517,6 +1532,9 @@ func buildDerivedSupportingCall(ctx *exportBuildContext, containingFn *callgraph
 	// vs. definition line), already separated by dedupSupportingCalls.
 	if ctx.kb != nil {
 		arity := len(sc.ParameterTypes)
+		if ctx.kb.Ecosystem == "cpp" {
+			arity = len(call.Arguments)
+		}
 		matches := contractMatchesForCall(ctx, call, arity)
 		for _, contract := range matches {
 			if contract.Role != "" {


### PR DESCRIPTION
## Summary

- make namespace-qualified C++ contract lookup independent of the scanned project path
- resolve simple typed receivers, lexical shadowing, fluent-chain arity, and leading global qualifiers
- preserve project-local classes and namespace functions across files/packages while keeping versioned dependency contracts eligible
- apply the same matching semantics to return inference, lifecycle roles, and parameter roles

## Root cause

C++ parser call identities retained the scanned package path and did not carry simple receiver types. The contract lookup therefore could not use stable library identities. Local declarations also lacked project-wide ownership, making a naive fallback unsafe.

## Verification

- `go test ./... -count=1`
- `go test ./internal/callgraph/... ./internal/scan/... -count=1`
- `make lint`
- dual independent Judgment Day review: approved with no critical or warning findings

The change is larger than the normal review target because the stable identity must stay consistent across parser extraction, graph construction, inference, and CBOM role export; splitting those layers would leave an unsafe intermediate behavior.

Closes #163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ callgraph accuracy for namespace-qualified library calls, regardless of the scanned project path.
  * Resolved typed receiver calls using the correct local and dependency declarations.
  * Preserved project-local declarations when resolving calls and contract matches.
  * Improved fluent-call resolution using call arity and global namespace qualifiers.
  * Standardized handling of `void` types and Java lambda return analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->