### PR TITLE
fix(scan): materialize selector-conditioned findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scanner failure messages now explain documented semgrep/opengrep exit codes (`opengrep execution failed with exit code 7 (rule configuration contains no valid rules)`) and attach a sanitized stderr tail (ANSI-stripped, single line, capped on UTF-8 rune boundaries) to logs and error details; the failure debug log records rule configs + target instead of dumping the full command line. (#112)
 
 ### Fixed
+- Java selector findings now preserve per-call-site wrapper values, resolve simple switch-return helpers, and materialize the applicable rule-owned algorithm metadata without guessing dynamic branches. (#135)
 - C++ callgraph contracts now match namespace-qualified library calls independently of the scanned project path and resolve simple typed receiver calls without overriding project-local declarations. (#163)
 - C callgraph contracts now match global library symbols independently of the scanned project's package path while preserving exact project-qualified matches. (#156)
 - C callgraph pointer-return inference now propagates through in-project wrapper functions while preserving arity-qualified contract lookup. (#153)

--- a/internal/callgraph/contracts/java/jdk-crypto.yaml
+++ b/internal/callgraph/contracts/java/jdk-crypto.yaml
@@ -148,6 +148,12 @@ contracts:
     return:
       type: java.security.MessageDigest
       confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
 
   - method: java.security.MessageDigest.digest
     arity: 0

--- a/internal/callgraph/java_parser.go
+++ b/internal/callgraph/java_parser.go
@@ -1272,6 +1272,19 @@ func (p *JavaParser) traceMethodCallExpression(
 	if receiverSources := p.traceMethodCallReceiverSources(object, analysis, currentClass, varTypes, origins, depth+1); len(receiverSources) > 0 {
 		node.SourceNodes = receiverSources
 	}
+	open := strings.Index(expr, "(")
+	closeIdx := strings.LastIndex(expr, ")")
+	if open >= 0 && closeIdx > open {
+		args := parseArgumentsFromDelimitedContent(expr[open : closeIdx+1])
+		for i, arg := range args {
+			argumentSources := p.traceExpression(strings.TrimSpace(arg), analysis, currentClass, varTypes, origins, depth+1)
+			for j := range argumentSources {
+				argumentSources[j].ParameterIndex = i
+				argumentSources[j].Flow = &SourceFlow{CallArgument: true}
+			}
+			node.SourceNodes = append(node.SourceNodes, argumentSources...)
+		}
+	}
 	if analysis != nil {
 		target := p.resolveCallee(object, javaMethodWithArity(method, argc), analysis, currentClass, varTypes)
 		node.CallTarget = &target
@@ -2519,6 +2532,10 @@ func (p *JavaParser) traceExpressionNode(
 		return p.traceMethodInvocationNode(node, src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)
 	case "ternary_expression":
 		return p.traceTernaryExpressionNode(node, src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)
+	case "switch_expression":
+		if nodes := p.traceSwitchExpressionNode(node, src, analysis, currentClass, varTypes, varOrigins, bodyAssignments); len(nodes) > 0 {
+			return nodes
+		}
 	case "string_literal", "character_literal", "null_literal",
 		"decimal_integer_literal", "hex_integer_literal", "octal_integer_literal",
 		"binary_integer_literal", "decimal_floating_point_literal",
@@ -2538,6 +2555,78 @@ func (p *JavaParser) traceExpressionNode(
 		return nil
 	}
 	return p.traceExpression(expr, analysis, currentClass, varTypes, varOrigins, 0)
+}
+
+// traceSwitchExpressionNode preserves simple parameter-selected return values
+// such as `return switch (algorithm) { case 1 -> "MD5"; default -> "SHA-512"; }`.
+// Each value carries a language-neutral equality/default guard so a caller's
+// concrete argument can select the applicable return without guessing.
+//
+//nolint:gocognit,gocyclo // Tree-sitter switch rules require explicit label/value/default traversal.
+func (p *JavaParser) traceSwitchExpressionNode(
+	node *sitter.Node,
+	src []byte,
+	analysis *FileAnalysis,
+	currentClass string,
+	varTypes map[string]string,
+	varOrigins map[string]varOrigin,
+	bodyAssignments map[string][]*sitter.Node,
+) []SourceNode {
+	selector := unwrapJavaParenthesizedExpression(node.ChildByFieldName("condition"))
+	if selector == nil {
+		return nil
+	}
+	origin, ok := varOrigins[strings.TrimSpace(selector.Content(src))]
+	if !ok || origin.kind != javaVarOriginKindParameter || origin.paramIndex < 0 {
+		return nil
+	}
+
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	var result []SourceNode
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		rule := body.NamedChild(i)
+		if rule == nil || rule.Type() != "switch_rule" || rule.NamedChildCount() < 2 {
+			continue
+		}
+		label := rule.NamedChild(0)
+		valueNode := rule.NamedChild(1)
+		if valueNode != nil && valueNode.Type() == "expression_statement" && valueNode.NamedChildCount() > 0 {
+			valueNode = valueNode.NamedChild(0)
+		}
+		values := p.traceExpressionNode(valueNode, src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)
+		if len(values) == 0 || label == nil || label.Type() != "switch_label" {
+			continue
+		}
+		if label.NamedChildCount() == 0 {
+			for j := range values {
+				values[j].Flow = &SourceFlow{Guard: &SourceGuard{ParameterIndex: origin.paramIndex, Default: true}}
+				result = append(result, values[j])
+			}
+			continue
+		}
+		for j := 0; j < int(label.NamedChildCount()); j++ {
+			caseValue := strings.TrimSpace(label.NamedChild(j).Content(src))
+			for k := range values {
+				candidate := values[k]
+				candidate.Flow = &SourceFlow{Guard: &SourceGuard{ParameterIndex: origin.paramIndex, Value: caseValue}}
+				result = append(result, candidate)
+			}
+		}
+	}
+	return result
+}
+
+func unwrapJavaParenthesizedExpression(node *sitter.Node) *sitter.Node {
+	for node != nil && node.Type() == "parenthesized_expression" {
+		if node.NamedChildCount() == 0 {
+			return nil
+		}
+		node = node.NamedChild(0)
+	}
+	return node
 }
 
 // traceIdentifierNode handles identifier and field_access AST nodes in
@@ -2706,6 +2795,7 @@ func (p *JavaParser) traceMethodInvocationNode(
 			argSources := p.traceExpressionNode(argNode, src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)
 			for k := range argSources {
 				argSources[k].ParameterIndex = j
+				argSources[k].Flow = &SourceFlow{CallArgument: true}
 			}
 			sn.SourceNodes = append(sn.SourceNodes, argSources...)
 		}
@@ -2715,8 +2805,8 @@ func (p *JavaParser) traceMethodInvocationNode(
 	return []SourceNode{sn}
 }
 
-// traceTernaryExpressionNode handles `condition ? expr1 : expr2` by collecting
-// SourceNodes from both branches (expr1 and expr2), skipping the condition.
+// traceTernaryExpressionNode preserves equality guards for simple
+// parameter-selected returns and otherwise collects both branches unresolved.
 func (p *JavaParser) traceTernaryExpressionNode(
 	node *sitter.Node,
 	src []byte,
@@ -2726,6 +2816,18 @@ func (p *JavaParser) traceTernaryExpressionNode(
 	varOrigins map[string]varOrigin,
 	bodyAssignments map[string][]*sitter.Node,
 ) []SourceNode {
+	if parameterIndex, guardValue, ok := ternaryEqualityParameterGuard(node, src, varOrigins); ok {
+		consequence := p.traceExpressionNode(node.ChildByFieldName("consequence"), src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)
+		alternative := p.traceExpressionNode(node.ChildByFieldName("alternative"), src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)
+		for i := range consequence {
+			consequence[i].Flow = &SourceFlow{Guard: &SourceGuard{ParameterIndex: parameterIndex, Value: guardValue}}
+		}
+		for i := range alternative {
+			alternative[i].Flow = &SourceFlow{Guard: &SourceGuard{ParameterIndex: parameterIndex, Default: true}}
+		}
+		return append(consequence, alternative...)
+	}
+
 	var result []SourceNode
 	for i := 0; i < int(node.ChildCount()); i++ {
 		child := node.Child(i)
@@ -2737,6 +2839,26 @@ func (p *JavaParser) traceTernaryExpressionNode(
 		result = append(result, p.traceExpressionNode(child, src, analysis, currentClass, varTypes, varOrigins, bodyAssignments)...)
 	}
 	return result
+}
+
+func ternaryEqualityParameterGuard(node *sitter.Node, src []byte, varOrigins map[string]varOrigin) (int, string, bool) {
+	condition := unwrapJavaParenthesizedExpression(node.ChildByFieldName("condition"))
+	if condition == nil || condition.Type() != "binary_expression" {
+		return 0, "", false
+	}
+	operator := condition.ChildByFieldName("operator")
+	left := unwrapJavaParenthesizedExpression(condition.ChildByFieldName("left"))
+	right := unwrapJavaParenthesizedExpression(condition.ChildByFieldName("right"))
+	if operator == nil || operator.Content(src) != "==" || left == nil || right == nil {
+		return 0, "", false
+	}
+	if origin, ok := varOrigins[strings.TrimSpace(left.Content(src))]; ok && origin.kind == javaVarOriginKindParameter && origin.paramIndex >= 0 {
+		return origin.paramIndex, strings.TrimSpace(right.Content(src)), true
+	}
+	if origin, ok := varOrigins[strings.TrimSpace(right.Content(src))]; ok && origin.kind == javaVarOriginKindParameter && origin.paramIndex >= 0 {
+		return origin.paramIndex, strings.TrimSpace(left.Content(src)), true
+	}
+	return 0, "", false
 }
 
 // returnStatementExpressionNode returns the expression child node from a

--- a/internal/callgraph/java_parser_test.go
+++ b/internal/callgraph/java_parser_test.go
@@ -1019,6 +1019,71 @@ class Sample {
 	}
 }
 
+func TestJavaParser_ReturnSwitch_PreservesSelectorGuards(t *testing.T) {
+	t.Parallel()
+
+	source := `package example;
+class DigestSelector {
+    String name(int algorithm) {
+        return switch (algorithm) {
+            case 1 -> "MD5";
+            case 2, 3 -> "SHA-256";
+            default -> "SHA-512";
+        };
+    }
+}`
+
+	fns := parseJavaInline(t, source)
+	fn := findFunctionByName(fns, "name")
+	if fn == nil {
+		t.Fatal("name function not found")
+	}
+	if len(fn.ReturnSources) != 4 {
+		t.Fatalf("ReturnSources = %#v, want one guarded value per switch label", fn.ReturnSources)
+	}
+	wants := []struct {
+		value      string
+		guardValue string
+		isDefault  bool
+	}{
+		{value: `"MD5"`, guardValue: "1"},
+		{value: `"SHA-256"`, guardValue: "2"},
+		{value: `"SHA-256"`, guardValue: "3"},
+		{value: `"SHA-512"`, isDefault: true},
+	}
+	for i, want := range wants {
+		got := fn.ReturnSources[i]
+		if got.Type != "VALUE" || got.Value != want.value || got.Flow == nil || got.Flow.Guard == nil {
+			t.Fatalf("ReturnSources[%d] = %#v, want guarded %q", i, got, want.value)
+		}
+		if got.Flow.Guard.ParameterIndex != 0 || got.Flow.Guard.Value != want.guardValue || got.Flow.Guard.Default != want.isDefault {
+			t.Fatalf("ReturnSources[%d].Guard = %#v, want index=0 value=%q default=%v", i, got.Flow.Guard, want.guardValue, want.isDefault)
+		}
+	}
+}
+
+func TestJavaParser_ReturnTernary_PreservesSelectorGuards(t *testing.T) {
+	t.Parallel()
+
+	source := `package example;
+class DigestSelector {
+    String name(int algorithm) {
+        return algorithm == 1 ? "SHA-256" : "SHA-512";
+    }
+}`
+
+	fn := findFunctionByName(parseJavaInline(t, source), "name")
+	if fn == nil || len(fn.ReturnSources) != 2 {
+		t.Fatalf("ReturnSources = %#v, want two guarded ternary values", fn)
+	}
+	if got := fn.ReturnSources[0]; got.Value != `"SHA-256"` || got.Flow == nil || got.Flow.Guard == nil || got.Flow.Guard.ParameterIndex != 0 || got.Flow.Guard.Value != "1" || got.Flow.Guard.Default {
+		t.Fatalf("true branch = %#v, want algorithm == 1 guard", got)
+	}
+	if got := fn.ReturnSources[1]; got.Value != `"SHA-512"` || got.Flow == nil || got.Flow.Guard == nil || got.Flow.Guard.ParameterIndex != 0 || !got.Flow.Guard.Default {
+		t.Fatalf("false branch = %#v, want default guard", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Batch 6: Argument provenance in traceMethodInvocationNode (T6.1, T6.2)
 // ---------------------------------------------------------------------------

--- a/internal/callgraph/types.go
+++ b/internal/callgraph/types.go
@@ -275,6 +275,24 @@ type SourceNode struct {
 	Location *SourceLocation
 	// SourceNodes traces where THIS node's value came from (recursive)
 	SourceNodes []SourceNode
+	// Flow carries optional branch/call-position semantics without inflating
+	// every SourceNode in the graph.
+	Flow *SourceFlow
+}
+
+// SourceFlow carries optional branch and call-position semantics.
+type SourceFlow struct {
+	Guard        *SourceGuard
+	ReturnValue  bool
+	CallArgument bool
+}
+
+// SourceGuard describes a simple parameter equality branch or its default.
+// Consumers keep every candidate when the selected parameter is unresolved.
+type SourceGuard struct {
+	ParameterIndex int
+	Value          string
+	Default        bool
 }
 
 // SourceLocation identifies a position in source code.
@@ -457,6 +475,8 @@ type CallChainStep struct {
 	Function FunctionID
 	FilePath string
 	Line     int
+	StartCol int
+	EndCol   int
 }
 
 // ParseFunctionID parses a fully-qualified function string back into a FunctionID.

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -782,6 +782,7 @@ func runScan(_ *cobra.Command, args []string) error {
 	if callGraphResult != nil && callGraphResult.CallGraph != nil {
 		if rulePaths, rerr := rulesManager.Load(); rerr == nil {
 			engine.SynthesizeRuleCryptoEntryPoints(report, callGraphResult.CallGraph, rulePaths, callGraphResult.Ecosystem)
+			scanutil.MaterializeConditionedFindings(report, callGraphResult.CallGraph, rulePaths, callGraphResult.Ecosystem)
 		} else {
 			log.Debug().
 				Err(rerr).

--- a/internal/cli/selector_materialization_acceptance_integration_test.go
+++ b/internal/cli/selector_materialization_acceptance_integration_test.go
@@ -1,0 +1,207 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package cli_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/pkg/graphfrag"
+)
+
+func TestSelectorMaterializationPublicExports(t *testing.T) {
+	if testing.Short() {
+		t.Skip("black-box CLI acceptance test")
+	}
+	t.Parallel()
+
+	root := repositoryRoot(t)
+	binary := buildCryptoFinder(t, root)
+	target := filepath.Join(root, "testdata", "projects", "dependency_intelligence_java")
+	sourcePath := filepath.Join(target, "src", "main", "java", "example", "Acceptance.java")
+	source, err := os.ReadFile(sourcePath)
+	require.NoError(t, err)
+
+	tmp := t.TempDir()
+	writeFakeScanner(t, tmp)
+	rulesPath := filepath.Join(tmp, "rules.yaml")
+	require.NoError(t, os.WriteFile(rulesPath, []byte(selectorAcceptanceRules), 0o600))
+	fakeOutput := filepath.Join(tmp, "opengrep.json")
+	writeSelectorScannerOutput(t, fakeOutput, sourcePath, string(source))
+	findingsPath := filepath.Join(tmp, "findings.json")
+	fragmentPath := filepath.Join(tmp, "fragment.json")
+	callgraphPath := filepath.Join(tmp, "callgraph.json")
+
+	cmd := exec.CommandContext(t.Context(), binary, "--error-format", "json", "scan", "--scanner", "opengrep", "--no-remote-rules",
+		"--no-default-exclusions", "--languages", "java", "--rules", rulesPath, "--output", findingsPath,
+		"--export-callgraph", callgraphPath, "--export-graph-fragment", fragmentPath, target)
+	cmd.Env = append(os.Environ(), "HOME="+filepath.Join(tmp, "home"), "FAKE_OPENGREP_OUTPUT="+fakeOutput,
+		"PATH="+tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "crypto-finder scan output:\n%s", output)
+
+	var report entities.InterimReport
+	readJSON(t, findingsPath, &report)
+	assets := allAssets(report)
+	byRule := make(map[string]entities.CryptographicAsset)
+	for _, asset := range assets {
+		if len(asset.Rules) > 0 {
+			byRule[asset.Rules[0].ID] = asset
+		}
+	}
+	require.Equal(t, "AES-128", byRule["java.pgp.aes128"].Metadata["algorithmName"], "assets: %#v", byRule)
+	require.Equal(t, "DES", byRule["java.pgp.des"].Metadata["algorithmName"], "assets: %#v", byRule)
+	require.Equal(t, "SHA-256", byRule["java.digest.sha2"].Metadata["algorithmName"], "assets: %#v", byRule)
+	require.NotContains(t, byRule, "java.digest.sha512", "dynamic helper input must not select the default branch")
+
+	var fragment graphfrag.GraphFragmentExport
+	readJSON(t, fragmentPath, &fragment)
+	fragmentRules := make(map[string]bool)
+	for _, operation := range fragment.CryptoAnnotations {
+		fragmentRules[operation.RuleID] = true
+	}
+	for _, ruleID := range []string{"java.pgp.aes128", "java.pgp.des", "java.digest.sha2"} {
+		require.Truef(t, fragmentRules[ruleID], "graph fragment missing conditioned %s", ruleID)
+	}
+
+	var live graphfrag.CallgraphExport
+	readJSON(t, callgraphPath, &live)
+	graphsByID := make(map[string]graphfrag.ExportFindingGraph)
+	for _, graph := range live.FindingGraphs {
+		graphsByID[graph.FindingID] = graph
+	}
+	for _, ruleID := range []string{"java.pgp.aes128", "java.pgp.des", "java.digest.sha2"} {
+		asset := byRule[ruleID]
+		graph, ok := graphsByID[asset.FindingID]
+		require.Truef(t, ok, "callgraph missing conditioned %s", ruleID)
+		require.Lenf(t, graph.CallChains, 1, "%s must retain only its applicable caller path", ruleID)
+		last := graph.CallChains[0][len(graph.CallChains[0])-1]
+		require.NotNil(t, last.CryptoCall)
+		require.NotEmpty(t, last.CryptoCall.Parameters[0].ResolvedValue)
+	}
+}
+
+func writeSelectorScannerOutput(t *testing.T, path, sourcePath, source string) {
+	t.Helper()
+	type anchor struct {
+		needle string
+		ruleID string
+		api    string
+	}
+	anchors := []anchor{
+		{"new JcePGPDataEncryptorBuilder(alg)", "java.pgp.dynamic", "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>"},
+		{"digestName(algorithm)", "java.digest.dynamic", "Wrong.getInstance"},
+	}
+	results := make([]map[string]any, 0, len(anchors))
+	for _, anchor := range anchors {
+		line, col := location(source, anchor.needle)
+		require.NotZero(t, line)
+		results = append(results, map[string]any{
+			"check_id": anchor.ruleID, "path": sourcePath,
+			"start": map[string]int{"line": line, "col": col}, "end": map[string]int{"line": line, "col": col + len(anchor.needle)},
+			"extra": map[string]any{
+				"message": "selector anchor", "severity": "INFO", "lines": anchor.needle,
+				"metadata": map[string]any{"crypto": map[string]any{"assetType": "algorithm", "api": anchor.api}},
+			},
+		})
+	}
+	writeJSON(t, path, map[string]any{"results": results, "errors": []any{}})
+}
+
+const selectorAcceptanceRules = `rules:
+  - id: java.pgp.dynamic
+    message: PGP selector anchor
+    severity: INFO
+    languages: [java]
+    pattern: $X
+    metadata:
+      crypto:
+        assetType: algorithm
+        api: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>
+  - id: java.pgp.aes128
+    message: AES-128 PGP
+    severity: INFO
+    languages: [java]
+    pattern: new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_128)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: AES
+        algorithmName: AES-128
+        operation: encrypt
+        parameterCondition: param[0]==SymmetricKeyAlgorithmTags.AES_128
+        api: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>
+  - id: java.pgp.des
+    message: DES PGP
+    severity: INFO
+    languages: [java]
+    pattern: new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.DES)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: DES
+        algorithmName: DES
+        operation: encrypt
+        parameterCondition: param[0]==SymmetricKeyAlgorithmTags.DES
+        api: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>
+  - id: java.digest.dynamic
+    message: Digest selector anchor
+    severity: INFO
+    languages: [java]
+    pattern: $X
+    metadata:
+      crypto:
+        assetType: algorithm
+        api: MessageDigest.getInstance
+  - id: java.digest.sha2
+    message: SHA-2 digest
+    severity: INFO
+    languages: [java]
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $ALGO
+          - metavariable-regex:
+              metavariable: $ALGO
+              regex: '"SHA-?(?<variant>224|256|384|512)"'
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: MessageDigest.getInstance($ALGO)
+              - pattern: MessageDigest.getInstance($ALGO, $PROVIDER)
+          - focus-metavariable: $ALGO
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: SHA-2
+        algorithmName: SHA-$variant
+        operation: digest
+        parameterCondition: param[0]~=SHA-?(?<variant>224|256|384|512)
+        api: MessageDigest.getInstance
+  - id: java.digest.sha512
+    message: SHA-512 digest
+    severity: INFO
+    languages: [java]
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $ALGO
+    pattern-sinks:
+      - patterns:
+          - pattern: MessageDigest.getInstance($ALGO)
+          - focus-metavariable: $ALGO
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: SHA-2
+        algorithmName: SHA-512
+        operation: digest
+        parameterCondition: param[0]==SHA-512
+        api: MessageDigest.getInstance
+`

--- a/internal/engine/rule_entrypoint_synthesis.go
+++ b/internal/engine/rule_entrypoint_synthesis.go
@@ -21,6 +21,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -419,13 +420,182 @@ func appendSyntheticAsset(
 
 // ── rule metadata.crypto extraction ────────────────────────────────────────
 
-// ruleFileCryptoYAML captures just the metadata.crypto block of each rule.
+// ruleFileCryptoYAML captures conditioned metadata plus the structural patterns
+// needed to identify the terminal call independently of informational api metadata.
 type ruleFileCryptoYAML struct {
-	Rules []struct {
-		Metadata struct {
-			Crypto map[string]any `yaml:"crypto"`
-		} `yaml:"metadata"`
-	} `yaml:"rules"`
+	Rules []ruleCryptoYAML `yaml:"rules"`
+}
+
+type ruleCryptoYAML struct {
+	ID             string                  `yaml:"id"`
+	Message        string                  `yaml:"message"`
+	Severity       string                  `yaml:"severity"`
+	Pattern        string                  `yaml:"pattern"`
+	Patterns       []rulePatternYAML       `yaml:"patterns"`
+	PatternSources []rulePatternSourceYAML `yaml:"pattern-sources"`
+	PatternSinks   []rulePatternSourceYAML `yaml:"pattern-sinks"`
+	Metadata       struct {
+		Crypto map[string]any `yaml:"crypto"`
+	} `yaml:"metadata"`
+}
+
+type rulePatternSourceYAML struct {
+	Patterns []rulePatternYAML `yaml:"patterns"`
+}
+
+type rulePatternYAML struct {
+	Pattern           string            `yaml:"pattern"`
+	PatternEither     []rulePatternYAML `yaml:"pattern-either"`
+	MetavariableRegex *struct {
+		Regex string `yaml:"regex"`
+	} `yaml:"metavariable-regex"`
+}
+
+// RuleCryptoMetadata is the rule-owned semantic payload used when a generic
+// source anchor must be specialized after callgraph selector resolution.
+type RuleCryptoMetadata struct {
+	Rule                entities.RuleInfo
+	Metadata            map[string]string
+	ParameterConditions []paramcondition.Condition
+	CaptureNames        []string
+}
+
+// LoadRuleCryptoMetadata indexes conditioned crypto rules by terminal symbols
+// parsed from their sink/direct patterns. Call-site specialization resolves
+// those structural symbols against the selected terminal call; metadata.api is
+// copied to output but never participates in routing.
+func LoadRuleCryptoMetadata(rulePaths []string) map[string][]RuleCryptoMetadata {
+	out := make(map[string][]RuleCryptoMetadata)
+	for _, path := range rulePaths {
+		for _, file := range expandRuleFiles(path) {
+			loadRuleCryptoMetadataFile(out, file)
+		}
+	}
+	return out
+}
+
+func loadRuleCryptoMetadataFile(out map[string][]RuleCryptoMetadata, file string) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return
+	}
+	var rf ruleFileCryptoYAML
+	if yaml.Unmarshal(data, &rf) != nil {
+		return
+	}
+	for i := range rf.Rules {
+		appendRuleCryptoMetadata(out, &rf.Rules[i])
+	}
+}
+
+func appendRuleCryptoMetadata(out map[string][]RuleCryptoMetadata, rule *ruleCryptoYAML) {
+	entrypoints := ruleCryptoEntrypoints(rule)
+	if len(entrypoints) == 0 {
+		return
+	}
+	metadata := stringifyCryptoBlock(rule.Metadata.Crypto)
+	conditions, err := paramcondition.ParseAll(metadata["parameterCondition"])
+	if err != nil || len(conditions) == 0 {
+		return
+	}
+	candidate := RuleCryptoMetadata{
+		Rule:     entities.RuleInfo{ID: rule.ID, Message: rule.Message, Severity: strings.ToUpper(rule.Severity)},
+		Metadata: metadata, ParameterConditions: conditions, CaptureNames: ruleCaptureNames(rule.PatternSources),
+	}
+	for _, entrypoint := range entrypoints {
+		duplicate := false
+		for _, existing := range out[entrypoint] {
+			if existing.Rule.ID == candidate.Rule.ID && maps.Equal(existing.Metadata, candidate.Metadata) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			out[entrypoint] = append(out[entrypoint], candidate)
+		}
+	}
+}
+
+func ruleCryptoEntrypoints(rule *ruleCryptoYAML) []string {
+	var patterns []string
+	if len(rule.PatternSinks) > 0 {
+		for _, sink := range rule.PatternSinks {
+			patterns = appendRulePatternStrings(patterns, sink.Patterns)
+		}
+	} else {
+		patterns = append(patterns, rule.Pattern)
+		patterns = appendRulePatternStrings(patterns, rule.Patterns)
+	}
+
+	var entrypoints []string
+	seen := make(map[string]struct{})
+	for _, pattern := range patterns {
+		entrypoint := rulePatternEntrypoint(pattern)
+		if entrypoint == "" {
+			continue
+		}
+		if _, ok := seen[entrypoint]; ok {
+			continue
+		}
+		seen[entrypoint] = struct{}{}
+		entrypoints = append(entrypoints, entrypoint)
+	}
+	return entrypoints
+}
+
+func appendRulePatternStrings(dst []string, patterns []rulePatternYAML) []string {
+	for _, pattern := range patterns {
+		dst = append(dst, pattern.Pattern)
+		dst = appendRulePatternStrings(dst, pattern.PatternEither)
+	}
+	return dst
+}
+
+func rulePatternEntrypoint(pattern string) string {
+	pattern = strings.TrimSpace(pattern)
+	constructor := strings.HasPrefix(pattern, "new ")
+	if constructor {
+		pattern = strings.TrimSpace(strings.TrimPrefix(pattern, "new "))
+	}
+	open := strings.IndexByte(pattern, '(')
+	if open <= 0 {
+		return ""
+	}
+	symbol := strings.TrimSpace(pattern[:open])
+	if strings.ContainsAny(symbol, " $<>") {
+		return ""
+	}
+	if constructor {
+		return symbol + ".<init>"
+	}
+	return symbol
+}
+
+func ruleCaptureNames(sources []rulePatternSourceYAML) []string {
+	var names []string
+	seen := make(map[string]struct{})
+	for _, source := range sources {
+		for _, pattern := range source.Patterns {
+			if pattern.MetavariableRegex == nil {
+				continue
+			}
+			re, err := regexp.Compile(pattern.MetavariableRegex.Regex)
+			if err != nil {
+				continue
+			}
+			for _, name := range re.SubexpNames() {
+				if name == "" {
+					continue
+				}
+				if _, ok := seen[name]; ok {
+					continue
+				}
+				seen[name] = struct{}{}
+				names = append(names, name)
+			}
+		}
+	}
+	return names
 }
 
 // buildRuleCryptoByAPI walks the ruleset (files and/or directories) and indexes
@@ -462,8 +632,8 @@ func addRuleCryptoFile(out map[string][]map[string]string, file, ecosystem strin
 		return
 	}
 
-	for _, r := range rf.Rules {
-		addRuleCrypto(out, r.Metadata.Crypto, ecosystem)
+	for i := range rf.Rules {
+		addRuleCrypto(out, rf.Rules[i].Metadata.Crypto, ecosystem)
 	}
 }
 

--- a/internal/entities/interim.go
+++ b/internal/entities/interim.go
@@ -113,6 +113,12 @@ type CryptographicAsset struct {
 	// Uses the same convention as opengrep/semgrep: End.Col = start + len(match).
 	EndCol int `json:"end_col,omitempty"`
 
+	// TerminalStartCol/TerminalEndCol retain the structurally selected enclosing
+	// call for in-process exports when a scanner focuses a nested argument span.
+	// They are routing state, not part of the public finding schema.
+	TerminalStartCol int `json:"-"`
+	TerminalEndCol   int `json:"-"`
+
 	// Match is the actual code snippet that was matched
 	Match string `json:"match"`
 

--- a/internal/scan/annotate_supporting.go
+++ b/internal/scan/annotate_supporting.go
@@ -35,7 +35,13 @@ func (e fragEdge) view() candidateView {
 		ChainID:     e.identity.ChainID,
 		AssignedVar: e.identity.AssignedVar,
 		RawLen:      len(e.raw),
+		Constructor: strings.HasPrefix(strings.TrimSpace(e.raw), "new ") || isConstructorFunctionKey(e.calleeKey),
 	}
+}
+
+func isConstructorFunctionKey(key string) bool {
+	id, err := callgraph.ParseFunctionID(key)
+	return err == nil && callgraph.BaseFunctionName(id.Name) == constructorMethodName
 }
 
 // functionName derives the dotted callee name from the edge's callee key, the

--- a/internal/scan/conditioned_findings.go
+++ b/internal/scan/conditioned_findings.go
@@ -1,0 +1,348 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scan
+
+import (
+	"maps"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+	"github.com/scanoss/crypto-finder/pkg/paramcondition"
+)
+
+// MaterializeConditionedFindings specializes generic rule anchors after the
+// call graph resolves operation-determining selector parameters. Crypto
+// semantics remain rule-owned: this function only evaluates parameterCondition
+// predicates and copies the applicable rule metadata onto the original source
+// anchor. Ambiguous paths produce no specialized asset.
+func MaterializeConditionedFindings(
+	report *entities.InterimReport,
+	graph *callgraph.CallGraph,
+	rulePaths []string,
+	ecosystem string,
+) int {
+	if report == nil || graph == nil || len(rulePaths) == 0 {
+		return 0
+	}
+	catalog := engine.LoadRuleCryptoMetadata(rulePaths)
+	if len(catalog) == 0 {
+		return 0
+	}
+	ctx := newExportBuildContext(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: ecosystem})
+	existing := indexExistingFindingRules(report)
+	added := 0
+	for findingIndex := range report.Findings {
+		added += materializeConditionedFinding(ctx, &report.Findings[findingIndex], graph, catalog, existing)
+	}
+	if added > 0 {
+		log.Info().Int("count", added).Str("ecosystem", ecosystem).Msg("Materialized conditioned crypto findings from selector provenance")
+	}
+	return added
+}
+
+func materializeConditionedFinding(
+	ctx *exportBuildContext,
+	finding *entities.Finding,
+	graph *callgraph.CallGraph,
+	catalog map[string][]engine.RuleCryptoMetadata,
+	existing map[string]struct{},
+) int {
+	added := 0
+	originalCount := len(finding.CryptographicAssets)
+	for assetIndex := 0; assetIndex < originalCount; assetIndex++ {
+		added += materializeConditionedAnchor(ctx, finding, graph, catalog, existing, finding.CryptographicAssets[assetIndex])
+	}
+	return added
+}
+
+func materializeConditionedAnchor(
+	ctx *exportBuildContext,
+	finding *entities.Finding,
+	graph *callgraph.CallGraph,
+	catalog map[string][]engine.RuleCryptoMetadata,
+	existing map[string]struct{},
+	anchor entities.CryptographicAsset,
+) int {
+	if len(anchor.ParameterConditions) > 0 {
+		return 0
+	}
+	containingFn := ctx.findContainingFunctionByFinding(finding.FilePath, anchor.StartLine)
+	if containingFn == nil {
+		return 0
+	}
+	terminalNode, rules := conditionedTerminalCall(graph, containingFn, anchor, catalog)
+	if terminalNode == nil {
+		return 0
+	}
+	terminal := buildCryptoCall(ctx, graph, containingFn, terminalNode)
+	anchor.TerminalStartCol = terminalNode.StartCol
+	anchor.TerminalEndCol = terminalNode.EndCol
+	return appendConditionedChainAssets(finding, anchor, rules, buildCallChains(ctx, containingFn, terminal), existing)
+}
+
+func conditionedTerminalCall(
+	graph *callgraph.CallGraph,
+	containingFn *callgraph.FunctionDecl,
+	anchor entities.CryptographicAsset,
+	catalog map[string][]engine.RuleCryptoMetadata,
+) (*callgraph.FunctionCall, []engine.RuleCryptoMetadata) {
+	lineCandidates := cryptoCallLineCandidates(containingFn, anchor.StartLine, anchor.EndLine)
+	conditioned := make([]*callgraph.FunctionCall, 0, len(lineCandidates))
+	for _, candidate := range lineCandidates {
+		if callContainsAnchorSpan(candidate, anchor) && len(conditionedRulesForCall(catalog, fullFunctionName(candidate.Callee))) > 0 {
+			conditioned = append(conditioned, candidate)
+		}
+	}
+	terminal := pickBestCandidate(graph, cryptoCallColumnCandidates(conditioned, anchor))
+	if terminal == nil {
+		return nil, nil
+	}
+	return terminal, conditionedRulesForCall(catalog, fullFunctionName(terminal.Callee))
+}
+
+func callContainsAnchorSpan(call *callgraph.FunctionCall, anchor entities.CryptographicAsset) bool {
+	if call.StartCol <= 0 || call.EndCol <= 0 || anchor.StartCol <= 0 || anchor.EndCol <= 0 {
+		return true
+	}
+	return call.StartCol <= anchor.StartCol && call.EndCol >= anchor.EndCol
+}
+
+func appendConditionedChainAssets(
+	finding *entities.Finding,
+	anchor entities.CryptographicAsset,
+	rules []engine.RuleCryptoMetadata,
+	chains [][]callGraphChainNode,
+	existing map[string]struct{},
+) int {
+	seen := make(map[string]struct{})
+	added := 0
+	for _, chain := range chains {
+		if len(chain) == 0 || chain[len(chain)-1].CryptoCall == nil {
+			continue
+		}
+		for _, rule := range rules {
+			if appendConditionedAsset(finding, anchor, rule, chain[len(chain)-1].CryptoCall.Parameters, seen, existing) {
+				added++
+			}
+		}
+	}
+	return added
+}
+
+func appendConditionedAsset(
+	finding *entities.Finding,
+	anchor entities.CryptographicAsset,
+	rule engine.RuleCryptoMetadata,
+	params []callGraphParameter,
+	seen, existing map[string]struct{},
+) bool {
+	if rule.Rule.ID == "" {
+		return false
+	}
+	conditionMatch, ok := matchParameterConditionsWithCaptureNames(rule.ParameterConditions, params, rule.CaptureNames)
+	if !ok {
+		return false
+	}
+	key := rule.Rule.ID
+	for _, condition := range conditionMatch.conditions {
+		key += "\x00" + condition.Raw
+	}
+	if _, duplicate := seen[key]; duplicate {
+		return false
+	}
+	seen[key] = struct{}{}
+	asset := cloneConditionedAsset(anchor, rule, conditionMatch)
+	assetKey := conditionedAssetKey(finding.FilePath, asset, rule.Rule.ID)
+	if _, duplicate := existing[assetKey]; duplicate {
+		return false
+	}
+	finding.CryptographicAssets = append(finding.CryptographicAssets, asset)
+	existing[assetKey] = struct{}{}
+	return true
+}
+
+func indexExistingFindingRules(report *entities.InterimReport) map[string]struct{} {
+	existing := make(map[string]struct{})
+	for findingIndex := range report.Findings {
+		finding := &report.Findings[findingIndex]
+		for assetIndex := range finding.CryptographicAssets {
+			asset := &finding.CryptographicAssets[assetIndex]
+			for _, rule := range asset.Rules {
+				existing[conditionedAssetKey(finding.FilePath, *asset, rule.ID)] = struct{}{}
+			}
+		}
+	}
+	return existing
+}
+
+func conditionedAssetKey(filePath string, asset entities.CryptographicAsset, ruleID string) string {
+	keys := make([]string, 0, len(asset.Metadata))
+	for key := range asset.Metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var metadata strings.Builder
+	for _, key := range keys {
+		metadata.WriteString(key)
+		metadata.WriteByte('=')
+		metadata.WriteString(asset.Metadata[key])
+		metadata.WriteByte(';')
+	}
+	return filePath + "\x00" + ruleID + "\x00" + strconv.Itoa(asset.StartLine) + ":" + strconv.Itoa(asset.StartCol) + ":" + strconv.Itoa(asset.EndLine) + ":" + strconv.Itoa(asset.EndCol) + "\x00" + metadata.String()
+}
+
+func conditionedRulesForCall(catalog map[string][]engine.RuleCryptoMetadata, callAPI string) []engine.RuleCryptoMetadata {
+	callAPI = strings.TrimSpace(callAPI)
+	var rules []engine.RuleCryptoMetadata
+	seen := make(map[string]struct{})
+	for api, candidates := range catalog {
+		if callAPI == "" || (api != callAPI && !strings.HasSuffix(api, "."+callAPI) && !strings.HasSuffix(callAPI, "."+api)) {
+			continue
+		}
+		for _, candidate := range candidates {
+			if _, duplicate := seen[candidate.Rule.ID]; duplicate {
+				continue
+			}
+			seen[candidate.Rule.ID] = struct{}{}
+			rules = append(rules, candidate)
+		}
+	}
+	sort.SliceStable(rules, func(i, j int) bool { return rules[i].Rule.ID < rules[j].Rule.ID })
+	return rules
+}
+
+type parameterConditionMatch struct {
+	captures   map[string]string
+	conditions []paramcondition.Condition
+}
+
+func matchParameterConditions(conditions []paramcondition.Condition, params []callGraphParameter) (parameterConditionMatch, bool) {
+	return matchParameterConditionsWithCaptureNames(conditions, params, nil)
+}
+
+func matchParameterConditionsWithCaptureNames(
+	conditions []paramcondition.Condition,
+	params []callGraphParameter,
+	captureNames []string,
+) (parameterConditionMatch, bool) {
+	result := parameterConditionMatch{captures: make(map[string]string)}
+	for _, condition := range conditions {
+		index := conditionParameterIndex(condition, params)
+		if index < 0 || index >= len(params) {
+			return parameterConditionMatch{}, false
+		}
+		actual := params[index].ResolvedValue
+		if condition.Match == paramcondition.MatchType {
+			actual = params[index].Type
+		}
+		actual = normalizeSelectorValue(actual)
+		if actual == "" {
+			return parameterConditionMatch{}, false
+		}
+		if !matchParameterCondition(condition, actual, result.captures, captureNames) {
+			return parameterConditionMatch{}, false
+		}
+		result.conditions = append(result.conditions, exactResolvedCondition(condition, actual))
+	}
+	return result, true
+}
+
+func conditionParameterIndex(condition paramcondition.Condition, params []callGraphParameter) int {
+	if condition.Selector.Index != nil {
+		return *condition.Selector.Index
+	}
+	if condition.Selector.Name == nil {
+		return -1
+	}
+	for i := range params {
+		if params[i].VariableName == *condition.Selector.Name {
+			return i
+		}
+	}
+	return -1
+}
+
+func matchParameterCondition(condition paramcondition.Condition, actual string, captures map[string]string, captureNames []string) bool {
+	if condition.Operator == paramcondition.OpExact {
+		return actual == normalizeSelectorValue(condition.Value)
+	}
+	if condition.Operator != paramcondition.OpRegex {
+		return false
+	}
+	re, err := regexp.Compile(condition.Value)
+	if err != nil {
+		return false
+	}
+	match := re.FindStringSubmatch(actual)
+	if match == nil {
+		return false
+	}
+	for i := 1; i < len(match); i++ {
+		if match[i] == "" {
+			continue
+		}
+		captures[strconv.Itoa(i)] = match[i]
+		name := re.SubexpNames()[i]
+		if name == "" && i-1 < len(captureNames) {
+			name = captureNames[i-1]
+		}
+		if name != "" {
+			captures[name] = match[i]
+		}
+	}
+	return true
+}
+
+func exactResolvedCondition(condition paramcondition.Condition, actual string) paramcondition.Condition {
+	resolved := condition
+	resolved.Operator = paramcondition.OpExact
+	resolved.Value = actual
+	selector := ""
+	if condition.Selector.Index != nil {
+		selector = strconv.Itoa(*condition.Selector.Index)
+	} else if condition.Selector.Name != nil {
+		selector = *condition.Selector.Name
+	}
+	typeSuffix := ""
+	if condition.Match == paramcondition.MatchType {
+		typeSuffix = ":type"
+	}
+	resolved.Raw = "param[" + selector + "]" + typeSuffix + "==" + actual
+	return resolved
+}
+
+func cloneConditionedAsset(anchor entities.CryptographicAsset, rule engine.RuleCryptoMetadata, match parameterConditionMatch) entities.CryptographicAsset {
+	asset := anchor
+	asset.FindingID = ""
+	asset.OID = ""
+	asset.Rules = []entities.RuleInfo{rule.Rule}
+	asset.Metadata = maps.Clone(rule.Metadata)
+	for key, value := range asset.Metadata {
+		for name, capture := range match.captures {
+			value = strings.ReplaceAll(value, "$"+name, capture)
+		}
+		if strings.Contains(value, "$") {
+			delete(asset.Metadata, key)
+			continue
+		}
+		asset.Metadata[key] = value
+	}
+	if asset.Metadata["cryptoFunction"] == "" && asset.Metadata["operation"] != "" {
+		asset.Metadata["cryptoFunction"] = asset.Metadata["operation"]
+	}
+	asset.ParameterConditions = append([]paramcondition.Condition(nil), match.conditions...)
+	conditionRaws := make([]string, len(asset.ParameterConditions))
+	for i := range asset.ParameterConditions {
+		conditionRaws[i] = asset.ParameterConditions[i].Raw
+	}
+	asset.Metadata["parameterCondition"] = strings.Join(conditionRaws, ",")
+	return asset
+}

--- a/internal/scan/conditioned_findings_test.go
+++ b/internal/scan/conditioned_findings_test.go
@@ -1,0 +1,289 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+)
+
+func TestMaterializeConditionedFindings_SpecializesWrapperPaths(t *testing.T) {
+	t.Parallel()
+
+	rules := writeConditionedRules(t, `rules:
+  - id: java.pgp.aes128
+    message: AES-128 PGP
+    severity: INFO
+    pattern: new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_128)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: AES
+        algorithmName: AES-128
+        operation: encrypt
+        parameterCondition: param[0]==SymmetricKeyAlgorithmTags.AES_128
+        api: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>
+  - id: java.pgp.des
+    message: DES PGP
+    severity: INFO
+    pattern: new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.DES)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: DES
+        algorithmName: DES
+        operation: encrypt
+        parameterCondition: param[0]==SymmetricKeyAlgorithmTags.DES
+        api: org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>
+`)
+	firstID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "first#0"}
+	secondID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "second#0"}
+	buildID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "build#1"}
+	ctorID := callgraph.FunctionID{Package: "org.bouncycastle.openpgp.operator.jcajce", Type: "JcePGPDataEncryptorBuilder", Name: "<init>#1"}
+	graph := &callgraph.CallGraph{
+		Functions: map[string]*callgraph.FunctionDecl{
+			firstID.String():  {ID: firstID, FilePath: "PGPFlow.java", Calls: []callgraph.FunctionCall{{Callee: buildID, Arguments: []string{"SymmetricKeyAlgorithmTags.AES_128"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.AES_128"}}}}}},
+			secondID.String(): {ID: secondID, FilePath: "PGPFlow.java", Calls: []callgraph.FunctionCall{{Callee: buildID, Arguments: []string{"SymmetricKeyAlgorithmTags.DES"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.DES"}}}}}},
+			buildID.String(): {
+				ID: buildID, FilePath: "PGPFlow.java", StartLine: 10, EndLine: 12,
+				Parameters: []callgraph.FunctionParameter{{Name: "algorithm", Type: "int"}},
+				Calls:      []callgraph.FunctionCall{{Callee: ctorID, FilePath: "PGPFlow.java", Line: 11, StartCol: 16, EndCol: 63, Arguments: []string{"algorithm"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "PARAMETER", Name: "algorithm", ParameterIndex: 0}}}}},
+			},
+		},
+		Callers: map[string][]string{buildID.String(): {firstID.String(), secondID.String()}},
+	}
+	report := &entities.InterimReport{Findings: []entities.Finding{{FilePath: "PGPFlow.java", Language: "java", CryptographicAssets: []entities.CryptographicAsset{{
+		StartLine: 11, EndLine: 11, StartCol: 16, EndCol: 63, Match: "new JcePGPDataEncryptorBuilder(algorithm)",
+		Rules: []entities.RuleInfo{{ID: "java.pgp.dynamic"}}, Metadata: map[string]string{"api": "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>"},
+	}}}}}
+
+	if got := MaterializeConditionedFindings(report, graph, []string{rules}, "java"); got != 2 {
+		t.Fatalf("MaterializeConditionedFindings() = %d, want 2", got)
+	}
+	if got := MaterializeConditionedFindings(report, graph, []string{rules}, "java"); got != 0 {
+		t.Fatalf("second MaterializeConditionedFindings() = %d, want idempotent 0", got)
+	}
+	byRule := make(map[string]entities.CryptographicAsset)
+	for _, asset := range report.Findings[0].CryptographicAssets {
+		byRule[asset.Rules[0].ID] = asset
+	}
+	if byRule["java.pgp.aes128"].Metadata["algorithmName"] != "AES-128" || byRule["java.pgp.des"].Metadata["algorithmName"] != "DES" {
+		t.Fatalf("materialized assets = %#v", byRule)
+	}
+	for _, ruleID := range []string{"java.pgp.aes128", "java.pgp.des"} {
+		asset := byRule[ruleID]
+		ctx := newExportBuildContext(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: "java"})
+		fg := buildFindingGraph(ctx, report.Findings[0], asset)
+		if len(fg.CallChains) != 1 {
+			t.Fatalf("%s call chains = %#v, want only applicable path", ruleID, fg.CallChains)
+		}
+	}
+	for i := range report.Findings[0].CryptographicAssets {
+		asset := &report.Findings[0].CryptographicAssets[i]
+		asset.FindingID = asset.Rules[0].ID
+	}
+	fragment := BuildGraphFragmentExport(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: "java"})
+	for entryID, wantFinding := range map[string]string{
+		firstID.String():  "java.pgp.aes128",
+		secondID.String(): "java.pgp.des",
+	} {
+		entry := findGraphFragmentEntryPoint(fragment.CryptoEntryPoints, entryID)
+		if entry == nil {
+			t.Fatalf("fragment entry %s missing", entryID)
+		}
+		got := make(map[string]bool)
+		for _, reachable := range entry.ReachableFindings {
+			got[reachable.FindingID] = true
+		}
+		otherFinding := "java.pgp.aes128"
+		if wantFinding == otherFinding {
+			otherFinding = "java.pgp.des"
+		}
+		if !got[wantFinding] || !got["java.pgp.dynamic"] || got[otherFinding] {
+			t.Fatalf("fragment entry %s findings = %#v, want generic + %s only", entryID, got, wantFinding)
+		}
+	}
+}
+
+func TestMaterializeConditionedFindings_ResolvesGuardedHelperReturnWithoutGuessing(t *testing.T) {
+	t.Parallel()
+
+	rules := writeConditionedRules(t, `rules:
+  - id: java.digest.sha2
+    message: SHA-2 digest
+    severity: INFO
+    pattern: MessageDigest.getInstance($ALGO)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: SHA-2
+        algorithmName: SHA-$variant
+        parameterCondition: param[0]~=SHA-?(?<variant>224|256|384|512)
+        operation: digest
+        api: MessageDigest.getInstance
+  - id: java.cipher.wrong-api
+    message: Unrelated cipher rule
+    severity: INFO
+    pattern: Cipher.getInstance($ALGO)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: WRONG
+        algorithmName: WRONG-$variant
+        parameterCondition: param[0]~=SHA-?(?<variant>224|256|384|512)
+        operation: encrypt
+        api: Cipher.getInstance
+`)
+	mainID := callgraph.FunctionID{Package: "example", Type: "DigestFlow", Name: "main#0"}
+	nameID := callgraph.FunctionID{Package: "example", Type: "DigestFlow", Name: "name#1"}
+	digestID := callgraph.FunctionID{Package: "java.security", Type: "MessageDigest", Name: "getInstance#1"}
+	selector := callgraph.SourceNode{Type: "VALUE", Value: "HashAlgorithmTags.SHA256", ParameterIndex: 0}
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		mainID.String(): {
+			ID: mainID, FilePath: "DigestFlow.java", StartLine: 1, EndLine: 8,
+			Calls: []callgraph.FunctionCall{
+				{Callee: digestID, FilePath: "DigestFlow.java", Line: 5, StartCol: 9, EndCol: 67, Arguments: []string{"name(HashAlgorithmTags.SHA256)"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "CALL_RESULT", CallTarget: &nameID, SourceNodes: []callgraph.SourceNode{selector}}}}},
+				{Callee: nameID, FilePath: "DigestFlow.java", Line: 5, StartCol: 35, EndCol: 66, Arguments: []string{"HashAlgorithmTags.SHA256"}, ArgumentSources: [][]callgraph.SourceNode{{selector}}},
+			},
+		},
+		nameID.String(): {
+			ID: nameID, Parameters: []callgraph.FunctionParameter{{Name: "algorithm", Type: "int"}},
+			ReturnSources: []callgraph.SourceNode{
+				{Type: "VALUE", Value: `"SHA-256"`, Flow: &callgraph.SourceFlow{Guard: &callgraph.SourceGuard{ParameterIndex: 0, Value: "HashAlgorithmTags.SHA256"}}},
+				{Type: "VALUE", Value: `"SHA-512"`, Flow: &callgraph.SourceFlow{Guard: &callgraph.SourceGuard{ParameterIndex: 0, Default: true}}},
+			},
+		},
+	}}
+	report := &entities.InterimReport{Findings: []entities.Finding{{FilePath: "DigestFlow.java", Language: "java", CryptographicAssets: []entities.CryptographicAsset{{
+		StartLine: 5, EndLine: 5, StartCol: 35, EndCol: 66, Match: "name(HashAlgorithmTags.SHA256)",
+		Rules: []entities.RuleInfo{{ID: "java.digest.dynamic"}}, Metadata: map[string]string{"api": "Cipher.getInstance"},
+	}}}}}
+
+	if got := MaterializeConditionedFindings(report, graph, []string{rules}, "java"); got != 1 {
+		t.Fatalf("MaterializeConditionedFindings() = %d, want 1", got)
+	}
+	asset := report.Findings[0].CryptographicAssets[1]
+	if asset.Metadata["algorithmName"] != "SHA-256" || asset.Rules[0].ID != "java.digest.sha2" {
+		t.Fatalf("materialized digest = %#v", asset)
+	}
+	if asset.Metadata["parameterCondition"] != "param[0]==SHA-256" || len(asset.ParameterConditions) != 1 || asset.ParameterConditions[0].Value != "SHA-256" {
+		t.Fatalf("materialized digest conditions = %#v / %q, want exact resolved selector", asset.ParameterConditions, asset.Metadata["parameterCondition"])
+	}
+
+	graph.Functions[mainID.String()].Calls[0].ArgumentSources[0][0].SourceNodes = []callgraph.SourceNode{{Type: "PARAMETER", Name: "algorithm", ParameterIndex: 0}}
+	report.Findings[0].CryptographicAssets = report.Findings[0].CryptographicAssets[:1]
+	if got := MaterializeConditionedFindings(report, graph, []string{rules}, "java"); got != 0 {
+		t.Fatalf("dynamic MaterializeConditionedFindings() = %d, want no guessed asset", got)
+	}
+}
+
+func TestConditionedRule_UsesPatternCaptureNamesForBroadVariants(t *testing.T) {
+	t.Parallel()
+
+	rules := writeConditionedRules(t, `rules:
+  - id: java.jca.algorithm.hash.sha-2
+    message: SHA-2 digest
+    severity: INFO
+    pattern-sources:
+      - patterns:
+          - pattern: $ALGO
+          - metavariable-regex:
+              metavariable: $ALGO
+              regex: '"SHA-?(?<variant>224|256|384|512)(?:/(?<subvariant>224|256))?"'
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: MessageDigest.getInstance($ALGO)
+              - pattern: MessageDigest.getInstance($ALGO, $PROVIDER)
+          - focus-metavariable: $ALGO
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: SHA-2
+        algorithmName: SHA-$variant
+        algorithmParameterSetIdentifier: $variant
+        parameterCondition: param[0]~=SHA-?(224|256|384|512)(?:/(224|256))?
+        operation: digest
+        api: Wrong.getInstance
+`)
+	rule := engine.LoadRuleCryptoMetadata([]string{rules})["MessageDigest.getInstance"][0]
+	finding := &entities.Finding{FilePath: "DigestFlow.java"}
+	seen := make(map[string]struct{})
+	existing := make(map[string]struct{})
+	anchor := entities.CryptographicAsset{StartLine: 4, Metadata: map[string]string{"api": "MessageDigest.getInstance"}}
+
+	for _, value := range []string{"SHA-256", "SHA-512"} {
+		if !appendConditionedAsset(finding, anchor, rule, []callGraphParameter{{ResolvedValue: value}}, seen, existing) {
+			t.Fatalf("appendConditionedAsset(%q) = false", value)
+		}
+	}
+	if len(finding.CryptographicAssets) != 2 {
+		t.Fatalf("materialized assets = %#v, want two exact variants", finding.CryptographicAssets)
+	}
+	if finding.CryptographicAssets[0].Metadata["algorithmName"] != "SHA-256" || finding.CryptographicAssets[1].Metadata["algorithmName"] != "SHA-512" {
+		t.Fatalf("algorithm names = %#v, want normalized SHA-256 and SHA-512", finding.CryptographicAssets)
+	}
+	if finding.CryptographicAssets[0].Metadata["algorithmParameterSetIdentifier"] != "256" || finding.CryptographicAssets[1].Metadata["algorithmParameterSetIdentifier"] != "512" {
+		t.Fatalf("parameter identifiers = %#v, want normalized 256 and 512", finding.CryptographicAssets)
+	}
+}
+
+func TestMaterializeConditionedFindings_DoesNotAttachNestedBuilderToOuterAnchor(t *testing.T) {
+	t.Parallel()
+
+	rules := writeConditionedRules(t, `rules:
+  - id: java.pgp.aes128
+    message: AES-128 PGP builder
+    severity: INFO
+    pattern: new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_128)
+    metadata:
+      crypto:
+        assetType: algorithm
+        algorithmFamily: AES
+        algorithmName: AES-128
+        parameterCondition: param[0]==SymmetricKeyAlgorithmTags.AES_128
+        operation: encrypt
+        api: JcePGPDataEncryptorBuilder.<init>
+`)
+	ownerID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "build#0"}
+	outerID := callgraph.FunctionID{Package: "org.bouncycastle.openpgp", Type: "PGPEncryptedDataGenerator", Name: "<init>#1"}
+	builderID := callgraph.FunctionID{Package: "org.bouncycastle.openpgp.operator.jcajce", Type: "JcePGPDataEncryptorBuilder", Name: "<init>#1"}
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		ownerID.String(): {
+			ID: ownerID, FilePath: "PGPFlow.java", StartLine: 1, EndLine: 5,
+			Calls: []callgraph.FunctionCall{
+				{Callee: outerID, FilePath: "PGPFlow.java", Line: 3, StartCol: 9, EndCol: 91, Arguments: []string{"new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_128)"}},
+				{Callee: builderID, FilePath: "PGPFlow.java", Line: 3, StartCol: 39, EndCol: 90, Arguments: []string{"SymmetricKeyAlgorithmTags.AES_128"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.AES_128"}}}},
+			},
+		},
+	}}
+	report := &entities.InterimReport{Findings: []entities.Finding{{
+		FilePath: "PGPFlow.java", Language: "java", CryptographicAssets: []entities.CryptographicAsset{
+			{StartLine: 3, EndLine: 3, StartCol: 9, EndCol: 91, Match: "new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_128))", Rules: []entities.RuleInfo{{ID: "java.pgp.generator"}}, Metadata: map[string]string{"assetType": "protocol"}},
+			{StartLine: 3, EndLine: 3, StartCol: 39, EndCol: 90, Match: "new JcePGPDataEncryptorBuilder(SymmetricKeyAlgorithmTags.AES_128)", Rules: []entities.RuleInfo{{ID: "java.pgp.builder.dynamic"}}, Metadata: map[string]string{"assetType": "algorithm"}},
+		},
+	}}}
+
+	if got := MaterializeConditionedFindings(report, graph, []string{rules}, "java"); got != 1 {
+		t.Fatalf("MaterializeConditionedFindings() = %d, want only nested builder specialization", got)
+	}
+	asset := report.Findings[0].CryptographicAssets[2]
+	if asset.StartCol != 39 || asset.Rules[0].ID != "java.pgp.aes128" {
+		t.Fatalf("materialized asset = %#v, want builder anchor only", asset)
+	}
+}
+
+func writeConditionedRules(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "rules.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/scan/export.go
+++ b/internal/scan/export.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scanoss/crypto-finder/internal/engine"
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/pkg/graphfrag"
+	"github.com/scanoss/crypto-finder/pkg/paramcondition"
 )
 
 const (
@@ -229,6 +230,10 @@ type exportSourceNode struct {
 	CallTargetInferredReturn *exportInferredReturn `json:"call_target_inferred_return,omitempty"`
 	Location                 *exportSourceLocation `json:"location,omitempty"`
 	SourceNodes              []exportSourceNode    `json:"source_nodes,omitempty"`
+	returnValue              bool
+	guard                    *callgraph.SourceGuard
+	callArgument             bool
+	sourceParameterIndex     int
 }
 
 type exportSourceLocation struct {
@@ -1260,6 +1265,9 @@ func buildFindingGraph(ctx *exportBuildContext, finding entities.Finding, asset 
 	}
 
 	fg.CallChains = buildCallChains(ctx, containingFn, cryptoCall)
+	if len(asset.ParameterConditions) > 0 {
+		fg.CallChains = filterConditionedCallChains(fg.CallChains, asset.ParameterConditions)
+	}
 
 	if unresolvedReason != "" {
 		fg.UnresolvedReason = unresolvedReason
@@ -1280,6 +1288,19 @@ func buildFindingGraph(ctx *exportBuildContext, finding entities.Finding, asset 
 	}
 
 	return fg
+}
+
+func filterConditionedCallChains(chains [][]callGraphChainNode, conditions []paramcondition.Condition) [][]callGraphChainNode {
+	filtered := make([][]callGraphChainNode, 0, len(chains))
+	for _, chain := range chains {
+		if len(chain) == 0 || chain[len(chain)-1].CryptoCall == nil {
+			continue
+		}
+		if _, ok := matchParameterConditions(conditions, chain[len(chain)-1].CryptoCall.Parameters); ok {
+			filtered = append(filtered, chain)
+		}
+	}
+	return filtered
 }
 
 // deriveSupportingCallsForFinding recovers a finding's supporting calls from the
@@ -1768,6 +1789,10 @@ func findCryptoCallNode(
 	}
 
 	// Step 2: column intersection filter (when both sides carry column info).
+	if asset.TerminalStartCol > 0 && asset.TerminalEndCol > 0 {
+		asset.StartCol = asset.TerminalStartCol
+		asset.EndCol = asset.TerminalEndCol
+	}
 	candidates := cryptoCallColumnCandidates(lineCandidates, asset)
 
 	// Step 3: tie-break.
@@ -1798,6 +1823,7 @@ func callCandidateViews(calls []*callgraph.FunctionCall) []candidateView {
 			ChainID:     c.ChainID,
 			AssignedVar: c.AssignedVar,
 			RawLen:      len(c.Raw),
+			Constructor: callgraph.BaseFunctionName(c.Callee.Name) == constructorMethodName,
 		}
 	}
 	return views
@@ -1909,7 +1935,15 @@ func findCryptoCall(
 	if bestCall == nil {
 		return nil
 	}
+	return buildCryptoCall(ctx, graph, containingFn, bestCall)
+}
 
+func buildCryptoCall(
+	ctx *exportBuildContext,
+	graph *callgraph.CallGraph,
+	containingFn *callgraph.FunctionDecl,
+	bestCall *callgraph.FunctionCall,
+) *callGraphCalledFunction {
 	callee := graph.Functions[bestCall.Callee.String()]
 	sourcePath := normalizeExportPath(ctx, bestCall.FilePath).FilePath
 	result := &callGraphCalledFunction{
@@ -1975,6 +2009,8 @@ func mergeCallParameters(
 // resolveExportSourceNodes follows simple Java parameter pass-through and return
 // paths before serializing provenance. It keeps every candidate so a dynamic
 // selector remains unresolved instead of choosing an arbitrary caller value.
+//
+//nolint:gocognit // Recursive provenance dispatch intentionally keeps every source-node kind fail-closed.
 func resolveExportSourceNodes(ctx *exportBuildContext, ownerID *callgraph.FunctionID, nodes []callgraph.SourceNode, depth int) []callgraph.SourceNode {
 	if ctx == nil || ctx.graph == nil || depth >= maxExportSourceResolutionDepth || len(nodes) == 0 {
 		return cloneCallgraphSourceNodes(nodes)
@@ -1990,7 +2026,14 @@ func resolveExportSourceNodes(ctx *exportBuildContext, ownerID *callgraph.Functi
 			node.SourceNodes = resolveExportSourceNodes(ctx, ownerID, node.SourceNodes, depth+1)
 			if node.CallTarget != nil {
 				if callee := ctx.graph.Functions[node.CallTarget.String()]; callee != nil {
-					node.SourceNodes = append(node.SourceNodes, resolveExportSourceNodes(ctx, node.CallTarget, callee.ReturnSources, depth+1)...)
+					returns := selectGuardedReturnSources(callee.ReturnSources, node.SourceNodes)
+					for i := range returns {
+						if returns[i].Flow == nil {
+							returns[i].Flow = &callgraph.SourceFlow{}
+						}
+						returns[i].Flow.ReturnValue = true
+					}
+					node.SourceNodes = append(node.SourceNodes, resolveExportSourceNodes(ctx, node.CallTarget, returns, depth+1)...)
 				}
 			}
 		case sourceNodeTypeField:
@@ -2019,17 +2062,107 @@ func resolveIncomingParameterSources(ctx *exportBuildContext, calleeID *callgrap
 	}
 	sort.Slice(callers, func(i, j int) bool { return callers[i].ID.String() < callers[j].ID.String() })
 
-	var sources []callgraph.SourceNode
+	var matches [][]callgraph.SourceNode
 	for _, caller := range callers {
 		for i := range caller.Calls {
 			call := &caller.Calls[i]
 			if call.Callee.String() != calleeID.String() || parameterIndex >= len(call.ArgumentSources) {
 				continue
 			}
-			sources = append(sources, resolveExportSourceNodes(ctx, &caller.ID, call.ArgumentSources[parameterIndex], depth+1)...)
+			matches = append(matches, resolveExportSourceNodes(ctx, &caller.ID, call.ArgumentSources[parameterIndex], depth+1))
 		}
 	}
-	return sources
+	if len(matches) != 1 {
+		return nil
+	}
+	return matches[0]
+}
+
+//nolint:gocognit // Guard matching must distinguish exact, default, and unresolved branches without guessing.
+func selectGuardedReturnSources(returns, arguments []callgraph.SourceNode) []callgraph.SourceNode {
+	if len(returns) == 0 {
+		return nil
+	}
+	values := make(map[int]string)
+	for i := range arguments {
+		if value, ok := resolveSimpleCallgraphSourceValue([]callgraph.SourceNode{arguments[i]}); ok {
+			values[arguments[i].ParameterIndex] = normalizeSelectorValue(value)
+		}
+	}
+
+	matched := make(map[int]bool)
+	for i := range returns {
+		guard := sourceNodeGuard(&returns[i])
+		if guard == nil || guard.Default {
+			continue
+		}
+		if value, ok := values[guard.ParameterIndex]; ok && value == normalizeSelectorValue(guard.Value) {
+			matched[guard.ParameterIndex] = true
+		}
+	}
+
+	selected := make([]callgraph.SourceNode, 0, len(returns))
+	for i := range returns {
+		source := &returns[i]
+		guard := sourceNodeGuard(source)
+		if guard == nil {
+			selected = append(selected, *source)
+			continue
+		}
+		value, known := values[guard.ParameterIndex]
+		if !known {
+			selected = append(selected, *source)
+			continue
+		}
+		if guard.Default {
+			if !matched[guard.ParameterIndex] {
+				selected = append(selected, *source)
+			}
+			continue
+		}
+		if value == normalizeSelectorValue(guard.Value) {
+			selected = append(selected, *source)
+		}
+	}
+	return selected
+}
+
+func sourceNodeGuard(node *callgraph.SourceNode) *callgraph.SourceGuard {
+	if node == nil || node.Flow == nil {
+		return nil
+	}
+	return node.Flow.Guard
+}
+
+func resolveSimpleCallgraphSourceValue(nodes []callgraph.SourceNode) (string, bool) {
+	if len(nodes) == 0 {
+		return "", false
+	}
+	var resolved string
+	for _, node := range nodes {
+		value := strings.TrimSpace(node.Value)
+		ok := node.Type == sourceNodeTypeValue && value != ""
+		if !ok && len(node.SourceNodes) > 0 {
+			value, ok = resolveSimpleCallgraphSourceValue(node.SourceNodes)
+		}
+		if !ok {
+			return "", false
+		}
+		if resolved == "" {
+			resolved = value
+		} else if resolved != value {
+			return "", false
+		}
+	}
+	return resolved, resolved != ""
+}
+
+func normalizeSelectorValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return value[1 : len(value)-1]
+	}
+	return value
 }
 
 func cloneCallgraphSourceNodes(nodes []callgraph.SourceNode) []callgraph.SourceNode {
@@ -2048,6 +2181,14 @@ func cloneCallgraphSourceNodes(nodes []callgraph.SourceNode) []callgraph.SourceN
 			location := *nodes[i].Location
 			cloned[i].Location = &location
 		}
+		if nodes[i].Flow != nil {
+			flow := *nodes[i].Flow
+			cloned[i].Flow = &flow
+			if nodes[i].Flow.Guard != nil {
+				guard := *nodes[i].Flow.Guard
+				cloned[i].Flow.Guard = &guard
+			}
+		}
 	}
 	return cloned
 }
@@ -2060,11 +2201,15 @@ func convertSourceNodes(ctx *exportBuildContext, nodes []callgraph.SourceNode, d
 	result := make([]exportSourceNode, len(nodes))
 	for i, n := range nodes {
 		result[i] = exportSourceNode{
-			Type:         n.Type,
-			Name:         n.Name,
-			DeclaredType: n.DeclaredType,
-			Value:        n.Value,
-			SourceNodes:  convertSourceNodes(ctx, n.SourceNodes, defaultFilePath, defaultLine),
+			Type:                 n.Type,
+			Name:                 n.Name,
+			DeclaredType:         n.DeclaredType,
+			Value:                n.Value,
+			SourceNodes:          convertSourceNodes(ctx, n.SourceNodes, defaultFilePath, defaultLine),
+			returnValue:          n.Flow != nil && n.Flow.ReturnValue,
+			guard:                sourceNodeGuard(&n),
+			callArgument:         n.Flow != nil && n.Flow.CallArgument,
+			sourceParameterIndex: n.ParameterIndex,
 		}
 		if n.Type == sourceNodeTypeParameter {
 			idx := n.ParameterIndex
@@ -2230,8 +2375,21 @@ func resolveSimpleExportSourceValueNode(node exportSourceNode) (string, bool) {
 }
 
 func resolveDirectExportReturnValue(nodes []exportSourceNode) (string, bool) {
+	if value, handled := resolveGuardedDirectReturnValue(nodes); handled {
+		return value, value != ""
+	}
+	hasMarkedReturn := false
+	for i := range nodes {
+		if nodes[i].returnValue {
+			hasMarkedReturn = true
+			break
+		}
+	}
 	var value string
 	for i := range nodes {
+		if hasMarkedReturn && !nodes[i].returnValue {
+			continue
+		}
 		if nodes[i].Type != sourceNodeTypeValue {
 			continue
 		}
@@ -2242,6 +2400,66 @@ func resolveDirectExportReturnValue(nodes []exportSourceNode) (string, bool) {
 		value = candidate
 	}
 	return value, value != ""
+}
+
+//nolint:gocognit,gocyclo // Mirrors guarded-source selection after path enrichment, retaining all ambiguous candidates.
+func resolveGuardedDirectReturnValue(nodes []exportSourceNode) (string, bool) {
+	hasGuard := false
+	arguments := make(map[int]string)
+	for i := range nodes {
+		if nodes[i].guard != nil {
+			hasGuard = true
+		}
+		if nodes[i].callArgument {
+			if value, ok := resolveSimpleExportSourceValueNode(nodes[i]); ok {
+				arguments[nodes[i].sourceParameterIndex] = normalizeSelectorValue(value)
+			}
+		}
+	}
+	if !hasGuard {
+		return "", false
+	}
+
+	matched := make(map[int]bool)
+	for i := range nodes {
+		guard := nodes[i].guard
+		if guard == nil || guard.Default {
+			continue
+		}
+		if value, ok := arguments[guard.ParameterIndex]; ok && value == normalizeSelectorValue(guard.Value) {
+			matched[guard.ParameterIndex] = true
+		}
+	}
+	var selected []exportSourceNode
+	for i := range nodes {
+		guard := nodes[i].guard
+		if guard == nil {
+			continue
+		}
+		value, known := arguments[guard.ParameterIndex]
+		if !known {
+			selected = append(selected, nodes[i])
+			continue
+		}
+		if guard.Default {
+			if !matched[guard.ParameterIndex] {
+				selected = append(selected, nodes[i])
+			}
+			continue
+		}
+		if value == normalizeSelectorValue(guard.Value) {
+			selected = append(selected, nodes[i])
+		}
+	}
+	returnValue := ""
+	for i := range selected {
+		value, ok := resolveSimpleExportSourceValueNode(selected[i])
+		if !ok || (returnValue != "" && returnValue != value) {
+			return "", true
+		}
+		returnValue = value
+	}
+	return returnValue, true
 }
 
 func looksLikeIntegerLiteralExpr(expr string) bool {
@@ -2328,6 +2546,7 @@ func buildBaseCallChains(
 		node := buildChainNode(ctx, containingFn.ID, containingFn.FilePath)
 		return [][]callGraphChainNode{{node}}
 	}
+	chains = expandCallChainCallSites(ctx.graph, chains, callGraphExportMaxChains)
 
 	result := make([][]callGraphChainNode, len(chains))
 	for i, chain := range chains {
@@ -2341,6 +2560,8 @@ func buildBaseCallChains(
 					chain.Steps[j-1].Function,
 					chain.Steps[j-1].FilePath,
 					chain.Steps[j-1].Line,
+					chain.Steps[j-1].StartCol,
+					chain.Steps[j-1].EndCol,
 					step.Function,
 				)
 			}
@@ -2350,6 +2571,56 @@ func buildBaseCallChains(
 	}
 
 	return result
+}
+
+// expandCallChainCallSites preserves distinct invocations when one caller
+// function calls the same wrapper more than once with different selector
+// values. The tracer intentionally deduplicates functions for O(V+E)
+// reachability; export expands only the bounded completed chains so per-call
+// applicability is not lost.
+func expandCallChainCallSites(graph *callgraph.CallGraph, chains []callgraph.CallChain, maxChains int) []callgraph.CallChain {
+	var expanded []callgraph.CallChain
+	for _, chain := range chains {
+		variants := expandOneCallChain(graph, chain, maxChains-len(expanded))
+		expanded = append(expanded, variants...)
+		if maxChains > 0 && len(expanded) >= maxChains {
+			return expanded[:maxChains]
+		}
+	}
+	return expanded
+}
+
+//nolint:gocognit // Bounded call-site cross-product is kept together so every cap check remains auditable.
+func expandOneCallChain(graph *callgraph.CallGraph, chain callgraph.CallChain, remaining int) []callgraph.CallChain {
+	variants := []callgraph.CallChain{{Steps: append([]callgraph.CallChainStep(nil), chain.Steps...)}}
+	for stepIndex := 1; stepIndex < len(chain.Steps); stepIndex++ {
+		caller := graph.Functions[chain.Steps[stepIndex-1].Function.String()]
+		matches := matchingInvocations(caller, chain.Steps[stepIndex].Function.String())
+		if len(matches) == 0 {
+			continue
+		}
+		var next []callgraph.CallChain
+		for _, variant := range variants {
+			for _, call := range matches {
+				cloned := callgraph.CallChain{Steps: append([]callgraph.CallChainStep(nil), variant.Steps...)}
+				cloned.Steps[stepIndex-1].Line = call.Line
+				cloned.Steps[stepIndex-1].StartCol = call.StartCol
+				cloned.Steps[stepIndex-1].EndCol = call.EndCol
+				if call.FilePath != "" {
+					cloned.Steps[stepIndex-1].FilePath = call.FilePath
+				}
+				next = append(next, cloned)
+				if remaining > 0 && len(next) >= remaining {
+					break
+				}
+			}
+			if remaining > 0 && len(next) >= remaining {
+				break
+			}
+		}
+		variants = next
+	}
+	return variants
 }
 
 func exportUserPackages(result *engine.DepScanResult) map[string]bool {
@@ -2545,6 +2816,8 @@ func buildEntryCall(
 	callerID callgraph.FunctionID,
 	callSitePath string,
 	fallbackLine int,
+	startCol int,
+	endCol int,
 	calleeID callgraph.FunctionID,
 ) *callGraphEntryCall {
 	location := normalizeExportPath(ctx, callSitePath)
@@ -2558,7 +2831,7 @@ func buildEntryCall(
 		return entryCall
 	}
 
-	call := findMatchingInvocation(callerFn, calleeID.String())
+	call := findMatchingInvocationAtSpan(callerFn, calleeID.String(), fallbackLine, startCol, endCol)
 	if call == nil {
 		entryCall := &callGraphEntryCall{
 			FilePath: location.FilePath,
@@ -3194,46 +3467,71 @@ func applyFallbackLocation(nodes []exportSourceNode, defaultFilePath string, def
 	}
 }
 
-func findMatchingInvocation(callerFn *callgraph.FunctionDecl, calleeKey string) *callgraph.FunctionCall {
+func findMatchingInvocationAtSpan(callerFn *callgraph.FunctionDecl, calleeKey string, line, startCol, endCol int) *callgraph.FunctionCall {
+	matches := matchingInvocations(callerFn, calleeKey)
+	if startCol > 0 && endCol > 0 {
+		for _, call := range matches {
+			if call.Line == line && call.StartCol == startCol && call.EndCol == endCol {
+				return call
+			}
+		}
+	}
+	for _, call := range matches {
+		if line > 0 && call.Line == line {
+			return call
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	return matches[0]
+}
+
+func matchingInvocations(callerFn *callgraph.FunctionDecl, calleeKey string) []*callgraph.FunctionCall {
 	if callerFn == nil {
 		return nil
 	}
 
 	calleeID, err := callgraph.ParseFunctionID(calleeKey)
-	bestIdx := -1
 	bestScore := -1
+	var best []*callgraph.FunctionCall
 	for i := range callerFn.Calls {
 		call := &callerFn.Calls[i]
-		if call.Callee.String() == calleeKey {
-			return call
-		}
-		if err != nil {
+		score := invocationMatchScore(call, calleeKey, calleeID, err == nil)
+		if score == 0 {
 			continue
-		}
-
-		score := 0
-		switch {
-		case call.Callee.Package == calleeID.Package &&
-			call.Callee.Type == calleeID.Type &&
-			methodArityKey(call.Callee.Name) == methodArityKey(calleeID.Name):
-			score = 80
-		case call.Callee.Type == calleeID.Type &&
-			methodArityKey(call.Callee.Name) == methodArityKey(calleeID.Name):
-			score = 60
-		case methodArityKey(call.Callee.Name) == methodArityKey(calleeID.Name):
-			score = 40
-		case callgraph.BaseFunctionName(call.Callee.Name) == callgraph.BaseFunctionName(calleeID.Name):
-			score = 20
 		}
 		if score > bestScore {
 			bestScore = score
-			bestIdx = i
+			best = []*callgraph.FunctionCall{call}
+		} else if score > 0 && score == bestScore {
+			best = append(best, call)
 		}
 	}
-	if bestIdx >= 0 {
-		return &callerFn.Calls[bestIdx]
+	return best
+}
+
+func invocationMatchScore(call *callgraph.FunctionCall, calleeKey string, calleeID callgraph.FunctionID, parsed bool) int {
+	if call.Callee.String() == calleeKey {
+		return 100
 	}
-	return nil
+	if !parsed {
+		return 0
+	}
+	callMethod := methodArityKey(call.Callee.Name)
+	wantMethod := methodArityKey(calleeID.Name)
+	switch {
+	case call.Callee.Package == calleeID.Package && call.Callee.Type == calleeID.Type && callMethod == wantMethod:
+		return 80
+	case call.Callee.Type == calleeID.Type && callMethod == wantMethod:
+		return 60
+	case callMethod == wantMethod:
+		return 40
+	case callgraph.BaseFunctionName(call.Callee.Name) == callgraph.BaseFunctionName(calleeID.Name):
+		return 20
+	default:
+		return 0
+	}
 }
 
 func methodArityKey(name string) string {

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -1229,8 +1229,7 @@ func buildGraphFragmentCryptoEntryPoints(ctx *exportBuildContext, result *engine
 	for _, finding := range result.Report.Findings {
 		for i := range finding.CryptographicAssets {
 			asset := finding.CryptographicAssets[i]
-			containingFn := ctx.findContainingFunctionByFinding(finding.FilePath, asset.StartLine)
-			chains := buildCallChains(ctx, containingFn, nil)
+			chains := buildFindingGraph(ctx, finding, asset).CallChains
 			addGraphFragmentFindingReachability(entries, chains, asset.FindingID)
 			supportingCalls := deriveSupportingCallsForFinding(ctx, finding, asset)
 			for i := range supportingCalls {

--- a/internal/scan/selector_provenance_test.go
+++ b/internal/scan/selector_provenance_test.go
@@ -101,3 +101,102 @@ func TestBuildGraphFragmentExport_LeavesAmbiguousSelectorUnresolved(t *testing.T
 		t.Fatalf("resolved_value = %q, want unresolved dynamic selector", got)
 	}
 }
+
+func TestBuildCallGraphExport_PreservesSelectorPerCallerPath(t *testing.T) {
+	t.Parallel()
+
+	firstID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "first#0"}
+	secondID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "second#0"}
+	buildID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "build#1"}
+	ctorID := callgraph.FunctionID{Package: "org.bouncycastle.openpgp.operator.jcajce", Type: "JcePGPDataEncryptorBuilder", Name: "<init>#1"}
+
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		firstID.String(): {
+			ID: firstID, FilePath: "PGPFlow.java", StartLine: 1, EndLine: 3,
+			Calls: []callgraph.FunctionCall{{Callee: buildID, FilePath: "PGPFlow.java", Line: 2, Arguments: []string{"SymmetricKeyAlgorithmTags.AES_128"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.AES_128"}}}}},
+		},
+		secondID.String(): {
+			ID: secondID, FilePath: "PGPFlow.java", StartLine: 5, EndLine: 7,
+			Calls: []callgraph.FunctionCall{{Callee: buildID, FilePath: "PGPFlow.java", Line: 6, Arguments: []string{"SymmetricKeyAlgorithmTags.DES"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.DES"}}}}},
+		},
+		buildID.String(): {
+			ID: buildID, FilePath: "PGPFlow.java", StartLine: 9, EndLine: 11,
+			Parameters: []callgraph.FunctionParameter{{Name: "algorithm", Type: "int"}},
+			Calls: []callgraph.FunctionCall{{
+				Callee: ctorID, FilePath: "PGPFlow.java", Line: 10, StartCol: 16, EndCol: 63,
+				Arguments: []string{"algorithm"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "PARAMETER", Name: "algorithm", ParameterIndex: 0}}},
+			}},
+		},
+	}, Callers: map[string][]string{buildID.String(): {firstID.String(), secondID.String()}}}
+	report := &entities.InterimReport{Findings: []entities.Finding{{
+		FilePath: "PGPFlow.java", Language: "java",
+		CryptographicAssets: []entities.CryptographicAsset{{
+			FindingID: "pgp-selector", StartLine: 10, EndLine: 10, StartCol: 16, EndCol: 63,
+			Match: "new JcePGPDataEncryptorBuilder(algorithm)", Rules: []entities.RuleInfo{{ID: "java.pgp.dynamic"}},
+			Metadata: map[string]string{"api": "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>"},
+		}},
+	}}}
+
+	payload := buildCallGraphExportV2(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: "java"})
+	if len(payload.FindingGraphs) != 1 || len(payload.FindingGraphs[0].CallChains) != 2 {
+		t.Fatalf("finding graphs = %#v, want two caller paths", payload.FindingGraphs)
+	}
+	got := make(map[string]bool)
+	for _, chain := range payload.FindingGraphs[0].CallChains {
+		last := chain[len(chain)-1]
+		if last.CryptoCall == nil || len(last.CryptoCall.Parameters) != 1 {
+			t.Fatalf("chain = %#v, want one crypto selector parameter", chain)
+		}
+		got[last.CryptoCall.Parameters[0].ResolvedValue] = true
+	}
+	for _, want := range []string{"SymmetricKeyAlgorithmTags.AES_128", "SymmetricKeyAlgorithmTags.DES"} {
+		if !got[want] {
+			t.Fatalf("resolved caller values = %#v, missing %q", got, want)
+		}
+	}
+}
+
+func TestBuildCallGraphExport_PreservesSelectorPerSameLineCallSite(t *testing.T) {
+	t.Parallel()
+
+	callerID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "run#0"}
+	buildID := callgraph.FunctionID{Package: "example", Type: "PGPFlow", Name: "build#1"}
+	ctorID := callgraph.FunctionID{Package: "org.bouncycastle.openpgp.operator.jcajce", Type: "JcePGPDataEncryptorBuilder", Name: "<init>#1"}
+	graph := &callgraph.CallGraph{Functions: map[string]*callgraph.FunctionDecl{
+		callerID.String(): {
+			ID: callerID, FilePath: "PGPFlow.java", StartLine: 1, EndLine: 3,
+			Calls: []callgraph.FunctionCall{
+				{Callee: buildID, FilePath: "PGPFlow.java", Line: 2, StartCol: 4, EndCol: 37, Arguments: []string{"SymmetricKeyAlgorithmTags.AES_128"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.AES_128"}}}},
+				{Callee: buildID, FilePath: "PGPFlow.java", Line: 2, StartCol: 40, EndCol: 69, Arguments: []string{"SymmetricKeyAlgorithmTags.DES"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "VALUE", Value: "SymmetricKeyAlgorithmTags.DES"}}}},
+			},
+		},
+		buildID.String(): {
+			ID: buildID, FilePath: "PGPFlow.java", StartLine: 5, EndLine: 7,
+			Parameters: []callgraph.FunctionParameter{{Name: "algorithm", Type: "int"}},
+			Calls: []callgraph.FunctionCall{{
+				Callee: ctorID, FilePath: "PGPFlow.java", Line: 6, StartCol: 16, EndCol: 63,
+				Arguments: []string{"algorithm"}, ArgumentSources: [][]callgraph.SourceNode{{{Type: "PARAMETER", Name: "algorithm", ParameterIndex: 0}}},
+			}},
+		},
+	}, Callers: map[string][]string{buildID.String(): {callerID.String()}}}
+	report := &entities.InterimReport{Findings: []entities.Finding{{
+		FilePath: "PGPFlow.java", Language: "java",
+		CryptographicAssets: []entities.CryptographicAsset{{
+			FindingID: "pgp-same-line", StartLine: 6, EndLine: 6, StartCol: 16, EndCol: 63,
+			Match: "new JcePGPDataEncryptorBuilder(algorithm)", Rules: []entities.RuleInfo{{ID: "java.pgp.dynamic"}},
+			Metadata: map[string]string{"api": "org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder.<init>"},
+		}},
+	}}}
+
+	payload := buildCallGraphExportV2(&engine.DepScanResult{Report: report, CallGraph: graph, Ecosystem: "java"})
+	if len(payload.FindingGraphs) != 1 || len(payload.FindingGraphs[0].CallChains) != 2 {
+		t.Fatalf("finding graphs = %#v, want two same-line call-site paths", payload.FindingGraphs)
+	}
+	got := make(map[string]bool)
+	for _, chain := range payload.FindingGraphs[0].CallChains {
+		got[chain[len(chain)-1].CryptoCall.Parameters[0].ResolvedValue] = true
+	}
+	if !got["SymmetricKeyAlgorithmTags.AES_128"] || !got["SymmetricKeyAlgorithmTags.DES"] {
+		t.Fatalf("resolved same-line values = %#v, want AES_128 and DES", got)
+	}
+}

--- a/internal/scan/terminal_selection.go
+++ b/internal/scan/terminal_selection.go
@@ -19,6 +19,7 @@ type candidateView struct {
 	ChainID     string
 	AssignedVar string
 	RawLen      int
+	Constructor bool
 }
 
 // identityIndices returns [0, 1, ..., n-1] — the full candidate set, used when a
@@ -63,6 +64,10 @@ func columnFilterIndices(views []candidateView, idxs []int, assetStartCol, asset
 }
 
 func tightestContainingIndices(views []candidateView, idxs []int, assetStartCol, assetEndCol int) []int {
+	if exact := exactSpanIndices(views, idxs, assetStartCol, assetEndCol); exact != nil {
+		return exact
+	}
+
 	best := -1
 	for _, i := range idxs {
 		v := views[i]
@@ -90,6 +95,23 @@ func tightestContainingIndices(views []candidateView, idxs []int, assetStartCol,
 		}
 	}
 	return tightest
+}
+
+func exactSpanIndices(views []candidateView, idxs []int, assetStartCol, assetEndCol int) []int {
+	var exact []int
+	for _, i := range idxs {
+		if views[i].StartCol != assetStartCol || views[i].EndCol != assetEndCol {
+			continue
+		}
+		if views[i].Constructor {
+			return []int{i}
+		}
+		exact = append(exact, i)
+	}
+	if len(exact) > 0 && views[exact[0]].ChainID == "" {
+		return exact
+	}
+	return nil
 }
 
 // chainRootIndexAmong returns the index (drawn from idxs) of the fluent-chain

--- a/internal/scan/terminal_selection_test.go
+++ b/internal/scan/terminal_selection_test.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scan
+
+import "testing"
+
+func TestColumnFilterIndices_ExactSpanBeatsFluentChainSibling(t *testing.T) {
+	t.Parallel()
+
+	views := []candidateView{
+		{StartCol: 16, EndCol: 51, ChainID: "chain", RawLen: 35, Constructor: true}, // constructor
+		{StartCol: 16, EndCol: 53, ChainID: "chain", RawLen: 80},                    // setSecureRandom
+		{StartCol: 16, EndCol: 46, ChainID: "chain", RawLen: 120},
+	}
+
+	got := columnFilterIndices(views, identityIndices(len(views)), 16, 51)
+	if len(got) != 1 || got[0] != 0 {
+		t.Fatalf("columnFilterIndices() = %v, want exact constructor span [0]", got)
+	}
+}

--- a/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
+++ b/testdata/projects/dependency_intelligence_java/src/main/java/example/Acceptance.java
@@ -18,6 +18,7 @@ package example;
 
 import java.security.SecureRandom;
 import java.security.Key;
+import java.security.MessageDigest;
 import javax.crypto.Cipher;
 import com.google.crypto.tink.Aead;
 import com.google.crypto.tink.KeysetHandle;
@@ -27,6 +28,8 @@ import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder;
+import org.bouncycastle.bcpg.HashAlgorithmTags;
+import org.bouncycastle.bcpg.SymmetricKeyAlgorithmTags;
 import org.apache.xml.security.encryption.XMLCipher;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -48,6 +51,22 @@ class Acceptance {
         return new JcePGPDataEncryptorBuilder(alg)
             .setSecureRandom(new SecureRandom())
             .setWithIntegrityPacket(true);
+    }
+
+    String digestName(int algorithm) {
+        return algorithm == HashAlgorithmTags.SHA256 ? "SHA-256" : "SHA-512";
+    }
+
+    MessageDigest digest(int algorithm) throws Exception {
+        return MessageDigest.getInstance(digestName(algorithm));
+    }
+
+    void selectorFixtures(int dynamicAlgorithm) throws Exception {
+        builder(SymmetricKeyAlgorithmTags.AES_128);
+        builder(SymmetricKeyAlgorithmTags.DES);
+        builder(dynamicAlgorithm);
+        digest(HashAlgorithmTags.SHA256);
+        digest(dynamicAlgorithm);
     }
 
     byte[] tink(byte[] data) throws Exception {


### PR DESCRIPTION
## Summary

- preserve selector provenance per call site through Java wrappers, focused helper expressions, and guarded switch/ternary returns
- derive conditioned crypto candidates structurally from rule patterns and materialize normalized rule-owned assets without relying on `metadata.api`
- filter live and fragment call chains by resolved conditions while leaving dynamic or ambiguous selectors unresolved

## Verification

- `go test -short ./...`
- `make lint`
- `git diff --check`
- Judgment Day Round 5: approved by both reviewers

Closes #135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Java selector findings now preserve distinct values for each call site.
  * Improved resolution of simple switch and ternary return paths without guessing dynamic branches.
  * Findings now apply matching rule metadata and algorithm details more accurately.
  * Call-chain exports better distinguish overlapping and same-line call sites.

* **Tests**
  * Added coverage for selector-specific algorithms, guarded branches, wrapper methods, and exported finding metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->