### PR TITLE
feat(callgraph): wire Node contract resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ internal/callgraph/contracts/
 ├── java/
 │   └── jdk-crypto.yaml    # JDK JCA/JCE contracts (shipped in v1)
 ├── go/                    # schema-v2 Go callgraph contracts
+├── node/                  # schema-v2 Node callgraph contracts
 ├── python/                # pyca-cryptography, pycryptodome, pycryptodomex, paramiko
 └── rust/                  # schema-v2 Rust callgraph contracts
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Node callgraph builds now load embedded schema-v2 contract knowledge bases and select the Node contract type resolver. (#82)
 - JavaScript and TypeScript callgraph parsing now records mapped function return sources for direct values, calls, and constructors. (#81)
 - C callgraph contracts now model the rule-covered Mbed TLS 3.6 LTS PKCS#7, LMS, public-key, TLS, and X.509 lifecycles. (#92)
 - C++ callgraph builds now load embedded schema-v2 contract knowledge bases. (#95)

--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -32,6 +32,9 @@ var cFS embed.FS
 //go:embed cpp/*.yaml
 var cppFS embed.FS
 
+//go:embed node/*.yaml
+var nodeFS embed.FS
+
 const (
 	// ecosystemC is the ecosystem identifier for the C contract KB.
 	ecosystemC = "c"
@@ -39,6 +42,8 @@ const (
 	ecosystemCPP = "cpp"
 	// ecosystemGo is the ecosystem identifier for the Go contract KB.
 	ecosystemGo = "go"
+	// ecosystemNode is the ecosystem identifier for the Node contract KB.
+	ecosystemNode = "node"
 	// ecosystemPython is the ecosystem identifier for the Python contract KB.
 	ecosystemPython = "python"
 	// ecosystemRust is the ecosystem identifier for the Rust contract KB.
@@ -495,6 +500,8 @@ func embedFSFor(ecosystem string) (fs.FS, string) {
 		return &cppFS, ecosystemCPP
 	case ecosystemGo:
 		return &goFS, ecosystemGo
+	case ecosystemNode:
+		return &nodeFS, ecosystemNode
 	case ecosystemPython:
 		return &pythonFS, ecosystemPython
 	case ecosystemRust:

--- a/internal/callgraph/contracts/node/bootstrap.yaml
+++ b/internal/callgraph/contracts/node/bootstrap.yaml
@@ -1,0 +1,9 @@
+schema_version: "2"
+ecosystem: node
+# ponytail: go:embed needs one YAML match; remove this file when the first Node library KB lands.
+library:
+  name: node-bootstrap
+  description: "Bootstrap for embedded Node callgraph contracts"
+
+contracts: []
+hierarchy: {}

--- a/internal/callgraph/contracts/node_bootstrap_test.go
+++ b/internal/callgraph/contracts/node_bootstrap_test.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedNode(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("node")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(node): %v", err)
+	}
+	if kb.Ecosystem != "node" || kb.Library == nil || kb.Library.Name != "node-bootstrap" {
+		t.Fatalf("LoadEmbedded(node) = %#v, want node-bootstrap KB", kb)
+	}
+}

--- a/internal/callgraph/node_type_resolver.go
+++ b/internal/callgraph/node_type_resolver.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import "github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+
+// NodeContractTypeResolver applies return types from the Node contracts KB.
+type NodeContractTypeResolver struct {
+	kb *contracts.KnowledgeBase
+}
+
+// NewNodeContractTypeResolver creates a resolver backed by the supplied KB.
+func NewNodeContractTypeResolver(kb *contracts.KnowledgeBase) *NodeContractTypeResolver {
+	return &NodeContractTypeResolver{kb: kb}
+}
+
+// NewNodeContractTypeResolverFromEmbedded loads the embedded Node KB. Contract
+// load failures degrade to a no-op resolver.
+func NewNodeContractTypeResolverFromEmbedded() *NodeContractTypeResolver {
+	kb, err := contracts.LoadEmbedded("node")
+	if err != nil {
+		return NewNodeContractTypeResolver(nil)
+	}
+	return NewNodeContractTypeResolver(kb)
+}
+
+// ResolveTypes fills missing declaration return types from unconditional contracts.
+func (r *NodeContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) error {
+	if r.kb == nil || len(r.kb.Contracts) == 0 {
+		return nil
+	}
+	for _, fn := range graph.Functions {
+		if fn.ReturnType != "" {
+			continue
+		}
+		for _, contract := range r.kb.ContractsFor(fn.ID.String(), len(fn.Parameters)) {
+			if contract.When == nil && contract.Return.Type != "" {
+				fn.ReturnType = contract.Return.Type
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/callgraph/node_type_resolver_test.go
+++ b/internal/callgraph/node_type_resolver_test.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestNodeContractTypeResolver_UsesCanonicalFunctionIDs(t *testing.T) {
+	kb, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: node
+library:
+  name: test-node
+contracts:
+  - method: node-forge.md.sha256.create
+    arity: 0
+    return:
+      type: node-forge.md.MessageDigest
+      confidence: high
+`))
+	if err != nil {
+		t.Fatalf("load test KB: %v", err)
+	}
+	create := &FunctionDecl{ID: FunctionID{Package: "node-forge.md.sha256", Name: "create"}}
+
+	if err := NewNodeContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(create), nil); err != nil {
+		t.Fatalf("ResolveTypes: %v", err)
+	}
+	if create.ReturnType != "node-forge.md.MessageDigest" {
+		t.Fatalf("ReturnType = %q, want node-forge.md.MessageDigest", create.ReturnType)
+	}
+
+	create.ReturnType = "ExistingType"
+	if err := NewNodeContractTypeResolver(kb).ResolveTypes(buildTestCallGraph(create), nil); err != nil {
+		t.Fatalf("ResolveTypes with existing return type: %v", err)
+	}
+	if create.ReturnType != "ExistingType" {
+		t.Fatalf("existing ReturnType was overwritten: %q", create.ReturnType)
+	}
+}

--- a/internal/callgraph/parser_registry.go
+++ b/internal/callgraph/parser_registry.go
@@ -42,6 +42,8 @@ func NewTypeResolverForEcosystem(ecosystem string, javaRuntime javaruntime.Confi
 		return NewGoContractTypeResolverFromEmbedded()
 	case "java":
 		return NewJavaBytecodeTypeResolver(javaRuntime)
+	case "node", "javascript", "typescript":
+		return NewNodeContractTypeResolverFromEmbedded()
 	case "python":
 		return NewPythonContractTypeResolverFromEmbedded()
 	case "rust":

--- a/internal/callgraph/parser_registry_extra_test.go
+++ b/internal/callgraph/parser_registry_extra_test.go
@@ -104,4 +104,9 @@ func TestNewTypeResolverForEcosystem(t *testing.T) {
 	if _, ok := NewTypeResolverForEcosystem("go", javaruntime.Config{}).(*GoContractTypeResolver); !ok {
 		t.Fatal("expected GoContractTypeResolver")
 	}
+	for _, ecosystem := range []string{"node", "javascript", "typescript"} {
+		if _, ok := NewTypeResolverForEcosystem(ecosystem, javaruntime.Config{}).(*NodeContractTypeResolver); !ok {
+			t.Fatalf("expected NodeContractTypeResolver for %q", ecosystem)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Embed and load schema-v2 Node callgraph contract knowledge bases.
- Select a Node contract type resolver for Node, JavaScript, and TypeScript ecosystems.
- Add focused loader/resolver coverage and document the new KB directory.

Closes #82

## Verification

- `go test ./internal/callgraph/contracts/... -count=1`
- `go test ./internal/callgraph/... -count=1`
- `go test ./... -count=1`
- `make lint`
- `git diff --check`

## Review

- Standards review: pass
- Issue #82 spec review: pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Node ecosystem callgraph builds using embedded schema-v2 contract knowledge.
  * Node, JavaScript, and TypeScript callgraphs can now automatically infer missing function return types from supported contracts.
  * Existing return types are preserved during inference.

* **Documentation**
  * Updated the changelog and knowledge-base layout documentation to reflect Node contract support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->