### PR TITLE
docs: architecture, error codes, and README overhaul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ Project-specific conventions for AI agents and human contributors working in thi
 Read this file before making non-trivial changes. It documents conventions that are
 load-bearing but not enforceable by lint or compiler alone.
 
+Human-readable counterparts: the architecture, pipeline, and package map live in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); the published failure code/stage
+taxonomy lives in [docs/ERROR_CODES.md](docs/ERROR_CODES.md).
+
 ## Changelog (HARD REQUIREMENT)
 
 Every user-facing change — new flag, behavior change, schema bump, bug fix, performance
@@ -69,14 +73,18 @@ The callgraph inference engine consumes language-agnostic YAML knowledge bases u
 ```
 internal/callgraph/contracts/
 ├── contracts.go           # loader, types, validation
-├── c/                     # schema-v2 C callgraph contracts
-├── cpp/                   # schema-v2 C++ callgraph contracts
-├── java/
-│   └── jdk-crypto.yaml    # JDK JCA/JCE contracts (shipped in v1)
-├── go/                    # schema-v2 Go callgraph contracts
-├── node/                  # schema-v2 Node callgraph contracts
-├── python/                # pyca-cryptography, pycryptodome, pycryptodomex, paramiko
-└── rust/                  # schema-v2 Rust callgraph contracts
+├── c/                     # openssl-evp, libsodium, mbedtls, wolfssl-wolfcrypt
+├── cpp/                   # bootstrap placeholder (no library KBs yet)
+├── go/                    # stdlib-crypto, golang-x-crypto, golang-fips-openssl-v2
+├── java/                  # jdk-crypto, bouncycastle (+ openpgp), tink-1.13.0, jjwt,
+│                          #   nimbus-jose-jwt, apache-santuario-xmlsec, apache-sshd,
+│                          #   password4j, spring-security-crypto
+├── node/                  # bootstrap placeholder (no library KBs yet)
+├── python/                # pyca-cryptography, pycryptodome(x), paramiko, passlib,
+│                          #   bcrypt, argon2-cffi, pynacl, pyopenssl, m2crypto,
+│                          #   pyjwt, flask-jwt-extended, pyotp, werkzeug, boto3,
+│                          #   azure-keyvault-keys, azure-keyvault-secrets
+└── rust/                  # ring, chacha20poly1305 (+ bootstrap)
 ```
 
 **One YAML file = one library version**. Adding a new library is a new YAML, not a code
@@ -103,7 +111,9 @@ concrete signature instead of the KB guessing one overload. Keep these fields di
 from semantic `return.type`, which may intentionally model only one inferred value.
 
 Schema version is `"2"` — schema `"1"` is hard-rejected. The YAML schema version is
-INTERNAL to the loader; the partner-facing export schema is independent (currently 6.0).
+INTERNAL to the loader; the partner-facing export schema is independent (currently
+`6.6` for the callgraph export — `pkg/graphfrag.CallgraphSchemaVersion` — and
+`graph-fragment-1.8` for the fragment export — `pkg/graphfrag.SchemaVersion`).
 
 To add a library:
 1. Drop a new YAML at `internal/callgraph/contracts/<ecosystem>/<library>.yaml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,20 +166,26 @@ Fix any issues reported by the linter. Common rules include:
 ### Test Coverage
 
 - Maintain or improve the current test coverage
-- Run coverage report:
+- Generate an HTML coverage report (runs the tests first, writes `coverage.html`):
   ```bash
-  make test-coverage
+  make coverage
+  ```
+- Check the coverage thresholds the CI enforces (requires `go-test-coverage`,
+  configured in `.testcoverage.yml`):
+  ```bash
+  go install github.com/vladopajic/go-test-coverage/v2@latest
+  make coverage-check
   ```
 - Aim for at least 80% coverage for new code
 
 ### Running Tests
 
 ```bash
-# Run all tests
+# Run all tests locally (writes coverage.out)
 make test
 
-# Run tests with coverage
-make test-coverage
+# Run tests in Docker, same environment as CI (includes semgrep + opengrep)
+make test-docker
 
 # Run tests for a specific package
 go test ./internal/scanner/...
@@ -187,6 +193,12 @@ go test ./internal/scanner/...
 # Run a specific test
 go test -run TestScannerName ./internal/scanner/
 ```
+
+`make test` runs the suite with your local toolchain: tests that shell out to a
+real scanner are skipped when `opengrep`/`semgrep` are not installed. CI runs
+`make test-docker`, which builds `Dockerfile.test` (Go + semgrep + opengrep) and
+runs the full suite inside it — use it before submitting scanner-touching
+changes so the integration tests actually execute.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -4,50 +4,40 @@
 ![License](https://img.shields.io/badge/license-GPL--2.0--only-brightgreen)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/scanoss/crypto-finder)](https://go.dev/)
 
-A powerful CLI tool for detecting cryptographic algorithm usage in source code repositories. Crypto Finder scans codebases using multiple scanning engines (OpenGrep, Semgrep) and outputs results in standardized formats including JSON and CycloneDX CBOM (Cryptography Bill of Materials).
+Crypto Finder is a CLI tool that detects cryptographic algorithm usage in source code. It runs detection rules through a scanning engine (OpenGrep by default, Semgrep supported), builds a call graph of the scanned code, computes which crypto findings are reachable from which API entry points, and exports the results as interim JSON, CycloneDX CBOM, a finding-centric call graph, or a reusable graph fragment.
 
-## TL;DR
+## Quick Start
 
 ```bash
 # Configure your API key (one-time setup)
 crypto-finder configure --api-key YOUR_API_KEY
 
-# Scan a project using remote rulesets
+# Scan a project using the remote ruleset
 crypto-finder scan /path/to/code
 
-# Generate CycloneDX CBOM
+# Generate a CycloneDX CBOM
 crypto-finder scan --format cyclonedx --output cbom.json /path/to/code
+
+# Scan with call graph reachability export
+crypto-finder scan --export-callgraph callgraph.json --output findings.json /path/to/code
 ```
 
 ## Installation
 
 ### Prerequisites
 
-Before you begin, ensure you have the following installed:
-
-- **Go** - version 1.25 or higher (for building from source)
-
-    ```bash
-    # macOS
-    brew install go
-
-    # Linux
-    # Download from https://go.dev/dl/
-    ```
-
-- **OpenGrep** or **Semgrep** - for running scans (included in Docker images)
+- **Go** 1.25+ (only for building from source)
+- **OpenGrep** (recommended) or **Semgrep** — the scanning engine. Included in the Docker images.
 
     ```bash
-    # OpenGrep (recommended)
-    # Download from https://github.com/opengrep/opengrep
-
-    # Semgrep
+    # OpenGrep: download from https://github.com/opengrep/opengrep
+    # Semgrep:
     pip install semgrep
     ```
 
 ### Setup
 
-**Option 1: Build from Source**
+**Option 1: Build from source**
 
 ```bash
 git clone https://github.com/scanoss/crypto-finder.git
@@ -56,7 +46,7 @@ make build
 sudo make install
 ```
 
-**Option 2: Go Install**
+**Option 2: Go install**
 
 ```bash
 go install github.com/scanoss/crypto-finder/cmd/crypto-finder@latest
@@ -75,81 +65,151 @@ docker pull ghcr.io/scanoss/crypto-finder:latest-slim
 docker pull ghcr.io/scanoss/crypto-finder:latest-deps
 ```
 
-## Usage
+## Commands
 
-### Basic Scanning
+| Command | Purpose |
+|---------|---------|
+| `scan` | Scan a source tree for crypto usage. Optionally builds the call graph, scans dependencies, and exports reachability artifacts. |
+| `annotate` | Re-run **only crypto detection** against a previously exported graph fragment — skips the expensive call graph rebuild. |
+| `convert` | Convert interim JSON results to CycloneDX CBOM. |
+| `configure` | Persist the SCANOSS API key / URL. |
+| `version` | Print version information. |
 
-**Scan with remote rulesets (recommended):**
+## Scanning
 
 ```bash
+# Remote ruleset (default; requires API key)
 crypto-finder scan /path/to/code
-```
 
-**Scan with local rules:**
-
-```bash
+# Local rules only (rules development loop, offline use)
 crypto-finder scan --no-remote-rules --rules-dir ./rules /path/to/code
-```
 
-**Generate CycloneDX CBOM:**
-
-```bash
-crypto-finder scan --format cyclonedx --output cbom.json /path/to/code
-```
-
-### Common Use Cases
-
-**CI/CD Integration:**
-
-```bash
-# Fail build if cryptographic assets are detected
+# CI/CD: fail the build when crypto is detected
 crypto-finder scan --fail-on-findings /path/to/code
+
+# Scan third-party dependencies with call chain tracing
+crypto-finder scan --scan-dependencies /path/to/code
+
+# Export the finding-centric call graph (reachability slices)
+crypto-finder scan --export-callgraph callgraph.json /path/to/code
+
+# Export a reusable structural graph fragment (for stitching / caching)
+crypto-finder scan --export-graph-fragment fragment.json /path/to/code
 ```
 
-**Custom Rule Combination:**
+The interim JSON report (findings + metadata) goes to `--output` (stdout by default). The call graph and graph fragment exports are **separate files** written to the paths given to `--export-callgraph` / `--export-graph-fragment`. See [Output Formats](docs/OUTPUT_FORMATS.md) for all schemas.
+
+## Re-annotation: `annotate` vs `scan`
+
+The call graph build (parsing + type inference) is the expensive ~95% of a scan and is **rules-independent**. When only the detection ruleset changed — new rules version, local rule you are iterating on — you do not need to rebuild the graph:
 
 ```bash
-# Combine remote rules with local custom rules
+# One-time: full scan, cache the structural fragment
+crypto-finder scan --export-graph-fragment fragment.json /path/to/code
+
+# Every rules change afterwards: detection-only re-annotation
+crypto-finder annotate --import-fragment fragment.json --source /path/to/code --output annotation.json
+```
+
+`annotate` runs only the detection pass, maps each finding onto the imported fragment's function line ranges, and emits `crypto_annotations` that are byte-identical to a full `scan --export-graph-fragment` for the same source + rules. On a large library this turns a ~20 minute re-scan into ~1 minute of detection.
+
+Use `scan` when the **source code** changed (the graph must be rebuilt); use `annotate` when only the **rules** changed. The fragment's `graph_algo_version` in `scan_metadata` tells you when a new binary release invalidates cached fragments (it bumps only on graph-construction changes).
+
+## Flag Reference
+
+### Global flags (all commands)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-v`, `--verbose` | off | Info-level logging |
+| `-d`, `--debug` | off | Debug-level logging |
+| `-q`, `--quiet` | off | Error-level logging only |
+| `--error-format <fmt>` | `text` | Terminal error rendering: `text` or `json`. With `json`, failures are emitted to stderr as a structured payload with a stable `code` and `stage` — see [Error Codes](docs/ERROR_CODES.md). |
+
+### `scan` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-r`, `--rules <file>` | — | Rule file path (repeatable) |
+| `--rules-dir <dir>` | — | Rule directory path (repeatable) |
+| `--no-remote-rules` | off | Disable the default remote ruleset |
+| `--no-cache` | off | Force fresh download of remote rules, bypass cache |
+| `--strict` | off | Fail if the rules cache expired and the API is unreachable (no stale-cache fallback) |
+| `--max-stale-age <dur>` | `30d` | Maximum age for stale cache fallback (max `90d`) |
+| `--scanner <name>` | `opengrep` | Scanner engine: `opengrep`, `semgrep` |
+| `-f`, `--format <fmt>` | `json` | Output format: `json` (interim), `cyclonedx` |
+| `-o`, `--output <file>` | stdout | Output file path for the findings report |
+| `--languages <langs>` | auto | Override language detection (comma-separated) |
+| `--fail-on-findings` | off | Exit non-zero if findings are detected |
+| `-t`, `--timeout <dur>` | `10m` | Scan timeout (e.g. `10m`, `1h`, `2w`) |
+| `--no-dedup` | off | Disable per-line deduplication of findings |
+| `--include-tests` | off | Include test sources in findings and dependency scans |
+| `--no-default-exclusions` | off | Disable built-in directory exclusions (`vendor`, `node_modules`, `dist`, ...). Slows scans on large repos; combine with `--exclude` to re-add specific dirs |
+| `--exclude <glob>` | — | Gitignore-style pattern to skip (repeatable); added on top of the defaults |
+| `--scan-dependencies` | off | Recursively scan third-party dependencies (requires the deps image or local toolchains) |
+| `--dep-ecosystem <eco>` | `auto` | Dependency ecosystem: `auto`, `go`, `java`, `python`, `rust` |
+| `--dep-workers <n>` | `0` | Parallel dependency scan workers (0 = half of CPU cores, max 8; Java max 2) |
+| `--findings-cache <backend>` | `disk` | Dependency findings cache backend: `disk`, `none`, `postgres` (also via `SCANOSS_FINDINGS_CACHE_BACKEND`; postgres needs `SCANOSS_FINDINGS_CACHE_DSN`) |
+| `--export-callgraph <file>` | — | Write the finding-centric crypto call graph (reachability slices) to `<file>` |
+| `--export-callgraph-format <fmt>` | `json` | Call graph export format (only `json`) |
+| `--export-graph-fragment <file>` | — | Write a reusable structural graph fragment to `<file>` |
+| `--export-graph-fragment-format <fmt>` | `json` | Graph fragment export format (only `json`) |
+| `--java-jdk-major <major>` | — | Java JDK major for dependency resolution/type enrichment: `auto`, `8`, `11`, `17`, `21` |
+| `--java-jdk-home <major=path>` | — | Explicit JDK home mapping (repeatable) |
+| `--java-compiled-artifact <path>` | — | Compiled Java artifact used for standalone callgraph/type enrichment |
+| `--interfile` | off | Cross-file analysis (Semgrep Pro only) |
+| `--api-key`, `--api-url` | config | Override the configured SCANOSS API key / base URL |
+
+### `annotate` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--import-fragment <file>` | required | Cached structural graph fragment JSON to re-annotate |
+| `--source <dir>` | required | Source directory to run crypto detection over |
+| `-o`, `--output <file>` | stdout | Output file for the annotation JSON |
+
+`annotate` also accepts the detection-related subset of `scan` flags: `--rules`, `--rules-dir`, `--no-remote-rules`, `--no-cache`, `--scanner`, `--timeout`, `--languages`, `--include-tests`, `--no-default-exclusions`, `--exclude`, `--api-key`, `--api-url`.
+
+## Language Coverage
+
+Detection (rules-based scanning) covers whatever languages the ruleset covers. Call graph construction and reachability analysis support these ecosystems:
+
+| Ecosystem | Call graph parser | Contract knowledge bases (`internal/callgraph/contracts/`) |
+|-----------|-------------------|-------------------------------------------------------------|
+| C | yes | OpenSSL EVP, libsodium, Mbed TLS, wolfSSL/wolfCrypt |
+| C++ | yes | none yet (bootstrap placeholder) |
+| Go | yes | stdlib `crypto/*`, `golang.org/x/crypto`, golang-fips/openssl |
+| Java | yes | JDK JCA/JCE, BouncyCastle (+ OpenPGP), Tink, jjwt, Nimbus JOSE+JWT, Apache Santuario, Apache SSHD, Password4j, Spring Security Crypto |
+| JavaScript / TypeScript (Node) | yes | none yet (bootstrap placeholder) |
+| Python | yes | pyca/cryptography, PyCryptodome(x), paramiko, passlib, bcrypt, argon2-cffi, PyNaCl, pyOpenSSL, M2Crypto, PyJWT, flask-jwt-extended, pyotp, werkzeug, boto3, azure-keyvault-keys/secrets |
+| Rust | yes | ring, chacha20poly1305 |
+
+Dependency scanning (`--scan-dependencies`) resolves and scans third-party packages for: **Go**, **Java** (Maven/Gradle), **Python** (pip), **Rust** (Cargo).
+
+## Detection Rules
+
+Detection rules are **not in this repository** — they live in [scanoss/crypto_rules](https://github.com/scanoss/crypto_rules) and are served as the remote `dca` ruleset via the SCANOSS API (cached locally with TTL + stale fallback; see [Remote Rulesets](docs/REMOTE_RULESETS.md)).
+
+Local rules development loop:
+
+```bash
+# Iterate on rules without touching the remote ruleset
+crypto-finder scan --no-remote-rules --rules-dir /path/to/crypto_rules/checkout /path/to/testcode
+
+# Combine remote rules with local additions
 crypto-finder scan --rules-dir ./custom-rules /path/to/code
 ```
 
-**Force Fresh Rules:**
+Small rule fixtures used by this repo's tests live under `testdata/rules/`. Rules detect **terminal crypto operations only** and carry standard CycloneDX metadata; supporting/lifecycle calls are derived structurally from the call graph, never tagged by rules — see [Architecture](docs/ARCHITECTURE.md#load-bearing-invariants).
+
+## Configuration
 
 ```bash
-# Bypass cache and force fresh download
-crypto-finder scan --no-cache /path/to/code
-```
-
-**Format Conversion:**
-
-```bash
-# Convert existing results to CycloneDX
-crypto-finder convert results.json --output cbom.json
-
-# Or pipe from scan
-crypto-finder scan /path/to/code | crypto-finder convert --output cbom.json
-```
-
-### Configuration
-
-The application can be configured via command-line flags, environment variables, or configuration files.
-
-```bash
-# Set API key
 crypto-finder configure --api-key YOUR_API_KEY
-
-# Set custom API URL
 crypto-finder configure --api-url https://custom.scanoss.com
 ```
 
-**Environment Variables:**
-
-```bash
-export SCANOSS_API_KEY=your-key
-export SCANOSS_API_URL=https://custom.scanoss.com
-```
-
-**Project-level configuration** via `scanoss.json`:
+Environment variables: `SCANOSS_API_KEY`, `SCANOSS_API_URL`. Project-level skip patterns via `scanoss.json`:
 
 ```json
 {
@@ -163,61 +223,25 @@ export SCANOSS_API_URL=https://custom.scanoss.com
 }
 ```
 
-For detailed configuration options, see [Configuration Documentation](docs/CONFIGURATION.md).
+See [Configuration](docs/CONFIGURATION.md) for the full guide.
 
-### Command Line Arguments
+## Documentation
 
-```bash
-crypto-finder scan [flags] <target>
-```
-
-**Common options:**
-
-- `--rules <file>` - Custom rule file (repeatable)
-- `--rules-dir <dir>` - Rule directory (repeatable)
-- `--no-remote-rules` - Disable remote ruleset fetching
-- `--no-cache` - Force fresh download, bypass cache
-- `--scanner <name>` - Scanner to use: `opengrep` (default), `semgrep`
-- `--format <format>` - Output format: `json` (default), `cyclonedx`
-- `--output <file>` - Output file path (default: stdout)
-- `--languages <langs>` - Override language detection (comma-separated)
-- `--fail-on-findings` - Exit with error if findings detected
-- `--timeout <duration>` - Scan timeout (default: 10m)
-- `--scan-dependencies` - Scan third-party dependencies for cryptographic usage (requires deps image or local toolchains)
-- `--export-callgraph` - Export call graph to JSON for debugging
-- `--java-jdk-major <major>` - Java JDK major for Java dependency resolution/type enrichment: `auto`, `8`, `11`, `17`, `21`
-- `--java-jdk-home <major=path>` - Java JDK home mapping for explicit Java runtime selection (repeatable)
-- `--interfile` - Enable cross-file analysis (Semgrep Pro only)
-- `--verbose`, `-v` - Enable verbose logging
-- `--help` - Display help information
-
-For a complete list of commands and options, run `crypto-finder --help`.
-
-## Advanced Topics
-
-### Features
-
-- **Multi-Scanner Support** - OpenGrep (default) and Semgrep with advanced taint analysis
-- **Remote Rulesets** - Automatically fetch curated rules from SCANOSS API with local caching
-- **Flexible Configuration** - Combine remote and local rules, configure via CLI, env vars, or config files
-- **Multiple Output Formats** - Interim JSON and CycloneDX 1.6 CBOM formats
-- **CI/CD Ready** - Docker images for GitHub Actions, GitLab CI, Jenkins, and more
-- **Dependency Scanning** - Detect cryptographic usage in third-party dependencies with call chain tracing (Go, Java via Maven/Gradle, Python, Rust)
-- **Smart Caching** - TTL-based cache with automatic stale cache fallback (opt-out with `--strict`)
-
-### Documentation
-
-- **[Remote Rulesets](docs/REMOTE_RULESETS.md)** - API configuration, caching strategies, and troubleshooting
-- **[Output Formats](docs/OUTPUT_FORMATS.md)** - Interim JSON and CycloneDX CBOM format specifications
-- **[Docker Usage](docs/DOCKER_USAGE.md)** - Container usage and CI/CD integration examples
-- **[Dependency Scanning](docs/DEPENDENCY_SCANNING.md)** - Scanning third-party dependencies for cryptographic usage
-- **[Configuration](docs/CONFIGURATION.md)** - Detailed configuration guide and skip patterns
+| Document | Contents |
+|----------|----------|
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Pipeline overview, package map, load-bearing invariants |
+| [docs/OUTPUT_FORMATS.md](docs/OUTPUT_FORMATS.md) | Interim JSON, callgraph export (schema `6.6`), graph fragment (`graph-fragment-1.8`), CycloneDX CBOM |
+| [docs/ERROR_CODES.md](docs/ERROR_CODES.md) | Stable failure code/stage taxonomy emitted by `--error-format json` |
+| [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | Configuration options and skip patterns |
+| [docs/DEPENDENCY_SCANNING.md](docs/DEPENDENCY_SCANNING.md) | Dependency scanning, call chain tracing, attribution |
+| [docs/REMOTE_RULESETS.md](docs/REMOTE_RULESETS.md) | Remote ruleset API, caching, troubleshooting |
+| [docs/DOCKER_USAGE.md](docs/DOCKER_USAGE.md) | Container usage and CI/CD integration |
+| [CONTEXT.md](CONTEXT.md) | Domain glossary — the ubiquitous language used across code and docs |
+| [AGENTS.md](AGENTS.md) | Conventions for AI agents and contributors (changelog policy, error layering, contracts KB) |
 
 ## Contributing
 
-We welcome contributions! For more details, see [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-### Quick Start
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
@@ -231,7 +255,7 @@ We welcome contributions! For more details, see [CONTRIBUTING.md](CONTRIBUTING.m
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.
+See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes — including every partner-facing schema bump.
 
 ## License
 
@@ -247,7 +271,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 - [SCANOSS Website](https://www.scanoss.com)
 - [SCANOSS Documentation](https://scanoss.readthedocs.io)
-- [SCANOSS Settings Schema](https://scanoss.readthedocs.io/projects/scanoss-py/en/latest/scanoss_settings_schema.html)
+- [Detection Rules Repository](https://github.com/scanoss/crypto_rules)
 - [Issue Tracker](https://github.com/scanoss/crypto-finder/issues)
 
 ## Support

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,139 @@
+# Architecture
+
+How crypto-finder turns a source tree into findings, reachability data, and partner-facing exports. For the domain vocabulary used below (finding, crypto entry point, supporting call, call chain, ...), see [CONTEXT.md](../CONTEXT.md).
+
+## Pipeline
+
+A `scan` run executes these stages in order:
+
+```
+target source tree
+   │
+   ▼
+1. Rules loading          remote "dca" ruleset (scanoss/crypto_rules via SCANOSS API,
+   (internal/rules,        cached with TTL + stale fallback) merged with any local
+    internal/cache,        --rules / --rules-dir sources
+    internal/api)
+   │
+   ▼
+2. Detection              language detection (internal/language), skip patterns
+   (internal/engine,       (internal/skip), then OpenGrep/Semgrep executes the rules
+    internal/scanner)      → raw matches → dedup (internal/deduplicator), dead-code
+                           filtering (internal/deadcode) → interim report entities
+   │
+   ▼
+3. Call graph             tree-sitter parsers per ecosystem build function nodes and
+   construction            call edges; type inference resolves receivers/returns using
+   (internal/callgraph)    the contracts KB (internal/callgraph/contracts) and, for
+                           Java, bytecode/JDK platform signatures (internal/javaruntime)
+   │
+   ▼
+4. Reachability           each finding is matched to its call graph node by POSITION
+   analysis                (match columns ∩ call-node columns), then call chains from
+   (internal/scan)         API entry points to the terminal crypto call are computed;
+                           dependency scans (internal/dependency, internal/engine)
+                           repeat 2–3 per resolved dependency with a findings cache
+   │
+   ▼
+5. Supporting-call        lifecycle/config/factory/output calls around each finding's
+   derivation              crypto object are derived STRUCTURALLY from the graph
+   (internal/scan)         (ReceiverVar / AssignedVar / ChainID — see invariants below)
+   │
+   ▼
+6. Enrichment + export    OID enrichment (internal/enricher); writers (internal/output,
+   (internal/enricher,     internal/converter) emit interim JSON or CycloneDX CBOM;
+    internal/scan,         --export-callgraph emits the schema-6.6 reachability export;
+    pkg/graphfrag)         --export-graph-fragment emits a graph-fragment-1.8 fragment
+```
+
+The `annotate` command is a shortcut through this pipeline: it runs stage 2 only and maps the fresh findings onto a cached stage-3 fragment (`graphfrag.Fragment.ContainingFunction`), skipping the expensive graph rebuild. `convert` runs stage 6's CBOM conversion standalone.
+
+Errors become terminal only at the CLI boundary, with a stable machine-readable code and stage — see [ERROR_CODES.md](ERROR_CODES.md).
+
+## Package Map
+
+### `internal/`
+
+| Package | Responsibility |
+|---------|----------------|
+| `api` | HTTP client for the SCANOSS REST API (remote ruleset download). |
+| `cache` | Local cache of downloaded rulesets: TTL, `--strict`, stale-fallback policy. |
+| `callgraph` | Function-level call graph construction: per-ecosystem tree-sitter parsers, type inference, and the contracts knowledge base (`contracts/`). |
+| `cli` | Cobra commands (`scan`, `annotate`, `convert`, `configure`, `version`), flag wiring, terminal error rendering. |
+| `config` | Configuration management: env vars, config file, flag overrides. |
+| `converter` | Interim JSON → CycloneDX 1.6 CBOM transformation. |
+| `deadcode` | Filters findings inside C/C++ preprocessor dead-code blocks (`#if 0 ... #endif`). |
+| `deduplicator` | Per-line deduplication of cryptographic assets (multiple rules on one line → one asset with a `rules[]` array). |
+| `dependency` | Dependency resolvers: Go modules, Java (Maven/Gradle), Python (pip), Rust (Cargo). |
+| `engine` | Scan orchestration: language detection → rules → scanner → report; the dependency scanner and its findings cache (disk/postgres); finding-ID assignment; rule-driven entry-point synthesis. |
+| `enricher` | OID enrichment of findings (algorithm → Object Identifier). |
+| `entities` | Domain data structures: the interim report (format version `1.4`) and its assets. |
+| `failure` | Structured machine-readable terminal errors (`Code`, `Stage`, JSON payload). |
+| `javaruntime` | Java JDK selection (`--java-jdk-major` / `--java-jdk-home`) for platform-signature type enrichment. |
+| `language` | Automatic language detection (go-enry) honoring skip patterns. |
+| `output` | Output writers: interim JSON and CycloneDX, stdout or file, streaming for large reports. |
+| `rules` | Rule source management: remote source, local files/dirs, multi-source merge. |
+| `scan` | Reusable scan utilities shared by CLI commands: flag validation, reachability export, graph-fragment export, supporting-call derivation, conditioned-finding materialization. |
+| `scanner` | Scanner abstraction plus the `opengrep/` and `semgrep/` engine implementations. |
+| `skip` | File/directory exclusion: built-in defaults, `scanoss.json` patterns, `--exclude`, gitignore-style matching. |
+| `utils` | Small general-purpose helpers. |
+| `version` | Build/version information for the binary. |
+
+### `pkg/` (public, importable by downstream services)
+
+| Package | Responsibility |
+|---------|----------------|
+| `graphfrag` | The graph-fragment model and wire schema (`graph-fragment-1.8`), fragment decode/encode, the tiered fail-closed **stitcher** that composes per-component fragments into transitive reachability, and the renderers (`ToCallgraphExport` — stamps callgraph schema `6.6` — and `ToFindingsEnvelope`). |
+| `graphfrag/equiv` | Semantic diff asserting a stitched callgraph equals a live one (the equivalence guarantee the renderers rely on). |
+| `paramcondition` | Parser for the crypto-rules `parameterCondition` grammar (`param[<selector>]<op><value>`) into structured predicates. |
+
+## Load-Bearing Invariants
+
+These rules are enforced by convention (and tests), not by the compiler. Violating them is the most common way to break the tool. The agent-facing statement of the same rules lives in [AGENTS.md](../AGENTS.md).
+
+### 1. Two-layer error model
+
+- **Deep library code** (`internal/callgraph`, `internal/scan`, `internal/converter`, `internal/cache`, `internal/rules`, `internal/output`, parsers, loaders) returns plain wrapped errors: `fmt.Errorf("<package-prefix>: ...: %w", err)`. It must **never** import `internal/failure`.
+- **Boundary code** (`internal/cli`, `internal/engine`, `internal/scanner`, `internal/dependency`) is where errors become policy: it wraps incoming errors with `failure.Wrap` / `failure.WrapUnknown`, assigning the `Code` and `Stage`. Already-typed failures pass through untouched.
+- Failure `Code`s are a **stable external contract** consumed by CI parsers — never rename a shipped code. The published taxonomy is [ERROR_CODES.md](ERROR_CODES.md).
+
+Why: deep code stays composable and testable; the boundary is the single place errors become exit codes and JSON payloads.
+
+### 2. Contracts knowledge base (KB)
+
+The type-inference engine consumes YAML knowledge bases under `internal/callgraph/contracts/<ecosystem>/`. **One YAML file = one library version** — adding a library is a new YAML, never a code change. The loader (`contracts.LoadEmbedded`) discovers, validates, and merges all files per ecosystem with these conflict rules:
+
+| Situation | Outcome |
+|-----------|---------|
+| Same method+arity+condition, identical return | Idempotent (no error) |
+| Same method+arity+condition, different return | **Hard error** naming both libraries |
+| Hierarchy `child → [A]` in both libraries | Idempotent |
+| Hierarchy `child → [A]` vs `[B]` (no subset) | **Hard error** naming both libraries |
+| Hierarchy `child → [A]` vs `[A, B]` | Union (subset accepted) |
+
+KB YAML schema version is `"2"` (internal to the loader). It is **independent** of the partner-facing export schemas (callgraph `6.6`, `graph-fragment-1.8`). See [AGENTS.md](../AGENTS.md#knowledge-base-layout-callgraph-inferred-types) for the authoring recipe.
+
+### 3. Detection vs reachability
+
+Detection rules (in [scanoss/crypto_rules](https://github.com/scanoss/crypto_rules)) detect **terminal crypto operations only** and carry standard CycloneDX metadata. They carry no crypto-finder routing concerns — there is no `supporting-call` assetType and no `supportingCall` sentinel; do not reintroduce them.
+
+### 4. Structural supporting-call derivation
+
+Supporting calls (setup/lifecycle/config calls around a crypto object, e.g. `digest.update`/`doFinal`) are **derived from the call graph**, not tagged by rules (`internal/scan/supporting_calls.go`, `deriveObjectLifecycleCalls`). A finding's "object" is the variable its terminal call is invoked on (`ReceiverVar`) or assigned to (`AssignedVar`); its supporting calls are the other calls on that variable, the fluent-chain links (`ChainID`), and the producing constructor. This scales to any library without per-call rules. New-language parsers should populate `ReceiverVar`, `AssignedVar`, `ChainID`, and 1-based `StartCol`/`EndCol` — omitting them degrades gracefully to line-only matching but loses precision on multi-call lines.
+
+### 5. Reachability must never depend on `metadata.api`
+
+`metadata.api` is informational CBOM metadata only. The matched operation's kind is classified from the matched **source text** (`inferMatchedOperationKind`), and the crypto call is located by **position** — match columns intersected with call-node columns, with a fluent-chain-root tie-break and a line-only fallback (`findCryptoCallNode`). A missing or wrong `api` must never zero out a finding's reachability. Do not re-add api-based selection or classification.
+
+## Schema Versioning
+
+Four independent version numbers ship in the outputs — do not conflate them:
+
+| Version | Constant | Current | Bumps when |
+|---------|----------|---------|------------|
+| Interim report format | `entities.InterimFormatVersion` | `1.4` | The findings.json envelope changes |
+| Callgraph export schema | `graphfrag.CallgraphSchemaVersion` | `6.6` | The partner-facing reachability contract changes |
+| Graph-fragment schema | `graphfrag.SchemaVersion` | `graph-fragment-1.8` | The fragment wire format changes |
+| Graph algorithm version | `graphfrag.GraphAlgoVersion` | `graph-algo-1` | Callgraph **construction** changes in a way that alters the structural graph (cache key for `annotate`) |
+
+Every schema bump is recorded in [CHANGELOG.md](../CHANGELOG.md) (a hard repo requirement) and the format details live in [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md).

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,0 +1,89 @@
+# Error Codes
+
+crypto-finder reports terminal failures with a **stable machine-readable code and pipeline stage**. Codes are an external contract consumed by CI parsers and downstream tooling: shipped codes are never renamed (see [AGENTS.md](../AGENTS.md#error-handling)). The source of truth is `internal/failure/error.go`.
+
+## Consuming errors in CI
+
+With `--error-format json`, any failure is emitted to **stderr** as a single JSON payload, and the process exits with code `1`:
+
+```bash
+crypto-finder scan --error-format json /path/to/code 2> error.json
+```
+
+```json
+{
+  "code": "scanner_timeout",
+  "stage": "scan",
+  "retryable": false,
+  "message": "scan timed out after 10m: ...",
+  "details": { "timeout": "10m" },
+  "cause": "context deadline exceeded"
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `code` | Stable failure identifier (table below). Parse on this, never on `message`. |
+| `stage` | Pipeline stage that produced the failure (table below). |
+| `retryable` | Whether retrying the same invocation may succeed. |
+| `message` | Human-readable description (free text, may change between releases). |
+| `details` | Optional structured key/value context (e.g. the offending flag value). |
+| `cause` / `raw_error` | Underlying error text, when available. |
+
+Errors that were never classified surface as `code: "unknown_error"`, `stage: "unknown"`.
+
+Note: `--error-format json` also disables log output and colors so stderr carries only the payload.
+
+## Stages
+
+| Stage | Pipeline phase |
+|-------|----------------|
+| `input` | CLI argument/flag validation |
+| `config` | Configuration, cache, and Java runtime initialization |
+| `rules` | Rule source loading |
+| `scan` | Language detection and scanner execution |
+| `dependency` | Dependency resolution and dependency scanning |
+| `callgraph` | Call graph construction |
+| `export` | Call graph / graph fragment export |
+| `output` | Findings report formatting and writing |
+| `policy` | Post-scan policy decisions (`--fail-on-findings`) |
+| `unknown` | Unclassified |
+
+## Codes
+
+The stage column shows the typical stage; the stage is assigned where the error becomes terminal, so a code can occasionally surface under a different stage.
+
+| Code | Typical stage | Meaning | Typical cause |
+|------|---------------|---------|---------------|
+| `unknown_error` | `unknown` | Unclassified failure | A plain error escaped without boundary wrapping |
+| `invalid_arguments` | `input` | Flag/argument validation failed | Bad flag value, missing required flag, unknown backend/format |
+| `invalid_timeout` | `input` | Unparseable duration | `--timeout` / `--max-stale-age` not in `10m` / `1h` / `30d` / `2w` form |
+| `config_initialization_failed` | `config` | Configuration could not be initialized | Unreadable/invalid config file or environment |
+| `java_runtime_config_invalid` | `config` | Java runtime selection invalid | Bad `--java-jdk-major` / malformed `--java-jdk-home <major>=<path>` |
+| `cache_initialization_failed` | `config` | Rules or findings cache setup failed | Cache dir not writable; `--findings-cache=postgres` without `SCANOSS_FINDINGS_CACHE_DSN`, pool/schema failure |
+| `rules_load_failed` | `rules` | No usable rule source | `--no-remote-rules` without `--rules`/`--rules-dir`; remote ruleset fetch failed with no cache |
+| `scanner_unavailable` | `scan` | Requested scanner not found | `opengrep`/`semgrep` binary not installed or not on `PATH` |
+| `scanner_initialization_failed` | `scan` | Scanner setup failed | Scanner present but could not be prepared for the run |
+| `scanner_execution_failed` | `scan` | Scanner process failed | Non-zero scanner exit, crash, or invalid rule files |
+| `scanner_timeout` | `scan` | Scan exceeded `--timeout` | Target too large for the configured timeout |
+| `scanner_canceled` | `scan` | Scan canceled | Context canceled (e.g. SIGINT) |
+| `scanner_output_parse_failed` | `scan` | Scanner output unreadable | Scanner emitted output the parser could not decode |
+| `language_detection_failed` | `scan` | Language detection failed | Unreadable target tree |
+| `dependency_resolution_failed` | `dependency` | Dependency resolution/scan failed | Missing toolchain, unresolvable manifest, dep scan error |
+| `java_build_tool_unknown` | `dependency` | Java build tool not detected | No `pom.xml` / Gradle build files found |
+| `java_build_tool_ambiguous` | `dependency` | Multiple Java build tools detected | Both Maven and Gradle present without a clear winner |
+| `gradle_tool_missing` | `dependency` | Gradle unavailable | No usable `gradle` / wrapper for dependency export |
+| `gradle_export_failed` | `dependency` | Gradle dependency export failed | Gradle invocation failed or produced unusable output |
+| `gradle_java_incompatible` | `dependency` | Gradle/JDK mismatch | Selected JDK major incompatible with the project's Gradle |
+| `callgraph_build_failed` | `callgraph` | Call graph construction failed | Unsupported ecosystem for export, parse failure |
+| `callgraph_export_failed` | `export` | Export write failed | `--export-callgraph` / `--export-graph-fragment` destination not writable, serialization failure |
+| `output_writer_unavailable` | `output` | No writer for the requested format | Unsupported `--format` value reaching the writer factory |
+| `output_write_failed` | `output` | Report write failed | Output path not writable, disk full |
+| `findings_detected` | `policy` | Findings found with `--fail-on-findings` | Expected CI gate behavior, not an error in the tool |
+
+## Adding a new failure mode
+
+1. Add a `Code` constant in `internal/failure/error.go` (and a `Stage` if it is a new pipeline phase).
+2. Wrap the error at the boundary layer (`internal/cli`, `internal/engine`, `internal/scanner`, `internal/dependency`) — never in deep library code.
+3. Add the code to this table.
+4. Never rename a shipped code.

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -89,9 +89,17 @@ The interim report is the primary findings artifact. It contains finding metadat
 
 ### Call Graph Export
 
-When `--export-callgraph` is enabled, Crypto Finder also writes a separate finding-centric call graph JSON file. This export contains the reachability slices and value-flow details associated with findings from the interim report.
+When `--export-callgraph <file>` is passed, Crypto Finder also writes a separate finding-centric call graph JSON file to `<file>`. This export contains the reachability slices and value-flow details associated with findings from the interim report.
 
-Schema note: call graph export version `6.4` is the current customer-facing reachability contract. Version `6.4` adds `method_role`, `role_provenance`, and `parameter_roles` — contracts-KB-derived method/parameter role classification (`factory`/`config`/`output`/`operation` on `method_role`; per-parameter `operation-determining`/`metadata-contributing`/`none` with a `contributes: {property, derivation}` block on `parameter_roles`). `method_role`/`role_provenance` appear on `crypto_entry_points`; `parameter_roles` appears on `crypto_entry_points` and on the supporting-call declaration, index-aligned with `parameter_types` — never on call-site parameter literals. As of `6.4`, these fields are populated on the live (`--export-callgraph`) and graph-fragment export paths and carried through the stitched/served path (role-bearing `crypto_entry_points` are merged into the served output by `function_key`, enriching an existing reachability entry or appending a `role: operation` catalog entry with no reachable finding). Version `6.3` added the optional per-finding `forward_calls` block — the finding anchor's forward call closure (deduped nodes with `depth`/`crypto_relevant`/`supporting_category`, plus traversed edges whose `entry_call` carries the call-site argument data-flow), emitted only when the stitch runs with `StitchOptions.ForwardClosure`; caps (depth/nodes/edges) are surfaced via `max_depth` and an explicit `truncated` flag, never silently. Version `6.0` removed the legacy `entry_point_index` projection and made `crypto_entry_points[]` canonical. Version `4.3` added Java runtime provenance in `scan_metadata` for JDK-aware platform signature enrichment.
+Schema note: call graph export version **`6.6`** is the current customer-facing reachability contract. The version constant is `pkg/graphfrag.CallgraphSchemaVersion`, and every `6.x` change is documented in [CHANGELOG.md](../CHANGELOG.md). Version history:
+
+- **`6.6`** adds deterministic `forward_calls.ambiguous_calls` groups for fail-closed interface dispatch: completeness state, stable group/candidate IDs, complete callable identities, and preserved call-site argument provenance — without promoting ambiguous candidates to resolved edges.
+- **`6.5`** makes `role: operation` contract methods **supporting-call-only**: they are exported as categorized `supporting_calls` referenced by `supporting_call_ids` (including interface-authored contracts resolved to concrete implementations) and are no longer synthesized as operation-only `crypto_entry_points` in live, fragment, or stitched exports.
+- **`6.4`** adds `method_role`, `role_provenance`, and `parameter_roles` — contracts-KB-derived method/parameter role classification (`factory`/`config`/`output`/`operation` on `method_role`; per-parameter `operation-determining`/`metadata-contributing`/`none` with a `contributes: {property, derivation}` block on `parameter_roles`). `method_role`/`role_provenance` appear on `crypto_entry_points`; `parameter_roles` appears on `crypto_entry_points` and on the supporting-call declaration, index-aligned with `parameter_types` — never on call-site parameter literals. These fields are populated on the live (`--export-callgraph`) and graph-fragment export paths and carried through the stitched/served path.
+- **`6.3`** added the optional per-finding `forward_calls` block — the finding anchor's forward call closure (deduped nodes with `depth`/`crypto_relevant`/`supporting_category`, plus traversed edges whose `entry_call` carries the call-site argument data-flow), emitted only when the stitch runs with `StitchOptions.ForwardClosure`; caps (depth/nodes/edges) are surfaced via `max_depth` and an explicit `truncated` flag, never silently.
+- **`6.2`** exposed `supporting_calls`, `crypto_entry_points`, and `graph_algo_version` end-to-end.
+- **`6.0`** removed the legacy `entry_point_index` projection and made `crypto_entry_points[]` canonical.
+- **`4.3`** added Java runtime provenance in `scan_metadata` for JDK-aware platform signature enrichment.
 
 - Each top-level record stays keyed by `finding_id`, which is the join key back to the interim report.
 - `call_chains` is the primary value-flow structure. Each chain is ordered from the first reachable caller to the function that contains the matched crypto call.
@@ -104,7 +112,7 @@ Schema note: call graph export version `6.4` is the current customer-facing reac
 - Method-call provenance is preserved as `CALL_RESULT` nodes. When the parser can resolve the invoked method, the node also exports `call_target`, and any traceable receiver value is nested under that `CALL_RESULT` via `source_nodes` (for example `CALL_RESULT -> PARAMETER alg -> VALUE SignatureAlgorithm.HS256`).
 - Findings missing a containing function or crypto-call match are still exported with `finding_location` and `unresolved_reason`.
 - `crypto_entry_points[]` is the stitch/API index. Each entry carries `function_key`, canonical/display symbols, aliases, and `reachable_findings[]` / `reachable_supporting_calls[]`.
-- `supporting_calls[]` carries config/lifecycle/context crypto-adjacent calls, such as builder options or parameter setup. These calls are not findings and do not inflate `finding_graphs[]`.
+- `supporting_calls[]` carries config/lifecycle/context crypto-adjacent calls, such as builder options or parameter setup. These calls are not findings and do not inflate `finding_graphs[]`. As of `6.5`, `role: operation` contract methods (the calls where the cryptographic computation actually executes, e.g. block-processing/finalization methods) are also exported here with a category and referenced via `supporting_call_ids`.
 - Constructor joins remain canonical (`<init>`), while display fields and aliases expose IBM-style names such as `com.acme.Factory.Factory`.
 - `entry_point_index` is not emitted by schema `6.0`. Consumers should migrate to `crypto_entry_points[]`.
 
@@ -266,20 +274,35 @@ artifact X?" The pure model and the stitcher that composes fragments live in the
 public package `github.com/scanoss/crypto-finder/pkg/graphfrag`, so downstream
 consumers can use one contract instead of reimplementing schema knowledge.
 
-Current schema version: `graph-fragment-1.3`.
+Current schema version: **`graph-fragment-1.8`** (`pkg/graphfrag.SchemaVersion`).
 
-As of `graph-fragment-1.3`, a fragment is **self-contained enough to reconstruct
+Since `graph-fragment-1.3`, a fragment is **self-contained enough to reconstruct
 the two artifacts a live `--scan-dependencies` run would produce** — see
 *Rendered artifacts* below.
+
+Fragment schema history (all changes are additive; older fragments decode with
+the missing fields empty and are handled fail-closed):
+
+| Version | Change |
+|---------|--------|
+| `1.1` | Per-edge resolution metadata (`resolution`, `declared_type`, `method_name`, `arity`). |
+| `1.2` | Per-edge call-site data-flow (`entry_call`) and full crypto-call identity + asset metadata on `crypto_annotations`. |
+| `1.3` | Customer-facing reachability projections: `crypto_entry_points`, `supporting_calls`, display aliases for constructor symbols. |
+| `1.4` | Call-site object identity (`ReceiverVar`/`AssignedVar`/`ChainID`) and match columns on annotations/supporting calls, enabling cache-side object-lifecycle re-derivation. |
+| `1.5` | `supporting_calls`, `crypto_entry_points`, `graph_algo_version` exposed end-to-end (paired with callgraph schema `6.2`). |
+| `1.6` | Optional `resolved_receiver_type` on internal edges and external calls — lets the stitcher disambiguate interface-dispatch groups with more than one candidate in closure. |
+| `1.7` | `internal_edges_compact` + `internal_edge_strings` — string/key-indexed compact edge encoding to keep large dependency fragments small. |
+| `1.8` | `role: operation` contract methods exported as categorized supporting calls, no longer as operation-only entry points (paired with callgraph schema `6.5`). |
 
 ### Structure
 
 | Field | Description |
 |-------|-------------|
-| `schema_version` | Fragment schema version (currently `graph-fragment-1.3`). |
+| `schema_version` | Fragment schema version (currently `graph-fragment-1.8`). |
 | `scan_metadata` | Ecosystem, root module, tool/rules versions, `graph_algo_version` (callgraph-construction algorithm version; cache key for annotate-only re-annotation), and per-array counts. |
 | `functions[]` | Callable nodes. `key` is the stable function identity (`pkg.(Type).name#arity`); also carries `file_path`, `package`, `type`, `name`, signature, etc. |
 | `internal_edges[]` | Caller→callee edges **within** the component (both functions are in this fragment). Each edge may carry `entry_call` (1.2+, see below). |
+| `internal_edges_compact[]` / `internal_edge_strings[]` | Compact (1.7+) encoding of internal edges: same fields as `internal_edges`, with repeated strings and function keys indexed into `internal_edge_strings` to keep large dependency fragments small. |
 | `external_calls[]` | Calls whose target may live in **another** component; resolved at stitch time against the dependency tree. Each edge may carry `entry_call` (1.2+, see below). |
 | `crypto_annotations[]` | Terminal crypto findings attached to a function. Beyond `function_key`/`finding_id`/`rule_id`/`symbol`, a 1.2+ annotation carries the data-flow and metadata needed to reconstruct a findings entry (see *Crypto annotation fields (1.2+)* below). A component with no crypto still emits a fragment (zero `crypto_annotations`) so it can serve as a bridge in transitive chains. |
 | `supporting_calls[]` | Non-finding config/lifecycle/context calls useful for explaining crypto behavior without increasing finding counts. |
@@ -313,16 +336,16 @@ reconstruct a full findings.json entry for the matched crypto call:
 
 ### Rendered artifacts: `ToCallgraphExport` / `ToFindingsEnvelope`
 
-Because a 1.3 fragment carries per-call data flow, full crypto-annotation,
+Because a 1.3+ fragment carries per-call data flow, full crypto-annotation,
 supporting-call, and entrypoint metadata, `pkg/graphfrag` can render a stitched
 `Result` into the same two artifacts a live `--scan-dependencies` run produces:
 
 - **`Result.ToCallgraphExport(root, meta)`** — renders the stitched result into
-  a schema-6.0 callgraph, equivalent to a live
+  a current-schema callgraph (stamps `CallgraphSchemaVersion`, currently `6.6`), equivalent to a live
   `--scan-dependencies --export-callgraph` run. Dep-component findings get
   `module@version/`-prefixed `finding_id`s, matching live output.
 - **`ToFindingsEnvelope(root, deps, fragments, meta)`** — reconstructs the
-  findings.json v1.3 envelope (asset metadata). Its `finding_id`s are computed
+  findings.json v1.4 envelope (asset metadata). Its `finding_id`s are computed
   with the **same inputs** as `ToCallgraphExport`, so the two agree: consumers
   join assets (envelope) to call chains (callgraph) by `finding_id`.
 
@@ -343,6 +366,7 @@ guesses, and refuse to present the latter as typed reachability proof.
 | `declared_type` | The static/interface type at the call site (e.g. the interface whose method was dispatched). Present on dispatch edges. |
 | `method_name` | The invoked method name, independent of the resolved target. |
 | `arity` | The argument count of the call. |
+| `resolved_receiver_type` | (1.6+) Concrete receiver type resolved by the producer's contracts-KB / return-type inference for an interface-dispatch call site, when available. Lets the stitcher disambiguate a dispatch group with more than one candidate; empty ⇒ fail-closed behavior unchanged. |
 
 `resolution` values:
 
@@ -375,7 +399,7 @@ reported as reachable crypto.
 
 ```json
 {
-  "schema_version": "graph-fragment-1.3",
+  "schema_version": "graph-fragment-1.8",
   "scan_metadata": { "ecosystem": "java", "root_module": "org.bouncycastle:bcpkix-jdk18on", "graph_algo_version": "graph-algo-1", "function_count": 4000, "internal_edge_count": 6417, "external_call_count": 9469, "crypto_operation_count": 160, "supporting_call_count": 12, "crypto_entry_point_count": 42 },
   "functions": [
     { "key": "org.bouncycastle.pkcs.(PKCS8EncryptedPrivateKeyInfo).decryptPrivateKeyInfo#1", "file_path": "org/bouncycastle/pkcs/PKCS8EncryptedPrivateKeyInfo.java" }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) for crypto-finder land in this directory, one file per decision (`NNNN-short-title.md`).
+
+No ADRs have been recorded yet. Until they exist:
+
+- The domain vocabulary lives in the root [CONTEXT.md](../../CONTEXT.md).
+- Architectural invariants and the package map live in [docs/ARCHITECTURE.md](../ARCHITECTURE.md).
+- Partner-facing schema history lives in [CHANGELOG.md](../../CHANGELOG.md) and [docs/OUTPUT_FORMATS.md](../OUTPUT_FORMATS.md).
+
+Domain-modeling workflows create ADRs lazily when an architectural decision is resolved (see [docs/agents/domain.md](../agents/domain.md)).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,6 +1,7 @@
 # Domain Docs
 
-Before exploring, read the root `CONTEXT.md` and relevant ADRs under `docs/adr/`.
+Before exploring, read the root `CONTEXT.md` and relevant ADRs under `docs/adr/`
+(see `docs/adr/README.md`; the directory may contain no ADRs yet).
 
 This repository uses a single-context layout:
 


### PR DESCRIPTION
Documentation overhaul ahead of the team handover. Docs-only — no Go code, no CHANGELOG entries per repo convention.

## Review first (partner-facing)
- `docs/OUTPUT_FORMATS.md` — schema versions corrected to the shipped constants: callgraph export **6.6**, **graph-fragment-1.8**, findings envelope 1.4; 6.x and fragment version histories reconstructed from the CHANGELOG.

## New documents
- `docs/ARCHITECTURE.md` — pipeline sequence (rules → callgraph → reachability → supporting calls → export/annotate), a responsibility map for all internal/ and pkg/ packages, and human-readable versions of the load-bearing invariants (two-layer error model, contracts KB merge rules, structural supporting-call derivation, the metadata.api reachability invariant).
- `docs/ERROR_CODES.md` — the full `failure.Code`/`Stage` taxonomy (24 codes, 10 stages) with the `--error-format json` payload contract. This was declared a stable external contract but had no published surface.

## Also included
- README: all 5 commands documented (including `annotate` and when to use it vs `scan`), full flag reference, current language coverage, rules-repo pointer + local rules dev loop, docs index.
- AGENTS.md: stale schema version and contracts-KB listing fixed; links to the new human-readable docs.
- CONTRIBUTING: `make test-coverage` → `make coverage`/`coverage-check`; test vs test-docker explained.
- `docs/adr/README.md` stub (domain.md referenced a nonexistent directory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the README with Quick Start guidance, installation options, command references, workflows, configuration, and coverage details.
  * Added architecture and machine-readable error-code documentation.
  * Added ADR guidance and expanded documentation navigation.
  * Updated output format references, examples, schema versions, and supporting-call details.
  * Improved contributor guidance for coverage checks, local testing, CI-equivalent tests, and scanner integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->