### PR TITLE
fix(scan): preserve external constructor arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C callgraph contracts now match global library symbols independently of the scanned project's package path while preserving exact project-qualified matches. (#156)
 - C callgraph pointer-return inference now propagates through in-project wrapper functions while preserving arity-qualified contract lookup. (#153)
 - Rust callgraph contracts now resolve associated functions using the canonical Rust callable identity, enabling inferred return types from embedded contracts. (#74)
-- Nested-call findings now attribute matched operations and canonical call identities to the tightest source invocation instead of an enclosing call. (#134)
+- Nested-call findings now attribute matched operations to the tightest source invocation and preserve external constructor arity and parameter types from source provenance. (#134)
 - Supporting-call catalogs now preserve every callable overload deterministically instead of selecting one by traversal order. (#131)
 - Stitched graph-fragment callgraph exports now retain parameter roles on supporting calls. (#130)
 - Concurrent scans sharing the default rules cache no longer expose partial metadata or lose in-flight filtered rule files when another process refreshes the cache. (#128)

--- a/internal/cli/dependency_intelligence_acceptance_integration_test.go
+++ b/internal/cli/dependency_intelligence_acceptance_integration_test.go
@@ -78,6 +78,12 @@ func TestDependencyIntelligenceExportContract(t *testing.T) {
 			source: "src/main/java/example/Acceptance.java", provider: "BC",
 			pinFile: "pom.xml", pinText: "<version>1.78.1</version>",
 			matches: []acceptanceMatch{
+				{
+					needle: "new JcePGPDataEncryptorBuilder(alg)", ruleID: "java.acceptance.pgp-builder",
+					api:           "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.setSecureRandom",
+					wantSymbol:    "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>",
+					wantSignature: "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>(int): JcePGPDataEncryptorBuilder",
+				},
 				{needle: "new KeyParameter(key)", ruleID: "java.acceptance.key-parameter", api: "org.bouncycastle.crypto.params.KeyParameter.<init>", requiresSupport: true, supportingCategories: []string{"factory", "output"}},
 				{
 					needle: "new KeyParameter(data)", ruleID: "java.acceptance.nested-key-parameter",

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -1916,6 +1916,9 @@ func mergeCallParameters(
 		if i < len(argSources) && len(argSources[i]) > 0 {
 			p.SourceNodes = convertSourceNodes(ctx, resolveExportSourceNodes(ctx, callerID, argSources[i], 0), filepath.ToSlash(sourceFilePath), sourceLine)
 		}
+		if p.Type == "" {
+			p.Type = uniqueSourceDeclaredType(p.SourceNodes)
+		}
 		p.ResolvedValue = resolveSimpleExportParameterValue(p.ArgumentExpression, p.SourceNodes)
 		if p.Type != "" || p.VariableName != "" || p.ArgumentExpression != "" {
 			params = append(params, p)
@@ -2891,6 +2894,38 @@ func mergeExportParameterTypes(existing, fallback []string) []string {
 	return merged
 }
 
+func parameterTypesFromCallParameters(parameters []callGraphParameter) []string {
+	if len(parameters) == 0 {
+		return nil
+	}
+	types := make([]string, len(parameters))
+	for i := range parameters {
+		types[i] = parameters[i].Type
+	}
+	return types
+}
+
+func uniqueSourceDeclaredType(nodes []exportSourceNode) string {
+	types := make(map[string]struct{})
+	var collect func([]exportSourceNode)
+	collect = func(current []exportSourceNode) {
+		for i := range current {
+			if declared := strings.TrimSpace(current[i].DeclaredType); declared != "" {
+				types[declared] = struct{}{}
+			}
+			collect(current[i].SourceNodes)
+		}
+	}
+	collect(nodes)
+	if len(types) != 1 {
+		return ""
+	}
+	for declared := range types {
+		return declared
+	}
+	return ""
+}
+
 func exportExternalSignature(
 	graph *callgraph.CallGraph,
 	id callgraph.FunctionID,
@@ -2938,10 +2973,10 @@ func applyExportFunctionMetadataToEntryCall(call *callGraphEntryCall, meta expor
 		return
 	}
 	call.FunctionName = meta.FunctionName
-	call.CanonicalSignature = meta.CanonicalSignature
 	call.ReturnType = meta.ReturnType
 	call.ReturnTypeRef = cloneExportTypeRef(meta.ReturnTypeRef)
-	call.ParameterTypes = cloneStringSlice(meta.ParameterTypes)
+	call.ParameterTypes = mergeExportParameterTypes(meta.ParameterTypes, parameterTypesFromCallParameters(call.Parameters))
+	call.CanonicalSignature = canonicalSignature(call.FunctionName, call.ParameterTypes, call.ReturnType)
 	call.ParameterTypeRefs = cloneExportTypeRefs(meta.ParameterTypeRefs)
 	call.DisplaySymbol = meta.DisplaySymbol
 	call.Aliases = cloneStringSlice(meta.Aliases)
@@ -2953,10 +2988,10 @@ func applyExportFunctionMetadataToCalledFunction(call *callGraphCalledFunction, 
 		return
 	}
 	call.FunctionName = meta.FunctionName
-	call.CanonicalSignature = meta.CanonicalSignature
 	call.ReturnType = meta.ReturnType
 	call.ReturnTypeRef = cloneExportTypeRef(meta.ReturnTypeRef)
-	call.ParameterTypes = cloneStringSlice(meta.ParameterTypes)
+	call.ParameterTypes = mergeExportParameterTypes(meta.ParameterTypes, parameterTypesFromCallParameters(call.Parameters))
+	call.CanonicalSignature = canonicalSignature(call.FunctionName, call.ParameterTypes, call.ReturnType)
 	call.ParameterTypeRefs = cloneExportTypeRefs(meta.ParameterTypeRefs)
 	call.DisplaySymbol = meta.DisplaySymbol
 	call.Aliases = cloneStringSlice(meta.Aliases)

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -304,6 +304,76 @@ func TestFindCryptoCallNode(t *testing.T) {
 	})
 }
 
+func TestFindCryptoCall_UsesArgumentSourceTypeForExternalConstructor(t *testing.T) {
+	constructorID := callgraph.FunctionID{
+		Package: "org.bouncycastle.openpgp.operator.jcajce",
+		Type:    "JcePGPDataEncryptorBuilder",
+		Name:    "<init>#1",
+	}
+	owner := &callgraph.FunctionDecl{
+		ID: callgraph.FunctionID{Package: "example", Type: "Acceptance", Name: "builder#1"},
+		Calls: []callgraph.FunctionCall{{
+			Callee:    constructorID,
+			Line:      5,
+			StartCol:  16,
+			EndCol:    55,
+			Arguments: []string{"alg"},
+			ArgumentSources: [][]callgraph.SourceNode{{{
+				Type:           "PARAMETER",
+				Name:           "alg",
+				DeclaredType:   "int",
+				ParameterIndex: 0,
+			}}},
+		}},
+	}
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{owner.ID.String(): owner}}
+	ctx := &exportBuildContext{
+		graph: graph,
+		kb: &contracts.KnowledgeBase{Ecosystem: "java", Contracts: map[string][]contracts.Contract{
+			"org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>#1": {{
+				Method: "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>",
+				Arity:  1,
+				Role:   "factory",
+				Parameters: []contracts.ParameterContract{{
+					Index: intPtr(0), Name: "encAlgorithm", Role: "operation-determining",
+					Contributes: &contracts.Contribution{Property: "algorithm", Derivation: "argument_value"},
+				}},
+			}},
+		}},
+	}
+	asset := entities.CryptographicAsset{StartLine: 5, EndLine: 5, StartCol: 16, EndCol: 55}
+
+	got := findCryptoCall(ctx, graph, owner, asset, 5, 5)
+	if got == nil {
+		t.Fatal("findCryptoCall returned nil")
+	}
+	const want = "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>(int): JcePGPDataEncryptorBuilder"
+	if got.CanonicalSignature != want {
+		t.Fatalf("CanonicalSignature = %q, want %q", got.CanonicalSignature, want)
+	}
+
+	support := buildDerivedSupportingCall(ctx, owner, &owner.Calls[0])
+	if support.Category != "factory" || support.SupportingCall == nil || support.SupportingCall.CanonicalSignature != want {
+		t.Fatalf("support = %#v, want arity-1 factory constructor", support)
+	}
+	if roles := support.SupportingCall.ParameterRoles; len(roles) != 1 || roles[0].Role != "operation-determining" ||
+		roles[0].Contributes == nil || roles[0].Contributes.Property != "algorithm" {
+		t.Fatalf("parameter roles = %#v, want algorithm operation-determining role", roles)
+	}
+}
+
+func TestApplyExportFunctionMetadataToCalledFunction_PreservesDeclaredArity(t *testing.T) {
+	call := &callGraphCalledFunction{Parameters: []callGraphParameter{{Type: "String"}, {Type: "int"}}}
+	applyExportFunctionMetadataToCalledFunction(call, exportFunctionMetadata{
+		FunctionName:   "example.Logger.log",
+		ParameterTypes: []string{"Object[]"},
+		ReturnType:     "void",
+	})
+	if got, want := call.CanonicalSignature, "example.Logger.log(Object[]): void"; got != want {
+		t.Fatalf("CanonicalSignature = %q, want declared signature %q", got, want)
+	}
+}
+
 // TestBestChainRootCandidate isolates the chain-root tie-break (step 3a): only
 // chain candidates with AssignedVar set are eligible, non-chain candidates are
 // ignored, and ties between multiple chain roots resolve to the lowest StartCol.

--- a/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
+++ b/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
@@ -16,10 +16,12 @@
 
 package example;
 
+import java.security.SecureRandom;
 import javax.crypto.Cipher;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder;
 
 interface Processor {
     byte[] apply(byte[] data);
@@ -34,6 +36,12 @@ class SecondProcessor implements Processor {
 }
 
 class Acceptance {
+    JcePGPDataEncryptorBuilder builder(int alg) {
+        return new JcePGPDataEncryptorBuilder(alg)
+            .setSecureRandom(new SecureRandom())
+            .setWithIntegrityPacket(true);
+    }
+
     byte[] run(byte[] data, byte[] key, String runtimeProvider) throws Exception {
         Cipher.getInstance("AES/GCM/NoPadding", "BC");
         Cipher.getInstance("AES/GCM/NoPadding", runtimeProvider);


### PR DESCRIPTION
Closes #134

## Summary

- recover external constructor canonical arity and parameter types from unambiguous source provenance when no declaration/signature is available
- keep known formal signatures authoritative, including variadic declarations
- add focused and public CLI/export regressions for the Bouncy Castle OpenPGP builder chain and its contract roles

## Root cause

The Java parser retained the constructor's `#1` arity and the argument provenance retained `DeclaredType: int`, but export metadata built the canonical signature only from the unavailable external declaration. That collapsed `<init>(int)` to `<init>()` and prevented the arity-1 contract from matching.

## Verification

- `go test ./internal/scan/... ./internal/cli/... -count=1`
- `go test ./... -count=1`
- pinned `golangci-lint v2.10.1` on the diff
- exact `crypto_rules` PGP rule reproduced with opengrep at commit `b6730e8721570f2ffaa8b841ddf2e845eca8e277`
- dual adversarial review approved after declared-arity and role-coverage hardening
