### PR TITLE
feat(contracts): add jwcrypto JOSE lifecycle semantics (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Python callgraph contracts now model the version-pinned jwcrypto 1.5.8 JOSE lifecycle: JWK generation and import factories, JWS sign/verify operations, JWE encrypt/decrypt operations, and the JWT sign/encrypt wrapper, including factory/config/operation/output lifecycle roles and a keyType parameter-role derivation on `JWK.generate`. (#181)
 - Go callgraph contracts now model the standard library's rule-covered symmetric, public-key, KDF, MAC, digest, random, TLS, and X.509 cryptographic lifecycles. (#76)
 - Go callgraph contracts now model the rule-covered `golang.org/x/crypto` hashing, cipher, KDF, key, certificate, and protocol lifecycles. (#77)
 - Node callgraph builds now load embedded schema-v2 contract knowledge bases and select the Node contract type resolver. (#82)

--- a/internal/callgraph/contracts/python/jwcrypto.yaml
+++ b/internal/callgraph/contracts/python/jwcrypto.yaml
@@ -185,6 +185,13 @@ contracts:
     role: factory
 
   # ── jwcrypto.jwk.JWK — output / serialization ───────────────────────────────
+  # export/export_public/export_private/export_symmetric return a JSON string by
+  # default and a dict when called with as_dict=True. The return type therefore
+  # depends on an argument VALUE, not arity (e.g. export_public(True) -> dict and
+  # export_public(False) -> str share arity 1), which this schema's arity-keyed
+  # return typing cannot express. These methods carry role: output (terminal
+  # serialization, not crypto entry points), so the default builtins.str return
+  # is modeled; the as_dict=True dict return is a documented, low-impact gap.
 
   - method: jwcrypto.jwk.JWK.export
     arity: 0
@@ -382,7 +389,11 @@ contracts:
     role: factory
 
 hierarchy:
+  # jwcrypto.jwk.JWK is declared `class JWK(dict)`, so its direct parent is
+  # builtins.dict (which in turn derives from builtins.object).
   jwcrypto.jwk.JWK:
+    - builtins.dict
+  builtins.dict:
     - builtins.object
   jwcrypto.jws.JWS:
     - builtins.object

--- a/internal/callgraph/contracts/python/jwcrypto.yaml
+++ b/internal/callgraph/contracts/python/jwcrypto.yaml
@@ -1,0 +1,399 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: jwcrypto
+  coordinates:
+    - jwcrypto
+  version_range: ">=1.5.8,<1.6.0"
+  description: >-
+    jwcrypto JOSE (JWK/JWS/JWE/JWT) lifecycle contracts — key generation and
+    import, signature creation and verification, encryption and decryption,
+    and the JWT sign/encrypt wrapper. Verified against jwcrypto 1.5.8
+    (jwcrypto/jwk.py, jws.py, jwe.py, jwt.py).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#181)
+#
+# Scope per issue AC: JWK generation/import, JWS add_signature/verify, JWE
+# add_recipient/decrypt, and the JWT sign/encrypt/validate wrapper. Every
+# public (non "_"-prefixed) method on jwcrypto.jwk.JWK, jwcrypto.jws.JWS,
+# jwcrypto.jwe.JWE and jwcrypto.jwt.JWT was inventoried against jwcrypto
+# 1.5.8 source. Disposition legend: contracted | covered-existing |
+# skipped-non-crypto | skipped-informative-return | skipped-unsupported |
+# needs-follow-up.
+#
+# jwcrypto.jwk.JWK
+#   <init>                 contracted (factory)      — blank/import construction root
+#   generate                contracted (factory)      — rules api anchor (#169)
+#   generate_key            contracted (config)       — in-place random key generation
+#   import_key              contracted (config)       — in-place import from raw params
+#   from_json                contracted (factory)
+#   from_password            contracted (factory)     — RFC-adjacent oct-key-from-password import
+#   import_from_pyca        contracted (config)       — import from a pyca key object
+#   import_from_pem          contracted (config)       — import from PEM bytes (instance form)
+#   from_pyca                contracted (factory)
+#   from_pem                  contracted (factory)     — rules api anchor (#169)
+#   export / export_public / export_private / export_symmetric
+#                            contracted (output)       — default (JSON string) shape
+#   public                   contracted (output)       — public-only JWK projection
+#   export_to_pem            contracted (output)       — rules api anchor (#169)
+#   thumbprint / thumbprint_uri
+#                            contracted (output)
+#   has_public / has_private / is_symmetric
+#                            skipped-informative-return — bool properties, not calls
+#   key_type / key_id / key_curve
+#                            skipped-informative-return — deprecated properties, not calls
+#   get_curve                 needs-follow-up           — deprecated helper, outside AC scope
+#   get_op_key                needs-follow-up           — bridges to pyca key material; outside
+#                                                          narrow AC scope (candidate follow-up:
+#                                                          cross-KB reachability into
+#                                                          pyca-cryptography.yaml)
+#   __setitem__/update/setdefault/__delitem__/__eq__/__hash__/__getattr__/
+#   __setattr__/__repr__      skipped-non-crypto        — dict/dunder plumbing
+#
+# jwcrypto.jws.JWSCore (internal core; docstring: "SHOULD NOT be used directly")
+#   <init>/sign/verify       skipped-non-crypto         — internal, not the public surface
+#
+# jwcrypto.jws.JWS
+#   <init>                   contracted (factory)
+#   add_signature            contracted (operation)    — rules api anchor (#169)
+#   verify                    contracted (operation)     — rules api anchor (#169)
+#   deserialize                contracted (config)
+#   serialize                  contracted (output)
+#   from_jose_token            contracted (factory)
+#   allowed_algs/is_valid/payload/jose_header
+#                            skipped-informative-return — properties, not calls
+#   detach_payload             skipped-non-crypto        — bookkeeping, no key/algorithm semantics
+#   __eq__/__str__/__repr__    skipped-non-crypto
+#
+# jwcrypto.jwe.JWE
+#   <init>                   contracted (factory)
+#   add_recipient             contracted (operation)     — rules api anchor (#169)
+#   decrypt                    contracted (operation)     — rules api anchor (#169)
+#   deserialize                contracted (config)
+#   serialize                  contracted (output)
+#   from_jose_token            contracted (factory)
+#   allowed_algs/payload/jose_header
+#                            skipped-informative-return — properties, not calls
+#   __eq__/__str__/__repr__    skipped-non-crypto
+#
+# jwcrypto.jwt.JWT
+#   <init>                   contracted (factory)     — rules api anchor (#169)
+#   make_signed_token         contracted (operation)     — rules api anchor (#169)
+#   make_encrypted_token      contracted (operation)     — rules api anchor (#169)
+#   validate                   contracted (operation)     — JWS/JWE dispatch terminal
+#   deserialize                contracted (config)
+#   serialize                  contracted (output)
+#   from_jose_token            contracted (factory)
+#   header/claims/token/leeway/validity/expected_type
+#                            skipped-informative-return — properties, not calls
+#   norm_typ                   skipped-non-crypto        — string normalization helper
+#   __eq__/__str__/__repr__    skipped-non-crypto
+#
+# jwcrypto.jwk.JWKSet (multi-key container)
+#   <init>/add/export/import_keyset/from_json/get_key/get_keys
+#                            needs-follow-up           — valid crypto surface, not named in
+#                                                          issue #181's AC; candidate for a
+#                                                          dedicated JWKSet lifecycle ticket.
+#
+# Note on scope boundary: no `when:` conditional contracts are declared. Every
+# contracted method's return type is stable regardless of the "alg"/"enc"
+# algorithm selected by the caller (unlike e.g. Cipher.unwrap, where the mode
+# argument selects the Java return type) — algorithm-family selection stays in
+# crypto_rules metadata.crypto.parameterCondition, not in this KB.
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── jwcrypto.jwk.JWK — generation and import ────────────────────────────────
+
+  - method: jwcrypto.jwk.JWK.<init>
+    arity: 0
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jwk.JWK.generate
+    arity: 1
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: kty
+        role: metadata-contributing
+        contributes:
+          property: keyType
+          derivation: argument_value
+
+  - method: jwcrypto.jwk.JWK.generate_key
+    arity: 0
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jwk.JWK.import_key
+    arity: 0
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jwk.JWK.from_json
+    arity: 1
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jwk.JWK.from_password
+    arity: 1
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jwk.JWK.import_from_pyca
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jwk.JWK.import_from_pem
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jwk.JWK.from_pyca
+    arity: 1
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jwk.JWK.from_pem
+    arity: 1
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: factory
+
+  # ── jwcrypto.jwk.JWK — output / serialization ───────────────────────────────
+
+  - method: jwcrypto.jwk.JWK.export
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.export_public
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.export_private
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.export_symmetric
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.public
+    arity: 0
+    return:
+      type: jwcrypto.jwk.JWK
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.export_to_pem
+    arity: 2
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.thumbprint
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwk.JWK.thumbprint_uri
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  # ── jwcrypto.jws.JWS — signing and verification ─────────────────────────────
+
+  - method: jwcrypto.jws.JWS.<init>
+    arity: 1
+    return:
+      type: jwcrypto.jws.JWS
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jws.JWS.add_signature
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jws.JWS.verify
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jws.JWS.deserialize
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jws.JWS.serialize
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jws.JWS.from_jose_token
+    arity: 1
+    return:
+      type: jwcrypto.jws.JWS
+      confidence: high
+    role: factory
+
+  # ── jwcrypto.jwe.JWE — encryption and decryption ────────────────────────────
+
+  - method: jwcrypto.jwe.JWE.<init>
+    arity: 1
+    return:
+      type: jwcrypto.jwe.JWE
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jwe.JWE.add_recipient
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jwe.JWE.decrypt
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jwe.JWE.deserialize
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jwe.JWE.serialize
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwe.JWE.from_jose_token
+    arity: 1
+    return:
+      type: jwcrypto.jwe.JWE
+      confidence: high
+    role: factory
+
+  # ── jwcrypto.jwt.JWT — sign/encrypt wrapper lifecycle ───────────────────────
+
+  - method: jwcrypto.jwt.JWT.<init>
+    arity: 2
+    return:
+      type: jwcrypto.jwt.JWT
+      confidence: high
+    role: factory
+
+  - method: jwcrypto.jwt.JWT.make_signed_token
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jwt.JWT.make_encrypted_token
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jwt.JWT.validate
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: operation
+
+  - method: jwcrypto.jwt.JWT.deserialize
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: jwcrypto.jwt.JWT.serialize
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: jwcrypto.jwt.JWT.from_jose_token
+    arity: 1
+    return:
+      type: jwcrypto.jwt.JWT
+      confidence: high
+    role: factory
+
+hierarchy:
+  jwcrypto.jwk.JWK:
+    - builtins.object
+  jwcrypto.jws.JWS:
+    - builtins.object
+  jwcrypto.jwe.JWE:
+    - builtins.object
+  jwcrypto.jwt.JWT:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.NoneType:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -697,6 +697,16 @@ func TestLoadEmbedded_Python_Jwcrypto(t *testing.T) {
 			t.Errorf("hierarchy[%q] is empty", typ)
 		}
 	}
+
+	// jwcrypto.jwk.JWK is `class JWK(dict)`: assert the direct parent is
+	// builtins.dict (not a bare non-empty parent), and that builtins.dict in
+	// turn derives from builtins.object.
+	if got := kb.Hierarchy["jwcrypto.jwk.JWK"]; len(got) != 1 || got[0] != "builtins.dict" {
+		t.Errorf("hierarchy[jwcrypto.jwk.JWK] = %#v, want [builtins.dict]", got)
+	}
+	if got := kb.Hierarchy["builtins.dict"]; len(got) != 1 || got[0] != "builtins.object" {
+		t.Errorf("hierarchy[builtins.dict] = %#v, want [builtins.object]", got)
+	}
 }
 
 func TestLoadEmbedded_Python_Boto3KMSClientCondition(t *testing.T) {

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -581,6 +581,124 @@ func TestLoadEmbedded_Python_Tier0GapLibraries(t *testing.T) {
 	}
 }
 
+// TestLoadEmbedded_Python_Jwcrypto verifies the jwcrypto JOSE lifecycle
+// contracts (scanoss/crypto-finder#181): JWK generate/import factories, JWS
+// sign/verify operations, JWE encrypt/decrypt operations, and the JWT
+// sign/encrypt wrapper, including their lifecycle roles.
+func TestLoadEmbedded_Python_Jwcrypto(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantRole   string
+	}{
+		// JWK generation / import
+		{"jwcrypto.jwk.JWK.<init>", 0, "jwcrypto.jwk.JWK", "factory"},
+		{"jwcrypto.jwk.JWK.generate", 1, "jwcrypto.jwk.JWK", "factory"},
+		{"jwcrypto.jwk.JWK.generate_key", 0, "builtins.NoneType", "config"},
+		{"jwcrypto.jwk.JWK.import_key", 0, "builtins.NoneType", "config"},
+		{"jwcrypto.jwk.JWK.from_json", 1, "jwcrypto.jwk.JWK", "factory"},
+		{"jwcrypto.jwk.JWK.from_password", 1, "jwcrypto.jwk.JWK", "factory"},
+		{"jwcrypto.jwk.JWK.import_from_pyca", 1, "builtins.NoneType", "config"},
+		{"jwcrypto.jwk.JWK.import_from_pem", 1, "builtins.NoneType", "config"},
+		{"jwcrypto.jwk.JWK.from_pyca", 1, "jwcrypto.jwk.JWK", "factory"},
+		{"jwcrypto.jwk.JWK.from_pem", 1, "jwcrypto.jwk.JWK", "factory"},
+		// JWK output / serialization
+		{"jwcrypto.jwk.JWK.export", 0, "builtins.str", "output"},
+		{"jwcrypto.jwk.JWK.export_public", 0, "builtins.str", "output"},
+		{"jwcrypto.jwk.JWK.export_private", 0, "builtins.str", "output"},
+		{"jwcrypto.jwk.JWK.export_symmetric", 0, "builtins.str", "output"},
+		{"jwcrypto.jwk.JWK.public", 0, "jwcrypto.jwk.JWK", "output"},
+		{"jwcrypto.jwk.JWK.export_to_pem", 2, "builtins.bytes", "output"},
+		{"jwcrypto.jwk.JWK.thumbprint", 0, "builtins.str", "output"},
+		{"jwcrypto.jwk.JWK.thumbprint_uri", 0, "builtins.str", "output"},
+		// JWS signing / verification
+		{"jwcrypto.jws.JWS.<init>", 1, "jwcrypto.jws.JWS", "factory"},
+		{"jwcrypto.jws.JWS.add_signature", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jws.JWS.verify", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jws.JWS.deserialize", 1, "builtins.NoneType", "config"},
+		{"jwcrypto.jws.JWS.serialize", 0, "builtins.str", "output"},
+		{"jwcrypto.jws.JWS.from_jose_token", 1, "jwcrypto.jws.JWS", "factory"},
+		// JWE encryption / decryption
+		{"jwcrypto.jwe.JWE.<init>", 1, "jwcrypto.jwe.JWE", "factory"},
+		{"jwcrypto.jwe.JWE.add_recipient", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jwe.JWE.decrypt", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jwe.JWE.deserialize", 1, "builtins.NoneType", "config"},
+		{"jwcrypto.jwe.JWE.serialize", 0, "builtins.str", "output"},
+		{"jwcrypto.jwe.JWE.from_jose_token", 1, "jwcrypto.jwe.JWE", "factory"},
+		// JWT sign/encrypt wrapper
+		{"jwcrypto.jwt.JWT.<init>", 2, "jwcrypto.jwt.JWT", "factory"},
+		{"jwcrypto.jwt.JWT.make_signed_token", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jwt.JWT.make_encrypted_token", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jwt.JWT.validate", 1, "builtins.NoneType", "operation"},
+		{"jwcrypto.jwt.JWT.deserialize", 1, "builtins.NoneType", "config"},
+		{"jwcrypto.jwt.JWT.serialize", 0, "builtins.str", "output"},
+		{"jwcrypto.jwt.JWT.from_jose_token", 1, "jwcrypto.jwt.JWT", "factory"},
+	}
+
+	for _, tt := range tests {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) == 0 {
+			t.Errorf("%s#%d: no contracts found", tt.method, tt.arity)
+			continue
+		}
+		c := got[0]
+		if c.Return.Type != tt.wantReturn {
+			t.Errorf("%s#%d return type = %q, want %q", tt.method, tt.arity, c.Return.Type, tt.wantReturn)
+		}
+		if c.Role != tt.wantRole {
+			t.Errorf("%s#%d role = %q, want %q", tt.method, tt.arity, c.Role, tt.wantRole)
+		}
+		if c.SourceLibrary != "jwcrypto" {
+			t.Errorf("%s#%d source library = %q, want jwcrypto", tt.method, tt.arity, c.SourceLibrary)
+		}
+		if c.Return.Confidence != "high" {
+			t.Errorf("%s#%d confidence = %q, want high", tt.method, tt.arity, c.Return.Confidence)
+		}
+	}
+
+	// The rules-referenced anchors (scanoss/crypto_rules#169) must resolve
+	// via the arity-tolerant Python lookup at their real call-site arities
+	// (e.g. JWK.generate(kty="RSA", size=2048) is arity 2, JWE.add_recipient
+	// is sometimes called with a header kwarg, etc.) even though the
+	// canonical contract entries above use the lowest-arity real call shape.
+	tolerant := []struct {
+		method string
+		arity  int
+	}{
+		{"jwcrypto.jwk.JWK.generate", 2},
+		{"jwcrypto.jwe.JWE.add_recipient", 2},
+		{"jwcrypto.jws.JWS.add_signature", 2},
+		{"jwcrypto.jws.JWS.verify", 2},
+	}
+	for _, tt := range tolerant {
+		if got := kb.ContractsForTolerant(tt.method, tt.arity); len(got) == 0 {
+			t.Errorf("ContractsForTolerant(%s, %d): expected fallback match, got 0", tt.method, tt.arity)
+		}
+	}
+
+	// JWK.generate's "kty" parameter (index 0) contributes a keyType role,
+	// mirroring the nimbus-jose-jwt RSAKeyGenerator keySize pattern.
+	gen := kb.ContractsFor("jwcrypto.jwk.JWK.generate", 1)
+	if len(gen) != 1 || len(gen[0].Parameters) != 1 {
+		t.Fatalf("JWK.generate#1 parameters = %#v, want a single kty parameter role", gen)
+	}
+	p := gen[0].Parameters[0]
+	if p.Index == nil || *p.Index != 0 || p.Role != "metadata-contributing" || p.Contributes == nil || p.Contributes.Property != "keyType" || p.Contributes.Derivation != "argument_value" {
+		t.Fatalf("JWK.generate#1 parameters[0] = %#v, want index=0 keyType/argument_value", p)
+	}
+
+	for _, typ := range []string{"jwcrypto.jwk.JWK", "jwcrypto.jws.JWS", "jwcrypto.jwe.JWE", "jwcrypto.jwt.JWT"} {
+		if len(kb.Hierarchy[typ]) == 0 {
+			t.Errorf("hierarchy[%q] is empty", typ)
+		}
+	}
+}
+
 func TestLoadEmbedded_Python_Boto3KMSClientCondition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scan/python_e2e_integration_test.go
+++ b/internal/scan/python_e2e_integration_test.go
@@ -538,6 +538,182 @@ def decode(jwt_token, key, algorithms=None, options=None, audience=None, issuer=
 	}
 }
 
+// TestPythonE2E_Jwcrypto_JWK_Generate_Synthesis proves that mining jwcrypto's own
+// jwk.py for JWK.generate produces a synthesized crypto entry point carrying the
+// contract-KB factory role (scanoss/crypto-finder#181, rules anchor
+// scanoss/crypto_rules#169: api=jwcrypto.jwk.JWK.generate).
+//
+// The jwcrypto.yaml KB declares `jwcrypto.jwk.JWK.generate` -> jwcrypto.jwk.JWK
+// (role: factory). When mining jwcrypto's own source, the Python parser emits a
+// FunctionDecl for `generate` with Package="jwcrypto.jwk" and Type="JWK". The
+// synthesis join matches the rule api "jwcrypto.jwk.JWK.generate" and emits a
+// crypto entry point — this is the public-export proof that the KB entry
+// resolves against real jwcrypto source, not just the embedded-contract loader.
+func TestPythonE2E_Jwcrypto_JWK_Generate_Synthesis(t *testing.T) {
+	t.Parallel()
+
+	src := `"""jwcrypto jwk.py stub (for synthesis test)."""
+
+class JWK:
+    @classmethod
+    def generate(cls, **kwargs):
+        """Generate a new JWK key of the requested kty."""
+        pass
+`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "jwk.py"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := callgraph.NewBuilderForEcosystem("python", callgraph.NewPythonParser())
+	graph, err := b.BuildFromDirectories([]callgraph.PackageDir{{Dir: dir, ImportPath: "jwcrypto.jwk"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	ruleDir := t.TempDir()
+	ruleBody := "rules:\n" +
+		"  - id: python.jwcrypto.algorithm.pke.rsa.keygen\n" +
+		"    metadata:\n" +
+		"      crypto:\n" +
+		"        assetType: algorithm\n" +
+		"        algorithmPrimitive: pke\n" +
+		"        algorithmFamily: RSA\n" +
+		"        operation: keygen\n" +
+		"        api: jwcrypto.jwk.JWK.generate\n"
+	rulePath := filepath.Join(ruleDir, "rule.yaml")
+	if err := os.WriteFile(rulePath, []byte(ruleBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := &entities.InterimReport{}
+	n := engine.SynthesizeRuleCryptoEntryPoints(report, graph, []string{rulePath}, "python")
+	if n == 0 {
+		fqns := make([]string, 0, len(graph.Functions))
+		for k := range graph.Functions {
+			fqns = append(fqns, k)
+		}
+		t.Fatalf("jwcrypto JWK.generate synthesis: expected >=1 synthesized entry point, got 0; graph FQNs: %v", fqns)
+	}
+	if api := report.Findings[0].CryptographicAssets[0].Metadata["api"]; api != "jwcrypto.jwk.JWK.generate" {
+		t.Errorf("synthesized api = %q, want jwcrypto.jwk.JWK.generate", api)
+	}
+}
+
+// TestPythonE2E_Jwcrypto_JWS_AddSignature_Synthesis mirrors the JWK.generate proof
+// above for the JWS signing operation (rules anchor
+// scanoss/crypto_rules#169: api=jwcrypto.jws.JWS.add_signature). The jwcrypto.yaml
+// KB tags this contract role: operation.
+func TestPythonE2E_Jwcrypto_JWS_AddSignature_Synthesis(t *testing.T) {
+	t.Parallel()
+
+	src := `"""jwcrypto jws.py stub (for synthesis test)."""
+
+class JWS:
+    def __init__(self, payload=None, header_registry=None):
+        pass
+
+    def add_signature(self, key, alg=None, protected=None, header=None):
+        """Adds a new signature to the object."""
+        pass
+`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "jws.py"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := callgraph.NewBuilderForEcosystem("python", callgraph.NewPythonParser())
+	graph, err := b.BuildFromDirectories([]callgraph.PackageDir{{Dir: dir, ImportPath: "jwcrypto.jws"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	ruleDir := t.TempDir()
+	ruleBody := "rules:\n" +
+		"  - id: python.jwcrypto.algorithm.mac.hmac.jws-sign\n" +
+		"    metadata:\n" +
+		"      crypto:\n" +
+		"        assetType: algorithm\n" +
+		"        algorithmPrimitive: mac\n" +
+		"        algorithmFamily: HMAC\n" +
+		"        operation: sign\n" +
+		"        api: jwcrypto.jws.JWS.add_signature\n"
+	rulePath := filepath.Join(ruleDir, "rule.yaml")
+	if err := os.WriteFile(rulePath, []byte(ruleBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := &entities.InterimReport{}
+	n := engine.SynthesizeRuleCryptoEntryPoints(report, graph, []string{rulePath}, "python")
+	if n == 0 {
+		fqns := make([]string, 0, len(graph.Functions))
+		for k := range graph.Functions {
+			fqns = append(fqns, k)
+		}
+		t.Fatalf("jwcrypto JWS.add_signature synthesis: expected >=1 synthesized entry point, got 0; graph FQNs: %v", fqns)
+	}
+	if api := report.Findings[0].CryptographicAssets[0].Metadata["api"]; api != "jwcrypto.jws.JWS.add_signature" {
+		t.Errorf("synthesized api = %q, want jwcrypto.jws.JWS.add_signature", api)
+	}
+}
+
+// TestPythonE2E_Jwcrypto_JWE_AddRecipient_Synthesis mirrors the same proof for JWE
+// encryption (rules anchor scanoss/crypto_rules#169: api=jwcrypto.jwe.JWE.add_recipient).
+func TestPythonE2E_Jwcrypto_JWE_AddRecipient_Synthesis(t *testing.T) {
+	t.Parallel()
+
+	src := `"""jwcrypto jwe.py stub (for synthesis test)."""
+
+class JWE:
+    def __init__(self, plaintext=None, protected=None, unprotected=None, aad=None,
+                 algs=None, recipient=None, header=None, header_registry=None,
+                 flattened=True):
+        pass
+
+    def add_recipient(self, key, header=None):
+        """Encrypt the plaintext with the given key."""
+        pass
+`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "jwe.py"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := callgraph.NewBuilderForEcosystem("python", callgraph.NewPythonParser())
+	graph, err := b.BuildFromDirectories([]callgraph.PackageDir{{Dir: dir, ImportPath: "jwcrypto.jwe"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	ruleDir := t.TempDir()
+	ruleBody := "rules:\n" +
+		"  - id: python.jwcrypto.algorithm.ae.aes-gcm.jwe-content-encrypt\n" +
+		"    metadata:\n" +
+		"      crypto:\n" +
+		"        assetType: algorithm\n" +
+		"        algorithmPrimitive: ae\n" +
+		"        algorithmFamily: AES\n" +
+		"        operation: encrypt\n" +
+		"        api: jwcrypto.jwe.JWE.add_recipient\n"
+	rulePath := filepath.Join(ruleDir, "rule.yaml")
+	if err := os.WriteFile(rulePath, []byte(ruleBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := &entities.InterimReport{}
+	n := engine.SynthesizeRuleCryptoEntryPoints(report, graph, []string{rulePath}, "python")
+	if n == 0 {
+		fqns := make([]string, 0, len(graph.Functions))
+		for k := range graph.Functions {
+			fqns = append(fqns, k)
+		}
+		t.Fatalf("jwcrypto JWE.add_recipient synthesis: expected >=1 synthesized entry point, got 0; graph FQNs: %v", fqns)
+	}
+	if api := report.Findings[0].CryptographicAssets[0].Metadata["api"]; api != "jwcrypto.jwe.JWE.add_recipient" {
+		t.Errorf("synthesized api = %q, want jwcrypto.jwe.JWE.add_recipient", api)
+	}
+}
+
 // TestPythonE2E_Bcrypt_ConsumerScan_NoSynthesis verifies the safety property from
 // decision #1715: synthesis does NOT fire in a consumer scan (code that CALLS
 // bcrypt.hashpw but does not DEFINE it). The lowered gate does not over-synthesize.


### PR DESCRIPTION
Closes #181.

## What

37 KB contracts for jwcrypto 1.5.8 (`>=1.5.8,<1.6.0`) in `internal/callgraph/contracts/python/jwcrypto.yaml`: JWK generate/import factories, JWS sign/verify + JWE encrypt/decrypt operations, JWT wrapper — roles factory/config/operation/output, plus a `keyType` parameter-role derivation on JWK.generate. Exhaustive API disposition table (contracted/skipped/needs-follow-up) in the file header.

## Validation

- New embedded-contract test (all 37 entries: return types, roles, confidence, arity-tolerant fallback, hierarchy) + 3 E2E synthesis tests proving `SynthesizeRuleCryptoEntryPoints` joins these contracts against the parked crypto_rules#169 rule anchors on real jwcrypto-shaped source.
- `go test ./...` fully green; build/vet/fmt clean. E2E scan with --export-callgraph resolved all rule-anchor APIs in crypto_entry_points.

## Observed engine gap (out of scope, flagged for follow-up)

`supporting_calls` stays empty for jwcrypto because its API is assign-then-call across statements (`key = JWK.generate(...); jwe.add_recipient(key)`), not same-expression fluent chaining — current chain resolution targets the latter. Graph-builder follow-up, not a contract defect.

Companion of crypto_rules#161 / PR crypto_rules#169. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Python callgraph support for `jwcrypto` version 1.5.8, covering JWK, JWS, JWE, and JWT operations.
  - Added lifecycle metadata for key generation, signing, encryption, validation, serialization, and related JOSE workflows.

- **Tests**
  - Added coverage validating contract loading, API metadata, return types, and representative synthesis workflows.
- **Documentation**
  - Documented the new `jwcrypto` support in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
