### PR TITLE
fix(scan): complete Java lifecycle exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,13 @@ Each YAML carries a `library:` block with `name`, optional `coordinates`, option
 `version_range`, and optional `description`. The `library.name` propagates onto every
 contract's `SourceLibrary` field for diagnostic identification across libraries.
 
+Contracts may declare `parameter_types` and `canonical_return_type` when method plus
+arity (and any resolved condition) identifies one unambiguous declared signature.
+The parameter list length must equal `arity`. Omit canonical fields when multiple
+same-arity overloads remain possible; call-site source provenance then selects the
+concrete signature instead of the KB guessing one overload. Keep these fields distinct
+from semantic `return.type`, which may intentionally model only one inferred value.
+
 Schema version is `"2"` — schema `"1"` is hard-rejected. The YAML schema version is
 INTERNAL to the loader; the partner-facing export schema is independent (currently 6.0).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Go callgraph contracts now model the legacy `github.com/golang-fips/openssl/v2` API's symmetric, KDF, public-key, and post-quantum cryptographic lifecycles. (#127)
 - Graph-fragment exports now carry complete canonical target signatures and hierarchy-proven compatible callable signatures, allowing interface-typed dependency calls to join concrete crypto entry points without fabricating call edges. (#136)
 - Java callgraph contracts now model the version-pinned Nimbus JOSE JWE and Spring Security Crypto lifecycles, including factory, operation, output, hierarchy, and key-size parameter-role semantics. (#137)
-- Java callgraph lifecycle contracts now cover Bouncy Castle OpenPGP builders, Tink AEAD operations, and Apache Santuario XMLCipher factories and finalization. (#138)
+- Java callgraph lifecycle contracts and public exports now cover Bouncy Castle OpenPGP builders, Tink AEAD operations, and Apache Santuario XMLCipher factories and finalization with applicable operation links and canonical signatures. (#138)
 - Rust callgraph inference now recognizes RustCrypto `chacha20poly1305` 0.11 factories and AEAD operations, including ChaCha20-Poly1305 and XChaCha20-Poly1305 detached and in-place calls. (#125)
 - Rust callgraph inference now models `ring` 0.17 AEAD, digest, HMAC, HKDF, key-agreement, and signature lifecycles. (#70)
 - Rust callgraph builds now load schema-v2 contract knowledge bases and select the Rust contract type resolver. (#69)

--- a/internal/callgraph/c_type_resolver.go
+++ b/internal/callgraph/c_type_resolver.go
@@ -34,7 +34,9 @@ func (r *CContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) e
 		if fn.ReturnType != "" {
 			continue
 		}
-		for _, contract := range r.kb.ContractsFor(fn.ID.String(), len(fn.Parameters)) {
+		matches := r.kb.ContractsFor(fn.ID.String(), len(fn.Parameters))
+		for i := range matches {
+			contract := &matches[i]
 			if contract.When == nil && contract.Return.Type != "" {
 				fn.ReturnType = contract.Return.Type
 				break

--- a/internal/callgraph/contracts/contracts.go
+++ b/internal/callgraph/contracts/contracts.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,11 +79,19 @@ type KnowledgeBase struct {
 
 // Contract describes a single KB entry mapping a method call to an inferred return type.
 type Contract struct {
-	Method        string
-	Arity         int
-	When          *Condition // nil = unconditional contract
-	Return        ContractReturn
-	SourceLibrary string // populated by Load() from the v2 YAML library.name field
+	Method string
+	Arity  int
+	When   *Condition // nil = unconditional contract
+	Return ContractReturn
+	// ParameterTypes optionally supplies the canonical declared parameter types
+	// when method+arity identifies one unambiguous signature. It is omitted for
+	// overload sets that share the same method and arity.
+	ParameterTypes []string
+	// CanonicalReturnType optionally supplies the callable's declared return
+	// type. It is distinct from Return.Type, which is semantic inference data
+	// and may intentionally omit tuple/error components.
+	CanonicalReturnType string
+	SourceLibrary       string // populated by Load() from the v2 YAML library.name field
 	// Role classifies a method's part in a crypto object's lifecycle (e.g.
 	// "factory", "config", "output", "operation") so exported supporting
 	// calls can carry semantic categories without duplicating crypto rule
@@ -257,10 +266,12 @@ type yamlLibrary struct {
 }
 
 type yamlContract struct {
-	Method string     `yaml:"method"`
-	Arity  int        `yaml:"arity"`
-	When   *yamlWhen  `yaml:"when"`
-	Return yamlReturn `yaml:"return"`
+	Method              string     `yaml:"method"`
+	Arity               int        `yaml:"arity"`
+	ParameterTypes      []string   `yaml:"parameter_types,omitempty"`
+	CanonicalReturnType string     `yaml:"canonical_return_type,omitempty"`
+	When                *yamlWhen  `yaml:"when"`
+	Return              yamlReturn `yaml:"return"`
 	// Role classifies the method's lifecycle part; see Contract.Role.
 	Role string `yaml:"role,omitempty"`
 	// Parameters declares per-parameter roles; see Contract.Parameters.
@@ -376,6 +387,9 @@ func validateContract(i int, c yamlContract) (*Condition, error) {
 	if c.Arity < 0 {
 		return nil, fmt.Errorf("contracts: contract[%d] (%s): arity must be >= 0, got %d", i, c.Method, c.Arity)
 	}
+	if err := validateCanonicalSignature(i, c); err != nil {
+		return nil, err
+	}
 	if c.Return.Type == "" {
 		return nil, fmt.Errorf("contracts: contract[%d] (%s): return.type is required", i, c.Method)
 	}
@@ -400,6 +414,23 @@ func validateContract(i int, c yamlContract) (*Condition, error) {
 		ArgIndex:   c.When.ArgIndex,
 		ArgValueIn: c.When.ArgValueIn,
 	}, nil
+}
+
+func validateCanonicalSignature(i int, c yamlContract) error {
+	if len(c.ParameterTypes) > 0 {
+		if len(c.ParameterTypes) != c.Arity {
+			return fmt.Errorf("contracts: contract[%d] (%s): parameter_types length %d must equal arity %d", i, c.Method, len(c.ParameterTypes), c.Arity)
+		}
+		for j, parameterType := range c.ParameterTypes {
+			if strings.TrimSpace(parameterType) == "" {
+				return fmt.Errorf("contracts: contract[%d] (%s): parameter_types[%d] must not be empty", i, c.Method, j)
+			}
+		}
+	}
+	if c.CanonicalReturnType != "" && strings.TrimSpace(c.CanonicalReturnType) == "" {
+		return fmt.Errorf("contracts: contract[%d] (%s): canonical_return_type must not be empty", i, c.Method)
+	}
+	return nil
 }
 
 // validateParameters checks that the Parameters sub-schema entries of a
@@ -442,7 +473,8 @@ func validateParameters(i int, c yamlContract) ([]ParameterContract, error) {
 // indexContracts validates and indexes all contract entries into the KnowledgeBase.
 func indexContracts(raw *yamlKB, kb *KnowledgeBase) error {
 	unconditionalSeen := make(map[string]struct{})
-	for i, c := range raw.Contracts {
+	for i := range raw.Contracts {
+		c := raw.Contracts[i]
 		when, err := validateContract(i, c)
 		if err != nil {
 			return err
@@ -460,13 +492,15 @@ func indexContracts(raw *yamlKB, kb *KnowledgeBase) error {
 			unconditionalSeen[key] = struct{}{}
 		}
 		kb.Contracts[key] = append(kb.Contracts[key], Contract{
-			Method:        c.Method,
-			Arity:         c.Arity,
-			When:          when,
-			Return:        ContractReturn{Type: c.Return.Type, Confidence: c.Return.Confidence},
-			SourceLibrary: raw.Library.Name,
-			Role:          c.Role,
-			Parameters:    params,
+			Method:              c.Method,
+			Arity:               c.Arity,
+			When:                when,
+			Return:              ContractReturn{Type: c.Return.Type, Confidence: c.Return.Confidence},
+			ParameterTypes:      append([]string(nil), c.ParameterTypes...),
+			CanonicalReturnType: c.CanonicalReturnType,
+			SourceLibrary:       raw.Library.Name,
+			Role:                c.Role,
+			Parameters:          params,
 		})
 	}
 	return nil
@@ -639,6 +673,10 @@ func cloneKB(kb *KnowledgeBase) *KnowledgeBase {
 	for k, v := range kb.Contracts {
 		dst := make([]Contract, len(v))
 		copy(dst, v)
+		for i := range dst {
+			dst[i].ParameterTypes = append([]string(nil), v[i].ParameterTypes...)
+			dst[i].Parameters = append([]ParameterContract(nil), v[i].Parameters...)
+		}
 		clone.Contracts[k] = dst
 	}
 	for k, v := range kb.Hierarchy {
@@ -717,7 +755,7 @@ func mergeContracts(kbs []*KnowledgeBase) (map[string][]Contract, error) {
 	result := make(map[string][]Contract, len(index))
 	for key, byCondition := range index {
 		cs := make([]Contract, 0, len(byCondition))
-		for _, c := range byCondition {
+		for _, c := range byCondition { //nolint:gocritic // Map iteration cannot use indexing.
 			cs = append(cs, c)
 		}
 		result[key] = cs
@@ -732,23 +770,37 @@ func mergeContracts(kbs []*KnowledgeBase) (map[string][]Contract, error) {
 // divergent values HARD-ERROR naming both libraries, mirroring the
 // pre-existing return-type conflict discipline.
 func mergeContractGroup(index map[string]Contract, cs []Contract, key string) error {
-	for _, c := range cs {
+	for i := range cs {
+		c := cs[i]
 		ck := conditionKey(c.When)
 		existing, exists := index[ck]
 		if !exists {
 			index[ck] = c
 			continue
 		}
+		if len(existing.ParameterTypes) == 0 && len(c.ParameterTypes) > 0 {
+			existing.ParameterTypes = slices.Clone(c.ParameterTypes)
+		}
+		if len(c.ParameterTypes) == 0 && len(existing.ParameterTypes) > 0 {
+			c.ParameterTypes = slices.Clone(existing.ParameterTypes)
+		}
+		if existing.CanonicalReturnType == "" {
+			existing.CanonicalReturnType = c.CanonicalReturnType
+		}
+		if c.CanonicalReturnType == "" {
+			c.CanonicalReturnType = existing.CanonicalReturnType
+		}
 		// Rule 1: identical return+role+parameters → idempotent
 		if contractsEquivalent(existing, c) {
+			index[ck] = existing
 			continue
 		}
 		// Rule 2: same condition + divergent return/role/parameters → HARD ERROR
 		return fmt.Errorf(
-			"contracts: contract conflict for %s: library %q has return %q (%s) role %q; library %q has return %q (%s) role %q",
+			"contracts: contract conflict for %s: library %q has return %q (%s) canonical signature (%v): %q role %q; library %q has return %q (%s) canonical signature (%v): %q role %q",
 			key,
-			existing.SourceLibrary, existing.Return.Type, existing.Return.Confidence, existing.Role,
-			c.SourceLibrary, c.Return.Type, c.Return.Confidence, c.Role,
+			existing.SourceLibrary, existing.Return.Type, existing.Return.Confidence, existing.ParameterTypes, existing.CanonicalReturnType, existing.Role,
+			c.SourceLibrary, c.Return.Type, c.Return.Confidence, c.ParameterTypes, c.CanonicalReturnType, c.Role,
 		)
 	}
 	return nil
@@ -760,6 +812,8 @@ func mergeContractGroup(index map[string]Contract, cs []Contract, key string) er
 func contractsEquivalent(a, b Contract) bool {
 	return a.Return.Type == b.Return.Type &&
 		a.Return.Confidence == b.Return.Confidence &&
+		slices.Equal(a.ParameterTypes, b.ParameterTypes) &&
+		a.CanonicalReturnType == b.CanonicalReturnType &&
 		a.Role == b.Role &&
 		parametersKey(a.Parameters) == parametersKey(b.Parameters)
 }

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -1,6 +1,7 @@
 package contracts_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -98,6 +99,85 @@ hierarchy: {}
 	_, err := contracts.Load([]byte(yamlNegArity))
 	if err == nil {
 		t.Fatal("expected error for arity -1, got nil")
+	}
+}
+
+func TestLoadKnowledgeBase_ParsesCanonicalSignatureTypes(t *testing.T) {
+	t.Parallel()
+
+	kb := mustLoad(t, `
+schema_version: "2"
+ecosystem: java
+library:
+  name: test
+contracts:
+  - method: example.Cipher.init
+    arity: 2
+    parameter_types: [int, java.security.Key]
+    canonical_return_type: void
+    return: {type: void, confidence: high}
+hierarchy: {}
+`)
+
+	got := kb.ContractsFor("example.Cipher.init", 2)
+	if len(got) != 1 || !slices.Equal(got[0].ParameterTypes, []string{"int", "java.security.Key"}) {
+		t.Fatalf("parameter types = %#v", got)
+	}
+	if got[0].CanonicalReturnType != "void" {
+		t.Fatalf("canonical return type = %q, want void", got[0].CanonicalReturnType)
+	}
+}
+
+func TestMerge_CanonicalParameterTypesEnrichUnknownContract(t *testing.T) {
+	withoutTypes := mustLoad(t, `
+schema_version: "2"
+ecosystem: java
+library: {name: without-types}
+contracts:
+  - method: example.Cipher.init
+    arity: 2
+    return: {type: void, confidence: high}
+hierarchy: {}
+`)
+	withTypes := mustLoad(t, `
+schema_version: "2"
+ecosystem: java
+library: {name: with-types}
+contracts:
+  - method: example.Cipher.init
+    arity: 2
+    parameter_types: [int, java.security.Key]
+    return: {type: void, confidence: high}
+hierarchy: {}
+`)
+
+	merged, err := contracts.Merge(withoutTypes, withTypes)
+	if err != nil {
+		t.Fatalf("Merge() error = %v", err)
+	}
+	matches := merged.ContractsFor("example.Cipher.init", 2)
+	if len(matches) != 1 || !slices.Equal(matches[0].ParameterTypes, []string{"int", "java.security.Key"}) {
+		t.Fatalf("merged parameter types = %#v, want canonical types", matches)
+	}
+}
+
+func TestLoadKnowledgeBase_RejectsParameterTypesArityMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := contracts.Load([]byte(`
+schema_version: "2"
+ecosystem: java
+library:
+  name: test
+contracts:
+  - method: example.Cipher.init
+    arity: 2
+    parameter_types: [int]
+    return: {type: void, confidence: high}
+hierarchy: {}
+`))
+	if err == nil || !strings.Contains(err.Error(), "parameter_types length 1 must equal arity 2") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/callgraph/contracts/java/apache-santuario-xmlsec.yaml
+++ b/internal/callgraph/contracts/java/apache-santuario-xmlsec.yaml
@@ -11,10 +11,13 @@ library:
 contracts:
   - method: org.apache.xml.security.encryption.XMLCipher.getInstance
     arity: 0
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
   - method: org.apache.xml.security.encryption.XMLCipher.getInstance
     arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
     parameters:
@@ -26,10 +29,13 @@ contracts:
   # factory role are stable, while the selector position is not.
   - method: org.apache.xml.security.encryption.XMLCipher.getInstance
     arity: 2
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
   - method: org.apache.xml.security.encryption.XMLCipher.getInstance
     arity: 3
+    parameter_types: [java.lang.String, java.lang.String, java.lang.String]
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
     parameters:
@@ -39,10 +45,14 @@ contracts:
         contributes: { property: transformation, derivation: argument_value }
   - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
     arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
   - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
     arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
     parameters:
@@ -52,22 +62,30 @@ contracts:
         contributes: { property: transformation, derivation: argument_value }
   - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
     arity: 3
+    parameter_types: [java.lang.String, java.lang.String, java.lang.String]
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
   - method: org.apache.xml.security.encryption.XMLCipher.getProviderInstance
     arity: 4
+    canonical_return_type: org.apache.xml.security.encryption.XMLCipher
     return: { type: org.apache.xml.security.encryption.XMLCipher, confidence: high }
     role: factory
   - method: org.apache.xml.security.encryption.XMLCipher.init
     arity: 2
+    parameter_types: [int, java.security.Key]
+    canonical_return_type: void
     return: { type: void, confidence: high }
     role: config
   - method: org.apache.xml.security.encryption.XMLCipher.doFinal
     arity: 2
+    canonical_return_type: org.w3c.dom.Document
     return: { type: org.w3c.dom.Document, confidence: high }
     role: operation
   - method: org.apache.xml.security.encryption.XMLCipher.doFinal
     arity: 3
+    parameter_types: [org.w3c.dom.Document, org.w3c.dom.Element, boolean]
+    canonical_return_type: org.w3c.dom.Document
     return: { type: org.w3c.dom.Document, confidence: high }
     role: operation
 

--- a/internal/callgraph/contracts/java/tink.yaml
+++ b/internal/callgraph/contracts/java/tink.yaml
@@ -18,12 +18,15 @@ library:
 contracts:
   - method: com.google.crypto.tink.KeyTemplates.get
     arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.google.crypto.tink.KeyTemplate
     return:
       type: com.google.crypto.tink.KeyTemplate
       confidence: high
 
   - method: com.google.crypto.tink.KeysetHandle.generateNew
     arity: 1
+    canonical_return_type: com.google.crypto.tink.KeysetHandle
     return:
       type: com.google.crypto.tink.KeysetHandle
       confidence: high
@@ -33,6 +36,8 @@ contracts:
   # primitive class literal.
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 1
+    parameter_types: [java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.Aead
     when:
       arg_index: 0
       arg_value_in: ["com.google.crypto.tink.Aead.class", "Aead.class"]
@@ -42,6 +47,8 @@ contracts:
 
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 1
+    parameter_types: [java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.Mac
     when:
       arg_index: 0
       arg_value_in: ["com.google.crypto.tink.Mac.class", "Mac.class"]
@@ -51,6 +58,8 @@ contracts:
 
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 1
+    parameter_types: [java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.PublicKeySign
     when:
       arg_index: 0
       arg_value_in: ["com.google.crypto.tink.PublicKeySign.class", "PublicKeySign.class"]
@@ -60,6 +69,8 @@ contracts:
 
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 1
+    parameter_types: [java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.PublicKeyVerify
     when:
       arg_index: 0
       arg_value_in: ["com.google.crypto.tink.PublicKeyVerify.class", "PublicKeyVerify.class"]
@@ -70,6 +81,8 @@ contracts:
   # getPrimitive(Configuration, Class<P>) — newer arity-2 form; class is arg[1].
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 2
+    parameter_types: [com.google.crypto.tink.Configuration, java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.Aead
     when:
       arg_index: 1
       arg_value_in: ["com.google.crypto.tink.Aead.class", "Aead.class"]
@@ -79,6 +92,8 @@ contracts:
 
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 2
+    parameter_types: [com.google.crypto.tink.Configuration, java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.Mac
     when:
       arg_index: 1
       arg_value_in: ["com.google.crypto.tink.Mac.class", "Mac.class"]
@@ -88,6 +103,8 @@ contracts:
 
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 2
+    parameter_types: [com.google.crypto.tink.Configuration, java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.PublicKeySign
     when:
       arg_index: 1
       arg_value_in: ["com.google.crypto.tink.PublicKeySign.class", "PublicKeySign.class"]
@@ -97,6 +114,8 @@ contracts:
 
   - method: com.google.crypto.tink.KeysetHandle.getPrimitive
     arity: 2
+    parameter_types: [com.google.crypto.tink.Configuration, java.lang.Class]
+    canonical_return_type: com.google.crypto.tink.PublicKeyVerify
     when:
       arg_index: 1
       arg_value_in: ["com.google.crypto.tink.PublicKeyVerify.class", "PublicKeyVerify.class"]
@@ -107,6 +126,8 @@ contracts:
   # Terminal operations — truthful returns that terminate the chain.
   - method: com.google.crypto.tink.Aead.encrypt
     arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: "byte[]"
     return:
       type: "byte[]"
       confidence: high
@@ -114,6 +135,8 @@ contracts:
 
   - method: com.google.crypto.tink.Aead.decrypt
     arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: "byte[]"
     return:
       type: "byte[]"
       confidence: high

--- a/internal/callgraph/cpp_type_resolver.go
+++ b/internal/callgraph/cpp_type_resolver.go
@@ -35,7 +35,9 @@ func (r *CPPContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir)
 			continue
 		}
 		method, _ := splitMethodArity(&fn.ID)
-		for _, contract := range r.kb.ContractsFor(method, len(fn.Parameters)) {
+		matches := r.kb.ContractsFor(method, len(fn.Parameters))
+		for i := range matches {
+			contract := &matches[i]
 			if contract.When == nil && contract.Return.Type != "" {
 				fn.ReturnType = contract.Return.Type
 				break

--- a/internal/callgraph/go_type_resolver.go
+++ b/internal/callgraph/go_type_resolver.go
@@ -34,7 +34,9 @@ func (r *GoContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir) 
 		if fn.ReturnType != "" {
 			continue
 		}
-		for _, contract := range r.kb.ContractsForTolerant(fn.ID.String(), len(fn.Parameters)) {
+		matches := r.kb.ContractsForTolerant(fn.ID.String(), len(fn.Parameters))
+		for i := range matches {
+			contract := &matches[i]
 			if contract.When == nil && contract.Return.Type != "" {
 				fn.ReturnType = contract.Return.Type
 				break

--- a/internal/callgraph/inference.go
+++ b/internal/callgraph/inference.go
@@ -731,7 +731,8 @@ func candidateFromKBContracts(
 
 	// Determine whether any condition's arg index is resolved.
 	anyResolved := false
-	for _, c := range conds {
+	for i := range conds {
+		c := &conds[i]
 		if _, ok := resolvedArgs[c.When.ArgIndex]; ok {
 			anyResolved = true
 			break
@@ -760,7 +761,8 @@ func candidateFromKBContracts(
 // arg values are resolved. Returns a candidate only when exactly 1 branch matches.
 func resolveExactConditionalMatch(conds []contracts.Contract, resolvedArgs map[int]string) (candidate, bool) {
 	var exactMatched []contracts.Contract
-	for _, c := range conds {
+	for i := range conds {
+		c := &conds[i]
 		argIdx := c.When.ArgIndex
 		resolvedVal, resolved := resolvedArgs[argIdx]
 		if !resolved {
@@ -768,7 +770,7 @@ func resolveExactConditionalMatch(conds []contracts.Contract, resolvedArgs map[i
 		}
 		for _, v := range c.When.ArgValueIn {
 			if v == resolvedVal {
-				exactMatched = append(exactMatched, c)
+				exactMatched = append(exactMatched, *c)
 				break
 			}
 		}

--- a/internal/callgraph/java_parser.go
+++ b/internal/callgraph/java_parser.go
@@ -1182,7 +1182,7 @@ func (p *JavaParser) traceOriginExpression(
 	node := SourceNode{
 		Type:         kindToSourceType(info.kind),
 		Name:         expr,
-		DeclaredType: info.typeName,
+		DeclaredType: qualifyJavaSourceType(info.typeName, analysis),
 		Location:     &SourceLocation{FilePath: info.filePath, Line: info.line},
 	}
 	if info.kind == javaVarOriginKindParameter {
@@ -2587,7 +2587,7 @@ func (p *JavaParser) traceIdentifierNode(
 	sn := SourceNode{
 		Type:         kindToSourceType(info.kind),
 		Name:         varName,
-		DeclaredType: info.typeName,
+		DeclaredType: qualifyJavaSourceType(info.typeName, analysis),
 		Location:     &SourceLocation{FilePath: info.filePath, Line: info.line},
 	}
 	if info.kind == javaVarOriginKindParameter {
@@ -2610,6 +2610,28 @@ func (p *JavaParser) traceIdentifierNode(
 	}
 
 	return []SourceNode{sn}
+}
+
+func qualifyJavaSourceType(typeName string, analysis *FileAnalysis) string {
+	trimmed := strings.TrimSpace(typeName)
+	if trimmed == "" || analysis == nil {
+		return trimmed
+	}
+	suffix := ""
+	for strings.HasSuffix(trimmed, "[]") {
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, "[]"))
+		suffix += "[]"
+	}
+	if strings.Contains(trimmed, ".") || strings.ContainsAny(trimmed, "<>") {
+		return trimmed + suffix
+	}
+	if pkg, ok := analysis.Imports[trimmed]; ok {
+		return pkg + "." + trimmed + suffix
+	}
+	if pkg, ok := knownWildcardImportPackage(trimmed, analysis.WildcardImports); ok {
+		return pkg + "." + trimmed + suffix
+	}
+	return trimmed + suffix
 }
 
 // traceObjectCreationNode handles `new ClassName(...)` → CALL_RESULT with <init> as CallTarget.

--- a/internal/callgraph/node_type_resolver.go
+++ b/internal/callgraph/node_type_resolver.go
@@ -34,7 +34,9 @@ func (r *NodeContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir
 		if fn.ReturnType != "" {
 			continue
 		}
-		for _, contract := range r.kb.ContractsFor(fn.ID.String(), len(fn.Parameters)) {
+		matches := r.kb.ContractsFor(fn.ID.String(), len(fn.Parameters))
+		for i := range matches {
+			contract := &matches[i]
 			if contract.When == nil && contract.Return.Type != "" {
 				fn.ReturnType = contract.Return.Type
 				break

--- a/internal/callgraph/python_type_resolver.go
+++ b/internal/callgraph/python_type_resolver.go
@@ -67,7 +67,8 @@ func (r *PythonContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageD
 		contractList := r.kb.ContractsForTolerant(fqn, arity)
 
 		// Find the first unconditional contract (When == nil) and apply it.
-		for _, c := range contractList {
+		for i := range contractList {
+			c := &contractList[i]
 			if c.When == nil && c.Return.Type != "" {
 				fn.ReturnType = c.Return.Type
 				break

--- a/internal/callgraph/rust_type_resolver.go
+++ b/internal/callgraph/rust_type_resolver.go
@@ -34,7 +34,9 @@ func (r *RustContractTypeResolver) ResolveTypes(graph *CallGraph, _ []PackageDir
 		if fn.ReturnType != "" {
 			continue
 		}
-		for _, contract := range r.kb.ContractsForTolerant(rustFunctionFQN(fn), len(fn.Parameters)) {
+		matches := r.kb.ContractsForTolerant(rustFunctionFQN(fn), len(fn.Parameters))
+		for i := range matches {
+			contract := &matches[i]
 			if contract.When == nil && contract.Return.Type != "" {
 				fn.ReturnType = contract.Return.Type
 				break

--- a/internal/cli/dependency_intelligence_acceptance_integration_test.go
+++ b/internal/cli/dependency_intelligence_acceptance_integration_test.go
@@ -42,7 +42,8 @@ const acceptanceCondition = `param[0]==true,param[algorithm]~=^AES,param[1|key]:
 
 type acceptanceCase struct {
 	name, ecosystem, fixture, source, provider string
-	pinFile, pinText                           string
+	pinFile                                    string
+	pinTexts                                   []string
 	matches                                    []acceptanceMatch
 }
 
@@ -54,6 +55,7 @@ type acceptanceMatch struct {
 	runtimeProvider      bool
 	requiresSupport      bool
 	supportingCategories []string
+	supportingSignatures map[string]string
 }
 
 type acceptanceResult struct {
@@ -76,7 +78,7 @@ func TestDependencyIntelligenceExportContract(t *testing.T) {
 		{
 			name: "java", ecosystem: "java", fixture: "dependency_intelligence_java",
 			source: "src/main/java/example/Acceptance.java", provider: "BC",
-			pinFile: "pom.xml", pinText: "<version>1.78.1</version>",
+			pinFile: "pom.xml", pinTexts: []string{"<version>1.78.1</version>", "<version>1.13.0</version>", "<version>4.0.3</version>"},
 			matches: []acceptanceMatch{
 				{
 					needle: "new JcePGPDataEncryptorBuilder(alg)", ruleID: "java.acceptance.pgp-builder",
@@ -94,6 +96,24 @@ func TestDependencyIntelligenceExportContract(t *testing.T) {
 				{needle: "params.getKey()", ruleID: "java.acceptance.key-output", api: "org.bouncycastle.crypto.params.KeyParameter.getKey", requiresSupport: true, supportingCategories: []string{"factory", "output"}},
 				{needle: "gcm.getOutputSize(16)", ruleID: "java.acceptance.gcm", api: "org.bouncycastle.crypto.modes.GCMBlockCipher.getOutputSize", requiresSupport: true, supportingCategories: []string{"config"}},
 				{needle: "new AESEngine()", ruleID: "java.acceptance.engine", api: "org.bouncycastle.crypto.engines.AESEngine.<init>", requiresSupport: true, supportingCategories: []string{"operation"}},
+				{
+					needle: "KeysetHandle.generateNew(template)", ruleID: "java.acceptance.tink-aead",
+					api: "com.google.crypto.tink.KeysetHandle.generateNew", requiresSupport: true,
+					supportingCategories: []string{"operation"},
+					supportingSignatures: map[string]string{
+						"com.google.crypto.tink.Aead.encrypt": "com.google.crypto.tink.Aead.encrypt(byte[], byte[]): byte[]",
+						"com.google.crypto.tink.Aead.decrypt": "com.google.crypto.tink.Aead.decrypt(byte[], byte[]): byte[]",
+					},
+				},
+				{
+					needle: "XMLCipher.getInstance(XMLCipher.AES_256_GCM)", ruleID: "java.acceptance.xml-cipher",
+					api: "org.apache.xml.security.encryption.XMLCipher.getInstance", requiresSupport: true,
+					supportingCategories: []string{"config", "operation"},
+					supportingSignatures: map[string]string{
+						"org.apache.xml.security.encryption.XMLCipher.init":    "org.apache.xml.security.encryption.XMLCipher.init(int, java.security.Key): void",
+						"org.apache.xml.security.encryption.XMLCipher.doFinal": "org.apache.xml.security.encryption.XMLCipher.doFinal(org.w3c.dom.Document, org.w3c.dom.Element): org.w3c.dom.Document",
+					},
+				},
 				{needle: `Cipher.getInstance("AES/GCM/NoPadding", "BC")`, ruleID: "java.acceptance.static-provider", api: "javax.crypto.Cipher.getInstance", staticProvider: true},
 				{needle: `Cipher.getInstance("AES/GCM/NoPadding", runtimeProvider)`, ruleID: "java.acceptance.runtime-provider", api: "javax.crypto.Cipher.getInstance", runtimeProvider: true},
 			},
@@ -101,7 +121,7 @@ func TestDependencyIntelligenceExportContract(t *testing.T) {
 		{
 			name: "python", ecosystem: "python", fixture: "dependency_intelligence_python",
 			source: "acceptance.py", provider: "pycryptodomex",
-			pinFile: "requirements.txt", pinText: "pycryptodomex==3.20.0",
+			pinFile: "requirements.txt", pinTexts: []string{"pycryptodomex==3.20.0"},
 			matches: []acceptanceMatch{
 				{needle: "AES.new(key, AES.MODE_GCM)", ruleID: "python.acceptance.aes-new", api: "Cryptodome.Cipher.AES.new", requiresSupport: true},
 				{needle: "cipher.encrypt(data)", ruleID: "python.acceptance.aes-encrypt", api: "Cryptodome.Cipher.AES.AESCipher.encrypt", requiresSupport: true, supportingCategories: []string{"factory"}},
@@ -366,6 +386,26 @@ func assertFragmentContract(t *testing.T, tc acceptanceCase, payload *graphfrag.
 		}
 		for _, category := range match.supportingCategories {
 			assert.Truef(t, findingCategories[category], "finding %s missing applicable %s support: %#v", op.RuleID, category, op.SupportingCallIDs)
+		}
+		for functionName, signature := range match.supportingSignatures {
+			found := false
+			for _, id := range op.SupportingCallIDs {
+				call := supportByID[id]
+				if call.SupportingCall != nil && call.SupportingCall.FunctionName == functionName {
+					found = true
+					assert.Equal(t, signature, call.SupportingCall.CanonicalSignature, "finding %s supporting call %s", op.RuleID, functionName)
+				}
+			}
+			assert.Truef(t, found, "finding %s missing supporting call %s", op.RuleID, functionName)
+			externalFound := false
+			for i := range payload.ExternalCalls {
+				call := &payload.ExternalCalls[i]
+				if call.TargetFunctionName == functionName {
+					externalFound = true
+					assert.Equal(t, signature, call.TargetCanonicalSignature, "external call %s", functionName)
+				}
+			}
+			assert.Truef(t, externalFound, "missing external call %s", functionName)
 		}
 	}
 	assert.Equal(t, len(tc.matches), seen, "expected crypto annotations by rule")
@@ -663,7 +703,9 @@ func assertDependencyPin(t *testing.T, target string, tc acceptanceCase) {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(target, tc.pinFile))
 	require.NoError(t, err)
-	require.Contains(t, string(data), tc.pinText, "fixture dependency pin")
+	for _, pin := range tc.pinTexts {
+		require.Contains(t, string(data), pin, "fixture dependency pin")
+	}
 }
 
 func repositoryRoot(t *testing.T) string {

--- a/internal/scan/annotate_supporting.go
+++ b/internal/scan/annotate_supporting.go
@@ -138,12 +138,13 @@ func annotateLifecycleSiblings(
 	edges []fragEdge,
 	terminalIdx int,
 ) []graphfrag.GraphFragmentSupporting {
-	terminalID := edges[terminalIdx].identity
-	out := make([]graphfrag.GraphFragmentSupporting, 0, len(edges))
+	identities := make([]objectIdentity, len(edges))
 	for i := range edges {
-		if i == terminalIdx || !isLifecycleSibling(edges[i].identity, terminalID) {
-			continue
-		}
+		identities[i] = edges[i].identity
+	}
+	indices := lifecycleCallIndices(identities, terminalIdx)
+	out := make([]graphfrag.GraphFragmentSupporting, 0, len(indices))
+	for _, i := range indices {
 		// The supporting call lives in the finding's file; use the detection
 		// finding's normalized, relative path for file_path and the
 		// path-derived supporting_id so both match the live exporter.

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -936,7 +937,8 @@ func parameterRolesFromKB(kb *contracts.KnowledgeBase, fqn string, arity int) []
 }
 
 func parameterRolesFromContracts(matches []contracts.Contract) []callGraphParameterRole {
-	for _, contract := range matches {
+	for i := range matches {
+		contract := &matches[i]
 		if len(contract.Parameters) == 0 {
 			continue
 		}
@@ -968,18 +970,56 @@ func contractMatchesForCall(ctx *exportBuildContext, call *callgraph.FunctionCal
 	if ctx.kb.Ecosystem != "c" {
 		matches := ctx.kb.ContractsForTolerant(fqn, arity)
 		if len(matches) == 0 && ctx.kb.Ecosystem == "cpp" && call.Callee.Type != "" && call.Callee.Linkage != callgraph.LinkageInternal && !hasCallDeclaration(ctx.graph, call.Callee) {
-			return ctx.kb.ContractsForTolerant(call.Callee.Type+"."+callgraph.BaseFunctionName(call.Callee.Name), arity)
+			matches = ctx.kb.ContractsForTolerant(call.Callee.Type+"."+callgraph.BaseFunctionName(call.Callee.Name), arity)
 		}
-		return matches
+		return exactConditionalContracts(matches, call)
 	}
 	if exact := ctx.kb.ContractsFor(fqn, arity); len(exact) > 0 {
-		return exact
+		return exactConditionalContracts(exact, call)
 	}
 	if ctx.graph == nil {
 		return nil
 	}
 	externalGlobal := call.Callee.Linkage == callgraph.LinkageExternal && ctx.graph.Functions[call.Callee.String()] == nil
-	return ctx.kb.ContractsForCFunction(fqn, arity, externalGlobal)
+	return exactConditionalContracts(ctx.kb.ContractsForCFunction(fqn, arity, externalGlobal), call)
+}
+
+func exactConditionalContracts(matches []contracts.Contract, call *callgraph.FunctionCall) []contracts.Contract {
+	exact := matchingConditionalContracts(matches, call)
+	if len(exact) > 0 {
+		return exact
+	}
+	return matches
+}
+
+func canonicalContractsForCall(matches []contracts.Contract, call *callgraph.FunctionCall) []contracts.Contract {
+	if exact := matchingConditionalContracts(matches, call); len(exact) > 0 {
+		return exact
+	}
+	unconditional := make([]contracts.Contract, 0, len(matches))
+	for i := range matches {
+		if matches[i].When == nil {
+			unconditional = append(unconditional, matches[i])
+		}
+	}
+	return unconditional
+}
+
+func matchingConditionalContracts(matches []contracts.Contract, call *callgraph.FunctionCall) []contracts.Contract {
+	exact := make([]contracts.Contract, 0, len(matches))
+	for i := range matches {
+		condition := matches[i].When
+		if condition == nil || condition.ArgIndex < 0 || condition.ArgIndex >= len(call.Arguments) {
+			continue
+		}
+		argument := strings.TrimSpace(call.Arguments[condition.ArgIndex])
+		if slices.ContainsFunc(condition.ArgValueIn, func(want string) bool {
+			return argument == strings.TrimSpace(want)
+		}) {
+			exact = append(exact, matches[i])
+		}
+	}
+	return exact
 }
 
 func hasCallDeclaration(graph *callgraph.CallGraph, id callgraph.FunctionID) bool {
@@ -1518,7 +1558,8 @@ func buildDerivedSupportingCall(ctx *exportBuildContext, containingFn *callgraph
 		Line:         call.Line,
 		Parameters:   mergeCallParameters(ctx, &containingFn.ID, &call.Callee, callee, call.Arguments, call.ArgumentSources, sourcePath, call.Line),
 	}
-	applyExportFunctionMetadataToCalledFunction(sc, buildExportFunctionMetadata(ctx.graph, call.Callee, callee))
+	callMeta, matches := buildCallExportFunctionMetadata(ctx, call, callee)
+	applyExportFunctionMetadataToCalledFunction(sc, callMeta)
 	support.SupportingCall = sc
 	if support.MatchedOperation != nil && sc.FunctionName != "" {
 		support.MatchedOperation.Symbol = sc.FunctionName
@@ -1535,8 +1576,11 @@ func buildDerivedSupportingCall(ctx *exportBuildContext, containingFn *callgraph
 		if ctx.kb.Ecosystem == "cpp" {
 			arity = len(call.Arguments)
 		}
-		matches := contractMatchesForCall(ctx, call, arity)
-		for _, contract := range matches {
+		if len(matches) == 0 || arity != len(call.Arguments) {
+			matches = contractMatchesForCall(ctx, call, arity)
+		}
+		for i := range matches {
+			contract := &matches[i]
 			if contract.Role != "" {
 				support.Category = contract.Role
 				break
@@ -1873,7 +1917,8 @@ func findCryptoCall(
 		Line:         bestCall.Line,
 		Parameters:   mergeCallParameters(ctx, &containingFn.ID, &bestCall.Callee, callee, bestCall.Arguments, bestCall.ArgumentSources, sourcePath, bestCall.Line),
 	}
-	applyExportFunctionMetadataToCalledFunction(result, buildExportFunctionMetadata(graph, bestCall.Callee, callee))
+	meta, _ := buildCallExportFunctionMetadata(ctx, bestCall, callee)
+	applyExportFunctionMetadataToCalledFunction(result, meta)
 
 	return result
 }
@@ -2530,7 +2575,8 @@ func buildEntryCall(
 		Line:       call.Line,
 		Parameters: mergeCallParameters(ctx, &callerID, &call.Callee, calleeFn, call.Arguments, call.ArgumentSources, location.FilePath, call.Line),
 	}
-	applyExportFunctionMetadataToEntryCall(entryCall, buildExportFunctionMetadata(graph, call.Callee, calleeFn))
+	meta, _ := buildCallExportFunctionMetadata(ctx, call, calleeFn)
+	applyExportFunctionMetadataToEntryCall(entryCall, meta)
 	callName := fullFunctionName(call.Callee)
 	if callName != fullFunctionName(calleeID) {
 		entryCall.FunctionName = callName
@@ -2732,6 +2778,45 @@ func buildExportFunctionMetadata(
 	return meta
 }
 
+// buildCallExportFunctionMetadata enriches an external call with canonical
+// signature details that the contract KB can state unambiguously. Source or
+// scanned declarations remain authoritative; contracts only fill gaps.
+func buildCallExportFunctionMetadata(
+	ctx *exportBuildContext,
+	call *callgraph.FunctionCall,
+	decl *callgraph.FunctionDecl,
+) (exportFunctionMetadata, []contracts.Contract) {
+	if call == nil {
+		return exportFunctionMetadata{}, nil
+	}
+	meta := buildExportFunctionMetadata(ctx.graph, call.Callee, decl)
+	matches := contractMatchesForCall(ctx, call, len(call.Arguments))
+	if len(matches) == 0 {
+		return meta, nil
+	}
+	canonicalMatches := canonicalContractsForCall(matches, call)
+	if len(canonicalMatches) == 0 {
+		return meta, matches
+	}
+
+	parameterTypes := canonicalMatches[0].ParameterTypes
+	returnType := canonicalMatches[0].CanonicalReturnType
+	for i := 1; i < len(canonicalMatches); i++ {
+		if !slices.Equal(parameterTypes, canonicalMatches[i].ParameterTypes) {
+			parameterTypes = nil
+		}
+		if returnType != canonicalMatches[i].CanonicalReturnType {
+			returnType = ""
+		}
+	}
+	meta.ParameterTypes = mergeExportParameterTypes(meta.ParameterTypes, parameterTypes)
+	if meta.ReturnType == "" {
+		meta.ReturnType = returnType
+	}
+	meta.CanonicalSignature = canonicalSignature(meta.FunctionName, meta.ParameterTypes, meta.ReturnType)
+	return meta, matches
+}
+
 // convertInferredReturnProvenance converts a []callgraph.SourceNode (inference
 // provenance) into the export shape without path normalization. This is used
 // only for the inferred_return.provenance field — the paths are not available
@@ -2906,22 +2991,29 @@ func parameterTypesFromCallParameters(parameters []callGraphParameter) []string 
 }
 
 func uniqueSourceDeclaredType(nodes []exportSourceNode) string {
-	types := make(map[string]struct{})
-	var collect func([]exportSourceNode)
-	collect = func(current []exportSourceNode) {
+	current := nodes
+	for len(current) > 0 {
+		types := make(map[string]struct{})
+		nextCapacity := 0
+		for i := range current {
+			nextCapacity += len(current[i].SourceNodes)
+		}
+		next := make([]exportSourceNode, 0, nextCapacity)
 		for i := range current {
 			if declared := strings.TrimSpace(current[i].DeclaredType); declared != "" {
 				types[declared] = struct{}{}
 			}
-			collect(current[i].SourceNodes)
+			next = append(next, current[i].SourceNodes...)
 		}
-	}
-	collect(nodes)
-	if len(types) != 1 {
-		return ""
-	}
-	for declared := range types {
-		return declared
+		if len(types) == 1 {
+			for declared := range types {
+				return declared
+			}
+		}
+		if len(types) > 1 {
+			return ""
+		}
+		current = next
 	}
 	return ""
 }

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -374,6 +374,109 @@ func TestApplyExportFunctionMetadataToCalledFunction_PreservesDeclaredArity(t *t
 	}
 }
 
+func TestBuildCallExportFunctionMetadata_DoesNotUseInferredReturnAsDeclared(t *testing.T) {
+	call := &callgraph.FunctionCall{
+		Callee:    callgraph.FunctionID{Package: "crypto/rsa", Name: "GenerateKey#2"},
+		Arguments: []string{"rand.Reader", "2048"},
+	}
+	ctx := &exportBuildContext{
+		graph: &callgraph.CallGraph{},
+		kb: &contracts.KnowledgeBase{Ecosystem: "go", Contracts: map[string][]contracts.Contract{
+			"crypto/rsa.GenerateKey#2": {{
+				Method: "crypto/rsa.GenerateKey",
+				Arity:  2,
+				Return: contracts.ContractReturn{Type: "*crypto/rsa.PrivateKey", Confidence: "high"},
+			}},
+		}},
+	}
+
+	got, _ := buildCallExportFunctionMetadata(ctx, call, nil)
+	if got.ReturnType != "" {
+		t.Fatalf("ReturnType = %q, want empty declared return", got.ReturnType)
+	}
+}
+
+func TestBuildCallExportFunctionMetadata_ResolvesConditionalCanonicalReturn(t *testing.T) {
+	ctx := conditionalCanonicalReturnContext()
+	call := &callgraph.FunctionCall{
+		Callee:    callgraph.FunctionID{Package: "com.google.crypto.tink", Type: "KeysetHandle", Name: "getPrimitive#1"},
+		Arguments: []string{"Aead.class"},
+	}
+
+	got, _ := buildCallExportFunctionMetadata(ctx, call, nil)
+	if got.ReturnType != "com.google.crypto.tink.Aead" {
+		t.Fatalf("ReturnType = %q, want resolved Aead return", got.ReturnType)
+	}
+}
+
+func TestBuildCallExportFunctionMetadata_LeavesUnresolvedConditionalReturnEmpty(t *testing.T) {
+	ctx := conditionalCanonicalReturnContext()
+	call := &callgraph.FunctionCall{
+		Callee:    callgraph.FunctionID{Package: "com.google.crypto.tink", Type: "KeysetHandle", Name: "getPrimitive#1"},
+		Arguments: []string{"primitiveClass"},
+	}
+
+	got, _ := buildCallExportFunctionMetadata(ctx, call, nil)
+	if got.ReturnType != "" {
+		t.Fatalf("ReturnType = %q, want unresolved return omitted", got.ReturnType)
+	}
+}
+
+func TestBuildCallExportFunctionMetadata_LeavesSingletonConditionalReturnEmpty(t *testing.T) {
+	ctx := conditionalCanonicalReturnContext()
+	ctx.kb.Contracts["com.google.crypto.tink.KeysetHandle.getPrimitive#1"] = ctx.kb.Contracts["com.google.crypto.tink.KeysetHandle.getPrimitive#1"][:1]
+	call := &callgraph.FunctionCall{
+		Callee:    callgraph.FunctionID{Package: "com.google.crypto.tink", Type: "KeysetHandle", Name: "getPrimitive#1"},
+		Arguments: []string{"primitiveClass"},
+	}
+
+	got, _ := buildCallExportFunctionMetadata(ctx, call, nil)
+	if got.ReturnType != "" {
+		t.Fatalf("ReturnType = %q, want unresolved singleton return omitted", got.ReturnType)
+	}
+}
+
+func TestBuildCallExportFunctionMetadata_MixedConditionalProvenanceFailsClosed(t *testing.T) {
+	ctx := conditionalCanonicalReturnContext()
+	call := &callgraph.FunctionCall{
+		Callee:    callgraph.FunctionID{Package: "com.google.crypto.tink", Type: "KeysetHandle", Name: "getPrimitive#1"},
+		Arguments: []string{"primitiveClass"},
+		ArgumentSources: [][]callgraph.SourceNode{{
+			{Type: "VALUE", Value: "Aead.class"},
+			{Type: "VARIABLE", Name: "runtimeClass"},
+		}},
+	}
+
+	got, _ := buildCallExportFunctionMetadata(ctx, call, nil)
+	if got.ReturnType != "" {
+		t.Fatalf("ReturnType = %q, want mixed provenance to remain unresolved", got.ReturnType)
+	}
+}
+
+func conditionalCanonicalReturnContext() *exportBuildContext {
+	return &exportBuildContext{
+		graph: &callgraph.CallGraph{},
+		kb: &contracts.KnowledgeBase{Ecosystem: "java", Contracts: map[string][]contracts.Contract{
+			"com.google.crypto.tink.KeysetHandle.getPrimitive#1": {
+				{
+					Method:              "com.google.crypto.tink.KeysetHandle.getPrimitive",
+					Arity:               1,
+					When:                &contracts.Condition{ArgIndex: 0, ArgValueIn: []string{"Aead.class"}},
+					ParameterTypes:      []string{"java.lang.Class"},
+					CanonicalReturnType: "com.google.crypto.tink.Aead",
+				},
+				{
+					Method:              "com.google.crypto.tink.KeysetHandle.getPrimitive",
+					Arity:               1,
+					When:                &contracts.Condition{ArgIndex: 0, ArgValueIn: []string{"Mac.class"}},
+					ParameterTypes:      []string{"java.lang.Class"},
+					CanonicalReturnType: "com.google.crypto.tink.Mac",
+				},
+			},
+		}},
+	}
+}
+
 // TestBestChainRootCandidate isolates the chain-root tie-break (step 3a): only
 // chain candidates with AssignedVar set are eligible, non-chain candidates are
 // ignored, and ties between multiple chain roots resolve to the lowest StartCol.

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -614,7 +614,19 @@ func buildFragmentExternalCall(
 	}
 	external.TargetFunctionName = fragmentTargetFunctionName(ctx, callerKey, callerDecl, calleeKey, &external)
 	if calleeID, err := callgraph.ParseFunctionID(calleeKey); err == nil {
-		external.TargetCanonicalSignature = buildExportFunctionMetadata(ctx.graph, calleeID, nil).CanonicalSignature
+		meta := buildExportFunctionMetadata(ctx.graph, calleeID, nil)
+		if call != nil && call.Callee.String() == calleeKey {
+			meta, _ = buildCallExportFunctionMetadata(ctx, call, nil)
+		}
+		parameterTypes := meta.ParameterTypes
+		if external.EntryCall != nil {
+			callTypes := make([]string, len(external.EntryCall.Parameters))
+			for i := range external.EntryCall.Parameters {
+				callTypes[i] = external.EntryCall.Parameters[i].Type
+			}
+			parameterTypes = mergeExportParameterTypes(parameterTypes, callTypes)
+		}
+		external.TargetCanonicalSignature = canonicalSignature(meta.FunctionName, parameterTypes, meta.ReturnType)
 	}
 	if call != nil {
 		external.Raw = call.Raw

--- a/internal/scan/supporting_calls.go
+++ b/internal/scan/supporting_calls.go
@@ -7,36 +7,129 @@ import "github.com/scanoss/crypto-finder/internal/callgraph"
 // bound to, and the fluent-chain group it belongs to. It is the shared currency
 // between the live-scan export (which projects it from callgraph.FunctionCall)
 // and the annotate-from-cache path (which projects it from a graph-fragment-1.4
-// edge's receiver_var/assigned_var/chain_id). Both paths run the SAME selection
-// policy (isLifecycleSibling) so they pick the identical set of supporting calls.
+// edge's receiver_var/assigned_var/chain_id). Both paths run the same directional
+// selector below so they pick the identical set of supporting calls.
 type objectIdentity struct {
 	ReceiverVar string
 	AssignedVar string
 	ChainID     string
 }
 
-// isLifecycleSibling reports whether call belongs to the lifecycle of the crypto
-// object identified by terminal. It is the single source of truth for the
-// object-lifecycle selection policy; callers must exclude the terminal call
-// itself. A call is a lifecycle sibling when:
-//
-//   - it is invoked on one of the terminal's object variables (ReceiverVar match);
-//   - it is a sibling link of the same fluent chain (ChainID match);
-//   - it produced one of the terminal's object variables (AssignedVar match).
-func isLifecycleSibling(call, terminal objectIdentity) bool {
-	matchesObjectVar := func(v string) bool {
-		return v != "" && (v == terminal.ReceiverVar || v == terminal.AssignedVar)
+type lifecycleSelector struct {
+	calls       []objectIdentity
+	selected    []bool
+	downVisited map[string]bool
+	upVisited   map[string]bool
+}
+
+// lifecycleCallIndices returns the directional receiver/assignment lifecycle
+// around one terminal call. Factory terminals walk down into the objects they
+// produce; operations walk up through their unique producer path. Keeping those
+// directions separate prevents sibling products of one factory from becoming
+// supporting calls for each other.
+func lifecycleCallIndices(calls []objectIdentity, terminalIdx int) []int {
+	if terminalIdx < 0 || terminalIdx >= len(calls) {
+		return nil
 	}
-	if matchesObjectVar(call.ReceiverVar) {
-		return true
+
+	selector := lifecycleSelector{
+		calls:       calls,
+		selected:    make([]bool, len(calls)),
+		downVisited: make(map[string]bool),
+		upVisited:   make(map[string]bool),
 	}
-	if terminal.ChainID != "" && call.ChainID == terminal.ChainID {
-		return true
+	selector.selected[terminalIdx] = true
+	terminal := calls[terminalIdx]
+	selector.selectChain(terminal.ChainID)
+	switch {
+	case terminal.ReceiverVar == "":
+		selector.selectDescendants(terminal.AssignedVar)
+	case terminal.AssignedVar != "" && selector.hasReceiver(terminal.AssignedVar):
+		selector.selectDescendants(terminal.AssignedVar)
+		selector.selectReceiverCalls(terminal.ReceiverVar, terminal.AssignedVar)
+		selector.selectAncestors(terminal.ReceiverVar)
+	default:
+		selector.selectReceiverCalls(terminal.ReceiverVar, "")
+		selector.selectAncestors(terminal.ReceiverVar)
 	}
-	if matchesObjectVar(call.AssignedVar) {
-		return true
+
+	out := make([]int, 0, len(calls)-1)
+	for i := range calls {
+		if i != terminalIdx && selector.selected[i] {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func (s *lifecycleSelector) hasReceiver(objectVar string) bool {
+	for i := range s.calls {
+		if s.calls[i].ReceiverVar == objectVar {
+			return true
+		}
 	}
 	return false
+}
+
+func (s *lifecycleSelector) selectChain(chainID string) {
+	if chainID == "" {
+		return
+	}
+	for i := range s.calls {
+		if s.calls[i].ChainID == chainID {
+			s.selected[i] = true
+		}
+	}
+}
+
+func (s *lifecycleSelector) selectDescendants(objectVar string) {
+	if objectVar == "" || s.downVisited[objectVar] {
+		return
+	}
+	s.downVisited[objectVar] = true
+	for i := range s.calls {
+		if s.calls[i].ReceiverVar != objectVar {
+			continue
+		}
+		s.selected[i] = true
+		s.selectChain(s.calls[i].ChainID)
+		if s.calls[i].AssignedVar != objectVar {
+			s.selectDescendants(s.calls[i].AssignedVar)
+		}
+	}
+}
+
+func (s *lifecycleSelector) selectAncestors(objectVar string) {
+	if objectVar == "" || s.upVisited[objectVar] {
+		return
+	}
+	s.upVisited[objectVar] = true
+	for i := range s.calls {
+		if s.calls[i].AssignedVar != objectVar {
+			continue
+		}
+		s.selected[i] = true
+		s.selectChain(s.calls[i].ChainID)
+		parentVar := s.calls[i].ReceiverVar
+		if parentVar != "" {
+			s.selectReceiverCalls(parentVar, objectVar)
+			s.selectAncestors(parentVar)
+		}
+	}
+}
+
+func (s *lifecycleSelector) selectReceiverCalls(receiverVar, pathChild string) {
+	for i := range s.calls {
+		if s.calls[i].ReceiverVar != receiverVar {
+			continue
+		}
+		assigned := s.calls[i].AssignedVar
+		if pathChild != "" && assigned != "" && assigned != receiverVar && assigned != pathChild {
+			continue
+		}
+		s.selected[i] = true
+		s.selectChain(s.calls[i].ChainID)
+	}
 }
 
 // deriveObjectLifecycleCalls returns the calls in fn that belong to the
@@ -66,22 +159,20 @@ func deriveObjectLifecycleCalls(fn *callgraph.FunctionDecl, terminal *callgraph.
 		return nil
 	}
 
-	terminalID := objectIdentity{
-		ReceiverVar: terminal.ReceiverVar,
-		AssignedVar: terminal.AssignedVar,
-		ChainID:     terminal.ChainID,
-	}
-
-	out := make([]*callgraph.FunctionCall, 0)
+	identities := make([]objectIdentity, len(fn.Calls))
+	terminalIdx := -1
 	for i := range fn.Calls {
 		c := &fn.Calls[i]
 		if c == terminal {
-			continue
+			terminalIdx = i
 		}
-		callID := objectIdentity{ReceiverVar: c.ReceiverVar, AssignedVar: c.AssignedVar, ChainID: c.ChainID}
-		if isLifecycleSibling(callID, terminalID) {
-			out = append(out, c)
-		}
+		identities[i] = objectIdentity{ReceiverVar: c.ReceiverVar, AssignedVar: c.AssignedVar, ChainID: c.ChainID}
+	}
+
+	indices := lifecycleCallIndices(identities, terminalIdx)
+	out := make([]*callgraph.FunctionCall, 0, len(indices))
+	for _, i := range indices {
+		out = append(out, &fn.Calls[i])
 	}
 	return out
 }

--- a/internal/scan/supporting_calls_test.go
+++ b/internal/scan/supporting_calls_test.go
@@ -100,35 +100,74 @@ func TestDeriveObjectLifecycleCalls_KeygenObjectAndConstructor(t *testing.T) {
 	}
 }
 
-// TestIsLifecycleSibling pins the shared object-lifecycle selection policy used
-// by BOTH the live-scan export and the annotate-from-cache path. If the two
-// paths ever diverge on which calls are "supporting", served reachability stops
-// matching a live scan — so this policy is the single source of truth.
-func TestIsLifecycleSibling(t *testing.T) {
-	t.Parallel()
-
-	genTerminal := objectIdentity{ReceiverVar: "gen"} // terminal call on the generator receiver
-	chainTerminal := objectIdentity{ChainID: "167"}   // terminal link in fluent chain 167
-
-	cases := []struct {
-		name     string
-		call     objectIdentity
-		terminal objectIdentity
-		want     bool
-	}{
-		{"receiver-var match (gen.init on gen)", objectIdentity{ReceiverVar: "gen"}, genTerminal, true},
-		{"assigned-var match (constructor binds gen)", objectIdentity{AssignedVar: "gen"}, genTerminal, true},
-		{"chain match (sibling fluent link)", objectIdentity{ChainID: "167"}, chainTerminal, true},
-		{"different receiver var", objectIdentity{ReceiverVar: "other"}, genTerminal, false},
-		{"different chain id", objectIdentity{ChainID: "999"}, chainTerminal, false},
-		{"empty call identity never matches", objectIdentity{}, genTerminal, false},
-		{"empty chain ids do not group", objectIdentity{ChainID: ""}, objectIdentity{ChainID: ""}, false},
+func TestDeriveObjectLifecycleCalls_FollowsProducedPrimitive(t *testing.T) {
+	fn := &callgraph.FunctionDecl{
+		Calls: []callgraph.FunctionCall{
+			{Callee: callgraph.FunctionID{Type: "KeysetHandle", Name: "generateNew#1"}, AssignedVar: "handle", Line: 5},
+			{Callee: callgraph.FunctionID{Type: "KeysetHandle", Name: "getPrimitive#1"}, ReceiverVar: "handle", AssignedVar: "aead", Line: 6},
+			{Callee: callgraph.FunctionID{Type: "Aead", Name: "encrypt#2"}, ReceiverVar: "aead", AssignedVar: "ciphertext", Line: 7},
+			{Callee: callgraph.FunctionID{Type: "Aead", Name: "decrypt#2"}, ReceiverVar: "aead", Line: 8},
+			{Callee: callgraph.FunctionID{Type: "Logger", Name: "info#1"}, ReceiverVar: "logger", Line: 9},
+		},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isLifecycleSibling(tc.call, tc.terminal); got != tc.want {
-				t.Errorf("isLifecycleSibling(%+v, %+v) = %v, want %v", tc.call, tc.terminal, got, tc.want)
-			}
-		})
+
+	got := methodsOf(deriveObjectLifecycleCalls(fn, &fn.Calls[0]))
+	want := []string{"decrypt", "encrypt", "getPrimitive"}
+	if !equalStrings(got, want) {
+		t.Errorf("derived = %v, want %v", got, want)
+	}
+}
+
+func TestDeriveObjectLifecycleCalls_DoesNotCrossProducedPrimitiveBranches(t *testing.T) {
+	fn := &callgraph.FunctionDecl{
+		Calls: []callgraph.FunctionCall{
+			{Callee: callgraph.FunctionID{Type: "KeysetHandle", Name: "generateNew#1"}, AssignedVar: "handle", Line: 5},
+			{Callee: callgraph.FunctionID{Type: "KeysetHandle", Name: "getPrimitive#1"}, ReceiverVar: "handle", AssignedVar: "aead", Line: 6},
+			{Callee: callgraph.FunctionID{Type: "KeysetHandle", Name: "getPrimitive#1"}, ReceiverVar: "handle", AssignedVar: "mac", Line: 7},
+			{Callee: callgraph.FunctionID{Type: "Aead", Name: "encrypt#2"}, ReceiverVar: "aead", Line: 8},
+			{Callee: callgraph.FunctionID{Type: "Mac", Name: "computeMac#1"}, ReceiverVar: "mac", Line: 9},
+		},
+	}
+
+	got := methodsOf(deriveObjectLifecycleCalls(fn, &fn.Calls[3]))
+	want := []string{"generateNew", "getPrimitive"}
+	if !equalStrings(got, want) {
+		t.Errorf("derived = %v, want %v", got, want)
+	}
+}
+
+func TestDeriveObjectLifecycleCalls_FollowsReceiverFactoryResultOnly(t *testing.T) {
+	fn := &callgraph.FunctionDecl{
+		Calls: []callgraph.FunctionCall{
+			{Callee: callgraph.FunctionID{Type: "Factory", Name: "<init>#0"}, AssignedVar: "factory", Line: 5},
+			{Callee: callgraph.FunctionID{Type: "Factory", Name: "create#1"}, ReceiverVar: "factory", AssignedVar: "encryptor", Line: 6},
+			{Callee: callgraph.FunctionID{Type: "Factory", Name: "create#1"}, ReceiverVar: "factory", AssignedVar: "decryptor", Line: 7},
+			{Callee: callgraph.FunctionID{Type: "Cipher", Name: "init#2"}, ReceiverVar: "encryptor", Line: 8},
+			{Callee: callgraph.FunctionID{Type: "Cipher", Name: "doFinal#2"}, ReceiverVar: "encryptor", Line: 9},
+			{Callee: callgraph.FunctionID{Type: "Cipher", Name: "doFinal#2"}, ReceiverVar: "decryptor", Line: 10},
+		},
+	}
+
+	got := methodsOf(deriveObjectLifecycleCalls(fn, &fn.Calls[1]))
+	want := []string{"<init>", "doFinal", "init"}
+	if !equalStrings(got, want) {
+		t.Errorf("derived = %v, want %v", got, want)
+	}
+}
+
+func TestDeriveObjectLifecycleCalls_KeepsReceiverSetupWhenOperationResultIsUsed(t *testing.T) {
+	fn := &callgraph.FunctionDecl{
+		Calls: []callgraph.FunctionCall{
+			{Callee: callgraph.FunctionID{Type: "MessageDigest", Name: "getInstance#1"}, AssignedVar: "digest", Line: 5},
+			{Callee: callgraph.FunctionID{Type: "MessageDigest", Name: "update#1"}, ReceiverVar: "digest", Line: 6},
+			{Callee: callgraph.FunctionID{Type: "MessageDigest", Name: "digest#0"}, ReceiverVar: "digest", AssignedVar: "hash", Line: 7},
+			{Callee: callgraph.FunctionID{Type: "byte[]", Name: "clone#0"}, ReceiverVar: "hash", Line: 8},
+		},
+	}
+
+	got := methodsOf(deriveObjectLifecycleCalls(fn, &fn.Calls[2]))
+	want := []string{"clone", "getInstance", "update"}
+	if !equalStrings(got, want) {
+		t.Errorf("derived = %v, want %v", got, want)
 	}
 }

--- a/testdata/projects/dependency_intelligence_java/pom.xml
+++ b/testdata/projects/dependency_intelligence_java/pom.xml
@@ -9,5 +9,15 @@
       <artifactId>bcprov-jdk18on</artifactId>
       <version>1.78.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink</artifactId>
+      <version>1.13.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.santuario</groupId>
+      <artifactId>xmlsec</artifactId>
+      <version>4.0.3</version>
+    </dependency>
   </dependencies>
 </project>

--- a/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
+++ b/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
@@ -17,11 +17,19 @@
 package example;
 
 import java.security.SecureRandom;
+import java.security.Key;
 import javax.crypto.Cipher;
+import com.google.crypto.tink.Aead;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.aead.AeadKeyTemplates;
+import com.google.crypto.tink.proto.KeyTemplate;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder;
+import org.apache.xml.security.encryption.XMLCipher;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 interface Processor {
     byte[] apply(byte[] data);
@@ -40,6 +48,20 @@ class Acceptance {
         return new JcePGPDataEncryptorBuilder(alg)
             .setSecureRandom(new SecureRandom())
             .setWithIntegrityPacket(true);
+    }
+
+    byte[] tink(byte[] data) throws Exception {
+        KeyTemplate template = AeadKeyTemplates.AES128_GCM;
+        KeysetHandle handle = KeysetHandle.generateNew(template);
+        Aead aead = handle.getPrimitive(Aead.class);
+        byte[] encrypted = aead.encrypt(data, data);
+        return aead.decrypt(encrypted, data);
+    }
+
+    Document xml(Document document, Element element, Key key) throws Exception {
+        XMLCipher cipher = XMLCipher.getInstance(XMLCipher.AES_256_GCM);
+        cipher.init(XMLCipher.ENCRYPT_MODE, key);
+        return cipher.doFinal(document, element);
     }
 
     byte[] run(byte[] data, byte[] key, String runtimeProvider) throws Exception {


### PR DESCRIPTION
Closes #138

## Summary

- derive Java lifecycle supporting calls directionally across factory-produced primitives without crossing sibling object branches
- add explicit canonical parameter and return signature metadata to the contract schema, while keeping semantic inferred returns separate
- resolve conditional canonical metadata only for direct selectors and fail closed for unresolved or mixed provenance
- exercise Bouncy Castle, Tink, and Apache XML Security through the public project export acceptance path

## Root cause

Lifecycle selection previously stopped after one receiver/assignment hop, so a Tink `KeysetHandle` could expose `getPrimitive` without connecting the produced `Aead` operations. XMLCipher calls also lacked canonical formal types when source expressions such as constants could not supply them. A naive transitive closure would over-link sibling primitives, and semantic contract returns are not safe substitutes for declared callable signatures.

## Verification

- `go test ./internal/callgraph/... ./internal/scan ./internal/cli -count=1`
- `go test ./... -count=1` including Docker-backed tests
- pinned `golangci-lint v2.10.1`: 0 issues
- real Java rules fixture: 95 findings; exact Tink `getPrimitive`/`encrypt`/`decrypt` and XMLCipher `init`/`doFinal` signatures in callgraph and graph-fragment exports
- four-round blind dual adversarial review: approved

## Upstream signature references

- Google Tink 1.13.0 (`KeysetHandle`, `Aead`)
- Apache Santuario XML Security 4.0.3 (`XMLCipher`)

The change is intentionally one atomic issue slice: the contract metadata, lifecycle selector, and public acceptance assertions must land together to avoid either incomplete signatures or imprecise reachability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved call graph metadata with more accurate canonical parameter and return signatures.
  * Added support for resolving signatures based on applicable argument conditions.
  * Enhanced lifecycle analysis to identify related supporting calls more accurately.
  * Improved Java type reporting by qualifying source types where possible.

* **Bug Fixes**
  * Prevented ambiguous or inferred information from producing misleading canonical signatures.
  * Improved handling of overloaded method signatures and lifecycle branches.

* **Documentation**
  * Documented canonical signature fields and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->