### PR TITLE
feat(callgraph): populate Node return sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- JavaScript and TypeScript callgraph parsing now records mapped function return sources for direct values, calls, and constructors. (#81)
 - C callgraph contracts now model the rule-covered Mbed TLS 3.6 LTS PKCS#7, LMS, public-key, TLS, and X.509 lifecycles. (#92)
 - C++ callgraph builds now load embedded schema-v2 contract knowledge bases. (#95)
 - C callgraph contracts now model libsodium 1.x high-level AEAD, authentication, hashing, password-hashing, KDF, key-exchange, box, stream, and signing lifecycles. (#145)

--- a/internal/callgraph/node_parser.go
+++ b/internal/callgraph/node_parser.go
@@ -26,6 +26,8 @@ const (
 	nodeArrowFunction        = "arrow_function"
 	nodeFunctionExpression   = "function_expression"
 	nodeMethodDefinition     = "method_definition"
+	nodeReturnStatement      = "return_statement"
+	nodeNewExpression        = "new_expression"
 )
 
 // NodeParser extracts JavaScript and TypeScript imports, declarations, and calls.
@@ -280,7 +282,7 @@ func (p *NodeParser) extractDeclarations(node *sitter.Node, src []byte, filePath
 	case "lexical_declaration", "variable_declaration":
 		p.extractAssignedFunctions(node, src, filePath, packagePath, analysis)
 		return
-	case "class_declaration":
+	case javaNodeClassDeclaration:
 		p.extractClassMethods(node, src, filePath, packagePath, analysis)
 		return
 	}
@@ -355,7 +357,93 @@ func (p *NodeParser) parseNodeFunction(node *sitter.Node, src []byte, filePath, 
 	}
 	locals := collectNodeLocalNames(params, body, src)
 	decl.Calls = p.extractCalls(body, src, filePath, packagePath, owner, imports, locals)
+	decl.ReturnSources = p.extractReturnSources(body, src, filePath, packagePath, owner, imports, locals)
 	return decl
+}
+
+func (p *NodeParser) extractReturnSources(body *sitter.Node, src []byte, filePath, packagePath, owner string, imports map[string]string, locals map[string]bool) []SourceNode {
+	if body.Type() != "statement_block" {
+		if source, ok := p.nodeReturnSource(body, src, filePath, packagePath, owner, imports, locals); ok {
+			return []SourceNode{source}
+		}
+		return nil
+	}
+	var sources []SourceNode
+	p.walkNodeReturnSources(body, src, filePath, packagePath, owner, imports, locals, &sources)
+	return sources
+}
+
+func (p *NodeParser) walkNodeReturnSources(node *sitter.Node, src []byte, filePath, packagePath, owner string, imports map[string]string, locals map[string]bool, sources *[]SourceNode) {
+	if node == nil {
+		return
+	}
+	if isNodeNestedScope(node.Type()) {
+		return
+	}
+	if node.Type() == nodeReturnStatement {
+		if node.NamedChildCount() > 0 {
+			if source, ok := p.nodeReturnSource(node.NamedChild(0), src, filePath, packagePath, owner, imports, locals); ok {
+				*sources = append(*sources, source)
+			}
+		}
+		return
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		p.walkNodeReturnSources(node.Child(i), src, filePath, packagePath, owner, imports, locals, sources)
+	}
+}
+
+func (p *NodeParser) nodeReturnSource(expr *sitter.Node, src []byte, filePath, packagePath, owner string, imports map[string]string, locals map[string]bool) (SourceNode, bool) {
+	location := &SourceLocation{FilePath: filePath, Line: int(expr.StartPoint().Row) + 1}
+	switch expr.Type() {
+	case nodeCallExpression:
+		call := p.parseNodeCall(expr, src, filePath, packagePath, owner, imports, locals)
+		if call == nil {
+			return SourceNode{}, false
+		}
+		callee := call.Callee
+		callee.Name = fmt.Sprintf("%s#%d", callee.Name, len(call.Arguments))
+		return SourceNode{Type: sourceNodeCallResult, CallTarget: &callee, Location: location}, true
+	case nodeNewExpression:
+		constructor := expr.ChildByFieldName("constructor")
+		if constructor == nil {
+			return SourceNode{}, false
+		}
+		var pkg, typeName string
+		switch constructor.Type() {
+		case goNodeIdentifier:
+			typeName = constructor.Content(src)
+			pkg = packagePath
+			if importedPackage, ok := nodeImportedPackage(imports, locals, typeName); ok {
+				pkg = importedPackage
+			}
+		case nodeMemberExpression:
+			object := constructor.ChildByFieldName("object")
+			property := constructor.ChildByFieldName("property")
+			if object == nil || property == nil {
+				return SourceNode{}, false
+			}
+			first, suffix := splitNodeMemberObject(object.Content(src))
+			var ok bool
+			pkg, ok = nodeImportedPackage(imports, locals, first)
+			if !ok {
+				return SourceNode{}, false
+			}
+			if suffix != "" {
+				pkg += "." + suffix
+			}
+			typeName = property.Content(src)
+		default:
+			return SourceNode{}, false
+		}
+		target := FunctionID{Package: pkg, Type: typeName, Name: fmt.Sprintf("%s#%d", constructorMethodName, len(nodeCallArguments(expr, src)))}
+		return SourceNode{Type: sourceNodeCallResult, DeclaredType: qualifiedType(pkg, typeName), CallTarget: &target, Location: location}, true
+	case goNodeIdentifier:
+		return SourceNode{Type: sourceNodeVariable, Name: expr.Content(src), Location: location}, true
+	case "string", "number", javaNodeBoolLiteralTrue, javaNodeBoolLiteralFalse, "null":
+		return SourceNode{Type: sourceNodeValue, Value: expr.Content(src), Location: location}, true
+	}
+	return SourceNode{}, false
 }
 
 func nodeParameters(node *sitter.Node, src []byte) []FunctionParameter {
@@ -394,6 +482,9 @@ func collectNodeBindingNames(node *sitter.Node, src []byte, locals map[string]bo
 	if node == nil {
 		return
 	}
+	if collectNodeNestedBinding(node, src, locals) {
+		return
+	}
 	if node.Type() == nodeVariableDeclarator {
 		name := node.ChildByFieldName("name")
 		if name != nil && name.Type() == goNodeIdentifier {
@@ -414,6 +505,29 @@ func collectNodeBindingNames(node *sitter.Node, src []byte, locals map[string]bo
 	}
 }
 
+func collectNodeNestedBinding(node *sitter.Node, src []byte, locals map[string]bool) bool {
+	if !isNodeNestedScope(node.Type()) {
+		return false
+	}
+	switch node.Type() {
+	case nodeFunctionDeclaration, nodeGeneratorDeclaration, javaNodeClassDeclaration:
+		if name := node.ChildByFieldName("name"); name != nil {
+			locals[name.Content(src)] = true
+		}
+		return true
+	}
+	return true
+}
+
+func isNodeNestedScope(nodeType string) bool {
+	switch nodeType {
+	case nodeFunctionDeclaration, nodeGeneratorDeclaration, nodeArrowFunction, nodeFunctionExpression, nodeMethodDefinition, javaNodeClassDeclaration:
+		return true
+	default:
+		return false
+	}
+}
+
 func (p *NodeParser) extractCalls(body *sitter.Node, src []byte, filePath, packagePath, owner string, imports map[string]string, locals map[string]bool) []FunctionCall {
 	var calls []FunctionCall
 	p.walkNodeCalls(body, src, filePath, packagePath, owner, imports, locals, &calls)
@@ -424,8 +538,7 @@ func (p *NodeParser) walkNodeCalls(node *sitter.Node, src []byte, filePath, pack
 	if node == nil {
 		return
 	}
-	switch node.Type() {
-	case nodeFunctionDeclaration, nodeGeneratorDeclaration, nodeArrowFunction, nodeFunctionExpression, nodeMethodDefinition, "class_declaration":
+	if isNodeNestedScope(node.Type()) {
 		return
 	}
 	if node.Type() == nodeCallExpression {

--- a/internal/callgraph/node_parser_test.go
+++ b/internal/callgraph/node_parser_test.go
@@ -126,6 +126,9 @@ export function encrypt(data: Buffer): Buffer {
 	if update.ReceiverVar != "cipher" {
 		t.Errorf("cipher.update ReceiverVar = %q, want cipher", update.ReceiverVar)
 	}
+	if got := encrypt.ReturnSources; len(got) != 1 || got[0].Type != sourceNodeCallResult || got[0].CallTarget == nil || got[0].CallTarget.Name != "update#1" {
+		t.Errorf("ReturnSources = %#v, want cipher.update call result", got)
+	}
 }
 
 func TestNodeParser_ErrorPrefix(t *testing.T) {
@@ -166,6 +169,82 @@ export function outer() {
 	}
 	inner := nodeFunction(t, analysis, "inner")
 	_ = nodeCall(t, inner, "node:crypto", "createHash", "crypto.createHash")
+}
+
+func TestNodeParser_ReturnSources(t *testing.T) {
+	t.Parallel()
+
+	src := `import { createHash } from "node:crypto";
+import { Builder } from "builder-lib";
+import * as sdk from "builder-sdk";
+
+export function direct(value) { return value; }
+export function factory() { return createHash("sha256"); }
+export function construct() { return new Builder(); }
+export function constructMember() { return new sdk.Builder(); }
+export function literal() { return "sha256"; }
+export function unknown(value) { return value ?? "fallback"; }
+export function bare() { return; }
+export const concise = value => value;
+export function outer(value) {
+  function nested() { return createHash("sha512"); }
+  return value;
+}
+export function scopedFactory() {
+  function nested() {
+    const createHash = () => null;
+    return createHash();
+  }
+  return createHash("sha256");
+}
+`
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "returns.js")
+	if err := os.WriteFile(filePath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analysis, err := NewNodeParser().ParseFile(filePath, "example-app")
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		want SourceNode
+	}{
+		{name: "direct", want: SourceNode{Type: sourceNodeVariable, Name: "value"}},
+		{name: "factory", want: SourceNode{Type: sourceNodeCallResult, CallTarget: &FunctionID{Package: "node:crypto", Name: "createHash#1"}}},
+		{name: "construct", want: SourceNode{Type: sourceNodeCallResult, DeclaredType: "builder-lib.Builder", CallTarget: &FunctionID{Package: "builder-lib", Type: "Builder", Name: constructorMethodName + "#0"}}},
+		{name: "constructMember", want: SourceNode{Type: sourceNodeCallResult, DeclaredType: "builder-sdk.Builder", CallTarget: &FunctionID{Package: "builder-sdk", Type: "Builder", Name: constructorMethodName + "#0"}}},
+		{name: "literal", want: SourceNode{Type: sourceNodeValue, Value: `"sha256"`}},
+		{name: "concise", want: SourceNode{Type: sourceNodeVariable, Name: "value"}},
+		{name: "outer", want: SourceNode{Type: sourceNodeVariable, Name: "value"}},
+		{name: "scopedFactory", want: SourceNode{Type: sourceNodeCallResult, CallTarget: &FunctionID{Package: "node:crypto", Name: "createHash#1"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources := nodeFunction(t, analysis, tt.name).ReturnSources
+			if len(sources) != 1 {
+				t.Fatalf("ReturnSources = %#v, want one source", sources)
+			}
+			got := sources[0]
+			if got.Type != tt.want.Type || got.Name != tt.want.Name || got.Value != tt.want.Value || got.DeclaredType != tt.want.DeclaredType {
+				t.Fatalf("ReturnSources[0] = %#v, want %#v", got, tt.want)
+			}
+			if tt.want.CallTarget != nil && (got.CallTarget == nil || *got.CallTarget != *tt.want.CallTarget) {
+				t.Fatalf("CallTarget = %#v, want %#v", got.CallTarget, tt.want.CallTarget)
+			}
+			if got.Location == nil || got.Location.FilePath != filePath || got.Location.Line == 0 {
+				t.Fatalf("Location = %#v, want %s with a source line", got.Location, filePath)
+			}
+		})
+	}
+
+	for _, name := range []string{"unknown", "bare"} {
+		if got := nodeFunction(t, analysis, name).ReturnSources; len(got) != 0 {
+			t.Errorf("%s ReturnSources = %#v, want none", name, got)
+		}
+	}
 }
 
 func TestNodeParser_LocalBindingsShadowImports(t *testing.T) {


### PR DESCRIPTION
## Summary

- populate JavaScript and TypeScript return sources for identifiers, literals, factory calls, constructors, and concise arrow functions
- preserve imported factory identity across nested lexical scopes
- add focused JavaScript/TypeScript parser regressions and an Unreleased changelog entry

## Verification

- `go test ./internal/callgraph/... -count=1`
- `go test ./... -count=1`
- `make lint`
- `git diff --check`
- standards and spec self-review

Closes #81