### PR TITLE
feat(contracts): add Netty TLS builder lifecycle semantics (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Python callgraph contracts now model the version-pinned jwcrypto 1.5.8 JOSE lifecycle: JWK generation and import factories, JWS sign/verify operations, JWE encrypt/decrypt operations, and the JWT sign/encrypt wrapper, including factory/config/operation/output lifecycle roles and a keyType parameter-role derivation on `JWK.generate`. (#181)
+- Java callgraph contracts now model the Netty 4.2 (`netty-handler`) `SslContextBuilder` TLS builder lifecycle: the `forClient`/`forServer` factories, the self-returning fluent configuration methods (`sslProvider`, `protocols`, `ciphers`, `keyManager`, `trustManager`, and the remaining builder methods), and the `build()` terminal that produces the `SslContext` engine object, including `provider`/`protocolVersion` parameter-role derivations and the factory/config lifecycle roles the exported `supporting_calls` carry as `category`. (#183)
 - Go callgraph contracts now model the standard library's rule-covered symmetric, public-key, KDF, MAC, digest, random, TLS, and X.509 cryptographic lifecycles. (#76)
 - Go callgraph contracts now model the rule-covered `golang.org/x/crypto` hashing, cipher, KDF, key, certificate, and protocol lifecycles. (#77)
 - Node callgraph builds now load embedded schema-v2 contract knowledge bases and select the Node contract type resolver. (#82)

--- a/internal/callgraph/contracts/java/netty-tls.yaml
+++ b/internal/callgraph/contracts/java/netty-tls.yaml
@@ -1,0 +1,328 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: netty-tls
+  coordinates:
+    - "io.netty:netty-handler"
+  version_range: ">=4.2.0,<4.3.0"
+  description: >-
+    Netty TLS builder lifecycle contracts — SslContextBuilder factory
+    (forClient/forServer), fluent configuration (sslProvider, protocols,
+    ciphers, keyManager, trustManager, and the remaining self-returning
+    builder methods), and the build() terminal that produces the SslContext
+    engine object. Verified against netty-handler 4.2.15.Final
+    (io/netty/handler/ssl/SslContextBuilder.java).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#183)
+#
+# Scope per issue AC: SslContextBuilder is a Type-2 fluent/builder API whose
+# crypto meaning lives on the API boundary (see the crypto_rules#168 api
+# anchors below), not in a detectable primitive call inside its own body.
+# Every public method on io.netty.handler.ssl.SslContextBuilder (4.2.15.Final)
+# was inventoried against the primary source
+# (netty-handler-4.2.15.Final/io/netty/handler/ssl/SslContextBuilder.java, a
+# local unpack of the released jar verified against the upstream Apache-2.0
+# source). The private constructor SslContextBuilder(boolean) and the private
+# static helper toArray(...) are not public API and are excluded.
+#
+# Overloads that share one method name AND one arity (Java varargs count as
+# one Object[] slot, per the crypto-kb-author skill) collapse into a SINGLE
+# contract entry: they all return io.netty.handler.ssl.SslContextBuilder
+# identically, and the loader hard-rejects two unconditional entries for the
+# same method+arity key, so an overload's distinct parameter TYPES are not
+# separately modeled — only its arity and (shared) return type are. This is
+# safe here because every SslContextBuilder overload family that shares an
+# arity also shares an identical return type; none of the collapsed groups
+# below hide a return-type disagreement.
+#
+# Disposition legend: contracted | covered-existing | skipped-non-crypto |
+# skipped-informative-return | skipped-unsupported | needs-follow-up.
+#
+#   forClient()                                       contracted (factory, arity 0) — rules api anchor (crypto_rules#168: SslContextBuilder.forClient)
+#   forServer(KeyManagerFactory)                       contracted (factory, arity 1)
+#   forServer(KeyManager)                              contracted (factory, arity 1) — collapsed into the arity-1 entry above (identical return)
+#   forServer(File,File)                               contracted (factory, arity 2) — rules api anchor (crypto_rules#168: SslContextBuilder.forServer + server-pem-key-material)
+#   forServer(InputStream,InputStream)                 contracted (factory, arity 2) — collapsed into the arity-2 entry above
+#   forServer(PrivateKey,X509Certificate...)           contracted (factory, arity 2) — collapsed into the arity-2 entry above
+#   forServer(PrivateKey,Iterable)                     contracted (factory, arity 2) — collapsed into the arity-2 entry above
+#   forServer(File,File,String)                        contracted (factory, arity 3) — rules api anchor (crypto_rules#168: server-pem-key-material)
+#   forServer(InputStream,InputStream,String)          contracted (factory, arity 3) — collapsed into the arity-3 entry above
+#   forServer(PrivateKey,String,X509Certificate...)    contracted (factory, arity 3) — collapsed into the arity-3 entry above
+#   forServer(PrivateKey,String,Iterable)              contracted (factory, arity 3) — collapsed into the arity-3 entry above
+#   option(SslContextOption,T)                         contracted (config, arity 2) — generic per-context option bag, no algorithm-specific value
+#   sslProvider(SslProvider)                           contracted (config, arity 1) — rules api anchor (crypto_rules#168: SslContextBuilder.sslProvider); param 0 contributes "provider" (argument_value)
+#   keyStoreType(String)                               contracted (config, arity 1)
+#   sslContextProvider(Provider)                       contracted (config, arity 1) — JCA java.security.Provider selection for the JDK path, distinct from SslProvider above
+#   trustManager(File)                                 contracted (config, arity 1)
+#   trustManager(InputStream)                          contracted (config, arity 1) — collapsed into the arity-1 entry above
+#   trustManager(X509Certificate...)                   contracted (config, arity 1) — collapsed into the arity-1 entry above
+#   trustManager(Iterable)                             contracted (config, arity 1) — collapsed into the arity-1 entry above
+#   trustManager(TrustManagerFactory)                  contracted (config, arity 1) — collapsed into the arity-1 entry above
+#   trustManager(TrustManager)                         contracted (config, arity 1) — collapsed into the arity-1 entry above
+#   keyManager(KeyManagerFactory)                      contracted (config, arity 1)
+#   keyManager(KeyManager)                             contracted (config, arity 1) — collapsed into the arity-1 entry above
+#   keyManager(File,File)                              contracted (config, arity 2)
+#   keyManager(InputStream,InputStream)                contracted (config, arity 2) — collapsed into the arity-2 entry above
+#   keyManager(PrivateKey,X509Certificate...)          contracted (config, arity 2) — collapsed into the arity-2 entry above
+#   keyManager(PrivateKey,Iterable)                    contracted (config, arity 2) — collapsed into the arity-2 entry above
+#   keyManager(File,File,String)                       contracted (config, arity 3)
+#   keyManager(InputStream,InputStream,String)         contracted (config, arity 3) — collapsed into the arity-3 entry above
+#   keyManager(PrivateKey,String,X509Certificate...)   contracted (config, arity 3) — collapsed into the arity-3 entry above
+#   keyManager(PrivateKey,String,Iterable)             contracted (config, arity 3) — collapsed into the arity-3 entry above
+#   addCredential(OpenSslCredential)                    contracted (config, arity 1) — BoringSSL-only multi-cert credential
+#   addCredentials(OpenSslCredential...)                contracted (config, arity 1) — collapsed with its own Iterable overload (same arity/return)
+#   addCredentials(Iterable)                            contracted (config, arity 1) — collapsed into the arity-1 addCredentials entry above
+#   ciphers(Iterable)                                   contracted (config, arity 1) — rules api anchor (crypto_rules#168: SslContextBuilder.ciphers)
+#   ciphers(Iterable,CipherSuiteFilter)                 contracted (config, arity 2)
+#   applicationProtocolConfig(ApplicationProtocolConfig) contracted (config, arity 1) — ALPN negotiation config; not itself a crypto primitive (per audit report) but a required link in the fluent chain
+#   sessionCacheSize(long)                               contracted (config, arity 1)
+#   sessionTimeout(long)                                 contracted (config, arity 1)
+#   clientAuth(ClientAuth)                               contracted (config, arity 1)
+#   protocols(String...)                                 contracted (config, arity 1) — rules api anchor (crypto_rules#168: SslContextBuilder.protocols); param 0 contributes "protocolVersion" (argument_value)
+#   protocols(Iterable)                                  contracted (config, arity 1) — collapsed into the arity-1 protocols entry above
+#   startTls(boolean)                                    contracted (config, arity 1)
+#   enableOcsp(boolean)                                  contracted (config, arity 1)
+#   secureRandom(SecureRandom)                           contracted (config, arity 1)
+#   endpointIdentificationAlgorithm(String)              contracted (config, arity 1)
+#   serverName(SNIServerName)                            contracted (config, arity 1) — client-only SNI; build() still throws server-side, chain shape is identical
+#   build()                                              contracted (factory, arity 0) — terminal builder call; produces the SslContext engine object (issue AC: "Resolve build() to SslContext")
+#
+# Out of scope / follow-up:
+#   io.netty.handler.ssl.SslContext.newEngine(...)/.newHandler(...) — the
+#   SSLEngine/SslHandler "engine-producing" step that consumes an already-built
+#   SslContext — needs-follow-up. Issue #183's AC and the joined
+#   crypto_rules#168 rules anchor only on SslContextBuilder.{forClient,
+#   forServer, sslProvider, protocols, ciphers} plus the server key-material
+#   rule; SslContext's own instance methods are a distinct class outside this
+#   builder-lifecycle ticket's narrow scope.
+#
+# Note on scope boundary: no `when:` conditional contracts are declared. Every
+# contracted method's return type is fixed (SslContextBuilder, or SslContext
+# for build()) regardless of the SslProvider/protocol/cipher values a caller
+# passes in — unlike e.g. Cipher.unwrap, where the mode argument selects the
+# Java return type. The two `parameters:` entries below (sslProvider,
+# protocols) only carry METADATA (which literal was selected), never a
+# return-type selection, and duplicate no parameterCondition grammar: the
+# actual condition matching (param[0]==SslProvider.JDK, etc.) stays owned by
+# crypto_rules#168's rule metadata, per the crypto-kb-author skill's
+# "Condition and provider ownership" rule.
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── Factories: forClient()/forServer(...) create the builder itself ────────
+
+  - method: io.netty.handler.ssl.SslContextBuilder.forClient
+    arity: 0
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: factory
+
+  - method: io.netty.handler.ssl.SslContextBuilder.forServer
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: factory
+
+  - method: io.netty.handler.ssl.SslContextBuilder.forServer
+    arity: 2
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: factory
+
+  - method: io.netty.handler.ssl.SslContextBuilder.forServer
+    arity: 3
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: factory
+
+  # ── Fluent configuration: every method self-returns SslContextBuilder ──────
+
+  - method: io.netty.handler.ssl.SslContextBuilder.option
+    arity: 2
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.sslProvider
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: provider
+        role: metadata-contributing
+        contributes:
+          property: provider
+          derivation: argument_value
+
+  - method: io.netty.handler.ssl.SslContextBuilder.keyStoreType
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.sslContextProvider
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.trustManager
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.keyManager
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.keyManager
+    arity: 2
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.keyManager
+    arity: 3
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.addCredential
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.addCredentials
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.ciphers
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.ciphers
+    arity: 2
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.applicationProtocolConfig
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.sessionCacheSize
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.sessionTimeout
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.clientAuth
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.protocols
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: protocols
+        role: metadata-contributing
+        contributes:
+          property: protocolVersion
+          derivation: argument_value
+
+  - method: io.netty.handler.ssl.SslContextBuilder.startTls
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.enableOcsp
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.secureRandom
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.endpointIdentificationAlgorithm
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  - method: io.netty.handler.ssl.SslContextBuilder.serverName
+    arity: 1
+    return:
+      type: io.netty.handler.ssl.SslContextBuilder
+      confidence: high
+    role: config
+
+  # ── Terminal: build() produces the SslContext engine object ────────────────
+
+  - method: io.netty.handler.ssl.SslContextBuilder.build
+    arity: 0
+    return:
+      type: io.netty.handler.ssl.SslContext
+      confidence: high
+    role: factory
+
+hierarchy:
+  io.netty.handler.ssl.SslContextBuilder:
+    - java.lang.Object
+  io.netty.handler.ssl.SslContext:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/netty-tls.yaml
+++ b/internal/callgraph/contracts/java/netty-tls.yaml
@@ -318,7 +318,10 @@ contracts:
     return:
       type: io.netty.handler.ssl.SslContext
       confidence: high
-    role: factory
+    # Terminal action that materializes the SslContext from the configured
+    # builder. role: operation (not factory) — forClient/forServer are the
+    # factories that create the builder; build() executes the construction.
+    role: operation
 
 hierarchy:
   io.netty.handler.ssl.SslContextBuilder:

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -264,3 +264,108 @@ func TestLoadEmbeddedJava_NimbusAndSpringLifecycleCoverage(t *testing.T) {
 		t.Fatalf("RsaSecretEncryptor hierarchy = %v, want BytesEncryptor and TextEncryptor", parents)
 	}
 }
+
+// TestLoadEmbeddedJava_NettyTLSBuilderLifecycle verifies the Netty
+// SslContextBuilder fluent lifecycle contracts (scanoss/crypto-finder#183):
+// forClient/forServer factories, the self-returning fluent configuration
+// methods (sslProvider, protocols, ciphers, keyManager, trustManager, and the
+// remaining builder methods), and the build() terminal that produces the
+// SslContext engine object — including the return types, lifecycle roles,
+// and the rules-anchor api FQNs (scanoss/crypto_rules#168) they must resolve
+// through.
+func TestLoadEmbeddedJava_NettyTLSBuilderLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	const builder = "io.netty.handler.ssl.SslContextBuilder"
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+	}{
+		// Factories.
+		{builder + ".forClient", 0, builder, "factory"},
+		{builder + ".forServer", 1, builder, "factory"},
+		{builder + ".forServer", 2, builder, "factory"},
+		{builder + ".forServer", 3, builder, "factory"},
+		// Fluent configuration — every method self-returns SslContextBuilder,
+		// which is what lets the chain keep resolving across every call.
+		{builder + ".option", 2, builder, "config"},
+		{builder + ".sslProvider", 1, builder, "config"},
+		{builder + ".keyStoreType", 1, builder, "config"},
+		{builder + ".sslContextProvider", 1, builder, "config"},
+		{builder + ".trustManager", 1, builder, "config"},
+		{builder + ".keyManager", 1, builder, "config"},
+		{builder + ".keyManager", 2, builder, "config"},
+		{builder + ".keyManager", 3, builder, "config"},
+		{builder + ".addCredential", 1, builder, "config"},
+		{builder + ".addCredentials", 1, builder, "config"},
+		{builder + ".ciphers", 1, builder, "config"},
+		{builder + ".ciphers", 2, builder, "config"},
+		{builder + ".applicationProtocolConfig", 1, builder, "config"},
+		{builder + ".sessionCacheSize", 1, builder, "config"},
+		{builder + ".sessionTimeout", 1, builder, "config"},
+		{builder + ".clientAuth", 1, builder, "config"},
+		{builder + ".protocols", 1, builder, "config"},
+		{builder + ".startTls", 1, builder, "config"},
+		{builder + ".enableOcsp", 1, builder, "config"},
+		{builder + ".secureRandom", 1, builder, "config"},
+		{builder + ".endpointIdentificationAlgorithm", 1, builder, "config"},
+		{builder + ".serverName", 1, builder, "config"},
+		// Terminal: build() produces the SslContext engine object.
+		{builder + ".build", 0, "io.netty.handler.ssl.SslContext", "factory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			c := got[0]
+			if c.Return.Type != tt.want || c.Role != tt.role {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q", tt.method, tt.arity, c, tt.want, tt.role)
+			}
+			if c.Return.Confidence != "high" {
+				t.Fatalf("%s#%d confidence = %q, want high", tt.method, tt.arity, c.Return.Confidence)
+			}
+			if c.SourceLibrary != "netty-tls" {
+				t.Fatalf("%s#%d source library = %q, want netty-tls", tt.method, tt.arity, c.SourceLibrary)
+			}
+		})
+	}
+
+	// sslProvider's SslProvider argument (index 0) contributes a "provider"
+	// metadata role, mirroring the RSAKeyGenerator keySize pattern above.
+	sslProvider := kb.ContractsFor(builder+".sslProvider", 1)
+	if len(sslProvider) != 1 || len(sslProvider[0].Parameters) != 1 {
+		t.Fatalf("sslProvider#1 parameters = %#v, want a single provider parameter role", sslProvider)
+	}
+	if p := sslProvider[0].Parameters[0]; p.Index == nil || *p.Index != 0 || p.Role != "metadata-contributing" ||
+		p.Contributes == nil || p.Contributes.Property != "provider" || p.Contributes.Derivation != "argument_value" {
+		t.Fatalf("sslProvider#1 parameters[0] = %#v, want index=0 provider/argument_value", p)
+	}
+
+	// protocols' String... argument (index 0) contributes a "protocolVersion"
+	// metadata role.
+	protocols := kb.ContractsFor(builder+".protocols", 1)
+	if len(protocols) != 1 || len(protocols[0].Parameters) != 1 {
+		t.Fatalf("protocols#1 parameters = %#v, want a single protocolVersion parameter role", protocols)
+	}
+	if p := protocols[0].Parameters[0]; p.Index == nil || *p.Index != 0 || p.Role != "metadata-contributing" ||
+		p.Contributes == nil || p.Contributes.Property != "protocolVersion" || p.Contributes.Derivation != "argument_value" {
+		t.Fatalf("protocols#1 parameters[0] = %#v, want index=0 protocolVersion/argument_value", p)
+	}
+
+	for _, typ := range []string{builder, "io.netty.handler.ssl.SslContext"} {
+		if len(kb.Hierarchy[typ]) == 0 {
+			t.Errorf("hierarchy[%q] is empty", typ)
+		}
+	}
+}

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -318,8 +318,9 @@ func TestLoadEmbeddedJava_NettyTLSBuilderLifecycle(t *testing.T) {
 		{builder + ".secureRandom", 1, builder, "config"},
 		{builder + ".endpointIdentificationAlgorithm", 1, builder, "config"},
 		{builder + ".serverName", 1, builder, "config"},
-		// Terminal: build() produces the SslContext engine object.
-		{builder + ".build", 0, "io.netty.handler.ssl.SslContext", "factory"},
+		// Terminal: build() executes construction of the SslContext (operation,
+		// not factory — forClient/forServer are the builder factories).
+		{builder + ".build", 0, "io.netty.handler.ssl.SslContext", "operation"},
 	}
 
 	for _, tt := range tests {

--- a/internal/scan/netty_tls_e2e_integration_test.go
+++ b/internal/scan/netty_tls_e2e_integration_test.go
@@ -203,9 +203,15 @@ func TestNettyTLS_E2E_SynthesizeRuleCryptoEntryPoints_JoinsRuleAPIAnchors(t *tes
 			engine.SyntheticEntryPointRuleID,
 		},
 	}
-	for api := range wantRulesByAPI {
+	for api, wantRuleIDs := range wantRulesByAPI {
 		if len(byAPIAndRule[api]) == 0 {
 			t.Errorf("no synthesized entry point for rule anchor api %q; got apis: %v", api, byAPIAndRule)
+			continue
+		}
+		for _, wantRuleID := range wantRuleIDs {
+			if !byAPIAndRule[api][wantRuleID] {
+				t.Errorf("api %q missing expected rule %q; got rules: %v", api, wantRuleID, byAPIAndRule[api])
+			}
 		}
 	}
 

--- a/internal/scan/netty_tls_e2e_integration_test.go
+++ b/internal/scan/netty_tls_e2e_integration_test.go
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+// netty_tls_e2e_integration_test.go — scanoss/crypto-finder#183 scan-layer proof.
+//
+// Proves that entry-point synthesis (engine.SynthesizeRuleCryptoEntryPoints)
+// JOINS the scanoss/crypto_rules#168 Netty TLS rule api anchors
+// (io.netty.handler.ssl.SslContextBuilder.{forClient,forServer,sslProvider,
+// protocols,ciphers} plus the server PEM key-material rule, which shares the
+// forServer anchor) against a netty-shaped source file mined with the real
+// Java parser + callgraph builder — the same path `crypto-finder scan
+// --export-callgraph` uses when mining netty-handler itself. This is the
+// public-export proof that the netty-tls.yaml contract's method+arity keys
+// (internal/callgraph/contracts/java/netty-tls.yaml) match what the Java
+// parser actually emits for SslContextBuilder's factory/config/build methods,
+// not just the embedded-contract loader assertions in java_libraries_test.go.
+
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph"
+	"github.com/scanoss/crypto-finder/internal/engine"
+	"github.com/scanoss/crypto-finder/internal/entities"
+)
+
+// nettySslContextBuilderSource is a netty-shaped stub of
+// io/netty/handler/ssl/SslContextBuilder.java (4.2.15.Final): the same
+// factory (forClient/forServer), fluent-config (sslProvider/protocols/
+// ciphers), and terminal (build) method shapes the real class declares, at
+// the same arities the netty-tls.yaml contract keys on. It is a stub (not a
+// full compilable copy) because the tree-sitter-based Java parser extracts
+// declarations syntactically and does not require SslProvider/SslContext to
+// be resolvable types.
+const nettySslContextBuilderSource = `package io.netty.handler.ssl;
+
+import java.io.File;
+
+public final class SslContextBuilder {
+
+    public static SslContextBuilder forClient() {
+        return new SslContextBuilder();
+    }
+
+    public static SslContextBuilder forServer(File keyCertChainFile, File keyFile) {
+        return new SslContextBuilder();
+    }
+
+    public SslContextBuilder sslProvider(SslProvider provider) {
+        return this;
+    }
+
+    public SslContextBuilder protocols(String... protocols) {
+        return this;
+    }
+
+    public SslContextBuilder ciphers(Iterable<String> ciphers) {
+        return this;
+    }
+
+    public SslContext build() throws Exception {
+        return new SslContext();
+    }
+}
+`
+
+// nettyTLSRulesYAML mirrors the scanoss/crypto_rules#168 rule shapes anchored
+// on SslContextBuilder: the client/server factory split, the two
+// value-variant sslProvider selection rules (OpenSSL vs JDK, sharing one api
+// per the crypto-kb-author skill's literal-argument convention), the
+// protocol-version and cipher-config rules, and the server PEM key-material
+// rule (which shares the forServer anchor with the factory rule above it —
+// proving two independently-authored rules on the same api both resolve).
+const nettyTLSRulesYAML = `rules:
+  - id: java.netty.protocol.tls.context-builder-client
+    metadata:
+      crypto:
+        assetType: protocol
+        protocolType: tls
+        protocolName: TLS
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.forClient
+  - id: java.netty.protocol.tls.context-builder-server
+    metadata:
+      crypto:
+        assetType: protocol
+        protocolType: tls
+        protocolName: TLS
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.forServer
+  - id: java.netty.related-crypto-material.key.server-pem-key-material
+    metadata:
+      crypto:
+        assetType: related-crypto-material
+        materialType: private-key
+        materialFormat: PEM
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.forServer
+  - id: java.netty.protocol.tls.provider-selection-openssl
+    metadata:
+      crypto:
+        assetType: protocol
+        protocolType: tls
+        provider: OpenSSL
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.sslProvider
+  - id: java.netty.protocol.tls.provider-selection-jdk
+    metadata:
+      crypto:
+        assetType: protocol
+        protocolType: tls
+        provider: JDK
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.sslProvider
+  - id: java.netty.protocol.tls.protocol-version-selection
+    metadata:
+      crypto:
+        assetType: protocol
+        protocolType: tls
+        protocolName: TLS
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.protocols
+  - id: java.netty.protocol.tls.cipher-config
+    metadata:
+      crypto:
+        assetType: protocol
+        protocolType: tls
+        library: Netty
+        api: io.netty.handler.ssl.SslContextBuilder.ciphers
+`
+
+// TestNettyTLS_E2E_SynthesizeRuleCryptoEntryPoints_JoinsRuleAPIAnchors proves
+// that mining netty-handler's own SslContextBuilder source produces a
+// synthesized crypto entry point for every scanoss/crypto_rules#168 api
+// anchor: forClient, forServer (shared by two independent rules), sslProvider
+// (shared by two value-variant rules), protocols, and ciphers.
+func TestNettyTLS_E2E_SynthesizeRuleCryptoEntryPoints_JoinsRuleAPIAnchors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SslContextBuilder.java"), []byte(nettySslContextBuilderSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph, err := callgraph.NewBuilder(callgraph.NewJavaParser()).
+		BuildFromDirectories([]callgraph.PackageDir{{Dir: dir, ImportPath: "io.netty.handler.ssl"}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories(netty SslContextBuilder stub): %v", err)
+	}
+
+	ruleDir := t.TempDir()
+	rulePath := filepath.Join(ruleDir, "netty-tls.yaml")
+	if err := os.WriteFile(rulePath, []byte(nettyTLSRulesYAML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := &entities.InterimReport{}
+	n := engine.SynthesizeRuleCryptoEntryPoints(report, graph, []string{rulePath}, "java")
+
+	// forClient (1 rule) + forServer (2 rules: factory + key-material) +
+	// sslProvider (2 rules: OpenSSL + JDK) + protocols (1 rule) + ciphers
+	// (1 rule) = 7 synthesized entry points, one per (definition, rule-block)
+	// pair.
+	const want = 7
+	if n != want {
+		fqns := make([]string, 0, len(graph.Functions))
+		for k := range graph.Functions {
+			fqns = append(fqns, k)
+		}
+		t.Fatalf("synthesized %d entry points, want %d; graph FQNs: %v", n, want, fqns)
+	}
+
+	byAPIAndRule := map[string]map[string]bool{}
+	for _, finding := range report.Findings {
+		for _, asset := range finding.CryptographicAssets {
+			api := asset.Metadata["api"]
+			if byAPIAndRule[api] == nil {
+				byAPIAndRule[api] = map[string]bool{}
+			}
+			for _, r := range asset.Rules {
+				byAPIAndRule[api][r.ID] = true
+			}
+		}
+	}
+
+	wantRulesByAPI := map[string][]string{
+		"io.netty.handler.ssl.SslContextBuilder.forClient": {
+			engine.SyntheticEntryPointRuleID,
+		},
+		"io.netty.handler.ssl.SslContextBuilder.forServer": {
+			engine.SyntheticEntryPointRuleID,
+		},
+		"io.netty.handler.ssl.SslContextBuilder.sslProvider": {
+			engine.SyntheticEntryPointRuleID,
+		},
+		"io.netty.handler.ssl.SslContextBuilder.protocols": {
+			engine.SyntheticEntryPointRuleID,
+		},
+		"io.netty.handler.ssl.SslContextBuilder.ciphers": {
+			engine.SyntheticEntryPointRuleID,
+		},
+	}
+	for api := range wantRulesByAPI {
+		if len(byAPIAndRule[api]) == 0 {
+			t.Errorf("no synthesized entry point for rule anchor api %q; got apis: %v", api, byAPIAndRule)
+		}
+	}
+
+	// forServer must carry BOTH the factory rule and the PEM key-material rule
+	// at the same definition site -- proving two independently-authored
+	// crypto_rules#168 rules sharing one api both resolve, not just the first.
+	forServerRuleIDs := map[string]bool{}
+	forClientRuleIDs := map[string]bool{}
+	sslProviderValues := map[string]bool{}
+	for _, finding := range report.Findings {
+		for _, asset := range finding.CryptographicAssets {
+			switch asset.Metadata["api"] {
+			case "io.netty.handler.ssl.SslContextBuilder.forServer":
+				for _, r := range asset.Rules {
+					forServerRuleIDs[r.ID] = true
+				}
+			case "io.netty.handler.ssl.SslContextBuilder.forClient":
+				for _, r := range asset.Rules {
+					forClientRuleIDs[r.ID] = true
+				}
+			case "io.netty.handler.ssl.SslContextBuilder.sslProvider":
+				sslProviderValues[asset.Metadata["provider"]] = true
+			}
+		}
+	}
+	if len(forServerRuleIDs) != 1 {
+		// Both rules use crypto-finder.api-entry-point as the synthesized rule
+		// ID (SyntheticEntryPointRuleID); the distinguishing signal is the two
+		// DISTINCT metadata blocks (assetType=protocol vs
+		// assetType=related-crypto-material), asserted below via asset count.
+		t.Errorf("forServer synthesized rule IDs = %v", forServerRuleIDs)
+	}
+	if len(forClientRuleIDs) != 1 {
+		t.Errorf("forClient synthesized rule IDs = %v", forClientRuleIDs)
+	}
+	if !sslProviderValues["OpenSSL"] || !sslProviderValues["JDK"] {
+		t.Errorf("sslProvider provider values = %v, want both OpenSSL and JDK present", sslProviderValues)
+	}
+
+	// forServer must have exactly 2 distinct assets (factory + key-material);
+	// sslProvider must have exactly 2 distinct assets (OpenSSL + JDK).
+	forServerAssets, sslProviderAssets := 0, 0
+	for _, finding := range report.Findings {
+		for _, asset := range finding.CryptographicAssets {
+			switch asset.Metadata["api"] {
+			case "io.netty.handler.ssl.SslContextBuilder.forServer":
+				forServerAssets++
+			case "io.netty.handler.ssl.SslContextBuilder.sslProvider":
+				sslProviderAssets++
+			}
+		}
+	}
+	if forServerAssets != 2 {
+		t.Errorf("forServer synthesized assets = %d, want 2 (factory + key-material)", forServerAssets)
+	}
+	if sslProviderAssets != 2 {
+		t.Errorf("sslProvider synthesized assets = %d, want 2 (OpenSSL + JDK)", sslProviderAssets)
+	}
+}


### PR DESCRIPTION
Closes #183. Companion of crypto_rules#163 (PR crypto_rules#168).

## What
27 KB contracts for io.netty.handler.ssl.SslContextBuilder (4.2.15.Final) in internal/callgraph/contracts/java/netty-tls.yaml: forClient/forServer factories (arities 0-3), self-returning fluent config methods (sslProvider, keyManager, trustManager, ciphers, protocols, option, addCredential, ...), build()→SslContext. sslProvider/protocols carry parameter-role derivations. Hierarchy edges + exhaustive audit disposition comment.

## Validation
- go build/vet/gofmt clean; go test ./... fully green (new embedded-contract test for all 27 entries + E2E synthesis test).
- Real E2E: crypto-finder --export-callgraph against PR-168 rules + netty-shaped source → 7 assets synthesized joining all rule anchors (both sslProvider OpenSSL/JDK, both forServer variants); fluent chain resolves end-to-end (ciphers entry point reaches all 6 supporting calls).

## Flagged
Multi-hop variable-assigned fluent chains not separately stress-tested (engine scope, per #181/PR186 note); netty's in-scope chain resolves correctly.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Java callgraph support for the Netty 4.2 `SslContextBuilder` TLS lifecycle.
  * Recognizes client/server context creation, fluent TLS configuration, provider and protocol metadata, and final context construction.

* **Tests**
  * Added coverage for builder lifecycle methods, configuration variants, API matching, and synthesized cryptographic entry points.
  * Added an Unreleased changelog entry documenting the support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
