### PR TITLE
fix(contracts): scope Tink signatures to 1.13.0

### DIFF
--- a/internal/callgraph/contracts/java/tink-1.13.0.yaml
+++ b/internal/callgraph/contracts/java/tink-1.13.0.yaml
@@ -6,7 +6,7 @@ library:
   coordinates:
     - "com.google.crypto.tink:tink"
     - "com.google.crypto.tink:tink-android"
-  version_range: ">=1.7,<2.0"
+  version_range: "1.13.0"
   description: "Google Tink high-level crypto API contracts (KeysetHandle -> primitive -> operation)"
 
 # Tink hides primitives behind KeysetHandle.getPrimitive(<Primitive>.class). These


### PR DESCRIPTION
Follow-up to #172.

## Summary

- rename the Tink knowledge-base file to identify its verified release
- narrow `library.version_range` from the historical broad range to the fixture-pinned Tink 1.13.0 release

## Why

PR #172 added canonical callable signatures verified against Tink 1.13.0. Its completed review correctly noted that leaving those signatures under `>=1.7,<2.0` overstates the verified version scope and conflicts with the repository's one-file-per-library-version convention.

## Verification

- `go test ./internal/callgraph/contracts ./internal/cli -run 'TestLoadEmbedded|TestDependencyIntelligenceExportContract' -count=1`
- pinned `golangci-lint v2.10.1`: 0 issues
