### PR TITLE
 feat(contracts): add Python RULE_ONLY backlog lifecycle semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Python callgraph contracts now model the python-rsa 4.x key-pair generation, PKCS#1 encryption, signing, and key-serialization lifecycles. (#208)
+- Python callgraph contracts now model the python-ecdsa 0.19 SigningKey/VerifyingKey generation, signing, verification, serialization, and ECDH key-agreement lifecycles. (#208)
+- Python callgraph contracts now model the python-jose 3.5 JWT/JWS/JWE operations and JWK key-construction lifecycles. (#208)
+- Python callgraph contracts now model the Authlib 1.6 JOSE serialization, JWT encode/decode, and JsonWebKey generation and import lifecycles. (#208)
+- Python callgraph contracts now model the hvac 2.4 Vault client construction and Transit/Transform secrets-engine key-management and crypto-operation lifecycles. (#208)
+- Python callgraph contracts now model the google-cloud-kms 3.x synchronous and asynchronous client construction, remote encryption, signing, MAC, KEM, random-bytes, and key-lifecycle operations. (#208)
+
 ## [0.18.0] - 2026-08-10
 
 ### Added

--- a/internal/callgraph/contracts/python/authlib.yaml
+++ b/internal/callgraph/contracts/python/authlib.yaml
@@ -1,0 +1,515 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: authlib
+  coordinates:
+    - Authlib
+  version_range: ">=1.0,<2.0"
+  description: >-
+    Authlib JOSE lifecycle contracts — JWS/JWE serialization and
+    deserialization, JWT encode/decode (class and module-level instance), and
+    JsonWebKey/Key generation and import. Verified against Authlib 1.6.12
+    (authlib/jose/rfc7515, rfc7516, rfc7517, rfc7518, rfc7519, rfc8037).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#208)
+#
+# Scope: the authlib.jose public surface (authlib/jose/__init__.py exports).
+# OAuth/OIDC modules are out of scope (no direct crypto terminals; they
+# delegate to jose). Every public (non "_"-prefixed) method of
+# JsonWebSignature, JsonWebEncryption, JsonWebToken (and its module-level
+# `jwt` instance), JsonWebKey, Key/OctKey/RSAKey/ECKey/OKPKey and KeySet was
+# inventoried against the Authlib 1.6.12 wheel source. Disposition legend:
+# contracted | covered-existing | skipped-non-crypto |
+# skipped-informative-return | skipped-unsupported | needs-follow-up.
+#
+# IMPORTANT — namespace discipline vs pyjwt/python-jose: authlib call sites
+# resolve to `authlib.jose.*` (`from authlib.jose import jwt` →
+# authlib.jose.jwt.encode). The bare `jwt.encode` FQN belongs to PyJWT
+# (pyjwt.yaml) and MUST NOT be declared here: authlib's encode returns BYTES
+# while PyJWT's returns str, so a bare declaration would hard-fail the
+# cross-library merge.
+#
+# authlib.jose.JsonWebSignature (rfc7515/jws.py)
+#   <init>                    contracted (factory)     — attr-call + <init> spellings
+#   serialize_compact         contracted (operation)   — rules api anchor; returns bytes
+#   serialize_json            contracted (operation)   — rules api anchor; returns dict
+#   serialize                 contracted (operation)   — compact/JSON dispatcher; modeled
+#                                                         as the dominant compact (bytes)
+#   deserialize_compact/_json/deserialize
+#                             contracted (operation)   — JWSObject is a dict subclass;
+#                                                         modeled as builtins.dict
+#   register_algorithm        contracted (config)
+#
+# authlib.jose.JsonWebEncryption (rfc7516/jwe.py)
+#   <init>                    contracted (factory)     — rules api anchor; attr + <init>
+#   serialize_compact         contracted (operation)   — rules api anchor; returns bytes
+#   serialize_json            contracted (operation)   — returns dict
+#   serialize                 contracted (operation)   — modeled as compact (bytes)
+#   deserialize_compact/_json/deserialize
+#                             contracted (operation)   — {"header", "payload"} dict
+#   register_algorithm        contracted (config)
+#   parse_json                skipped-non-crypto       — JSON shape parsing, no crypto
+#
+# authlib.jose.JsonWebToken (rfc7519/jwt.py) and module-level instance
+#   <init>                    contracted (factory)     — rules api anchor; algorithms
+#                                                         allow-list is REQUIRED (arity 1)
+#   encode                    contracted (operation)   — rules api anchor; returns BYTES
+#   decode                    contracted (operation)   — JWTClaims is a dict subclass;
+#                                                         modeled as builtins.dict
+#   authlib.jose.jwt.encode/decode
+#                             contracted (operation)   — pre-instantiated module instance
+#                                                         (authlib/jose/__init__.py); same
+#                                                         semantics as the class methods
+#   check_sensitive_data      skipped-non-crypto       — claims hygiene check
+#
+# authlib.jose.JsonWebKey (rfc7517/jwk.py; pure classmethod dispatcher)
+#   generate_key              contracted (factory)     — kty argument selects the key
+#                                                         class; modeled as the shared
+#                                                         authlib.jose.Key base
+#   import_key                contracted (factory)     — rules api anchor
+#   import_key_set            contracted (factory)
+#
+# Concrete key classes (rfc7518, rfc8037)
+#   OctKey/RSAKey/ECKey/OKPKey.generate_key
+#                             contracted (factory)     — precise per-class return types
+#   OctKey/RSAKey/ECKey/OKPKey.import_key
+#                             contracted (factory)
+#   ECKey/OKPKey.exchange_shared_key
+#                             contracted (operation)   — ECDH/X25519/X448 shared secret
+#   RSAKey.import_dict_key    skipped-non-crypto       — internal dict-import override
+#                                                         reached via import_key
+#   OctKey/AsymmetricKey.get_op_key
+#                             needs-follow-up          — returns a pyca cryptography key
+#                                                         object; candidate for cross-KB
+#                                                         reachability into
+#                                                         pyca-cryptography.yaml
+#
+# Shared key surface (declared once on authlib.jose.Key per KB convention;
+# as_pem/as_der/as_bytes/as_dict are defined on AsymmetricKey but reached
+# through Key-typed values produced by JsonWebKey.import_key/generate_key).
+# KNOWN ENGINE GAP (e2e-verified, issue #208): fluent-chain callee rewriting
+# (resolveChainLinkCallees) looks up <returnType>.<method> without walking
+# kb.Hierarchy, so a chain rooted at a CONCRETE factory
+# (RSAKey.generate_key().as_pem()) does not resolve these base-declared
+# methods; chains rooted at JsonWebKey.import_key/generate_key (which return
+# the Key base type) do. Export-time role categorization honors the hierarchy
+# (typeOrAncestor), so per KB convention the contracts stay on the base
+# rather than being duplicated onto the four concrete classes.
+#   thumbprint                contracted (operation)   — RFC 7638 SHA-256 thumbprint
+#   as_json                   contracted (output)
+#   as_dict                   contracted (output)
+#   as_bytes/as_pem/as_der    contracted (output)
+#   tokens / kid properties   skipped-informative-return — properties, not calls
+#   check_key_op              skipped-non-crypto       — key-op policy validation
+#
+# authlib.jose.KeySet (rfc7517/key_set.py)
+#   <init>                    contracted (factory)
+#   find_by_kid               contracted (output)
+#   as_dict / as_json         contracted (output)
+#
+# Deprecated authlib.jose.jwk module (loads/dumps shims)
+#                             skipped-non-crypto       — deprecated aliases over
+#                                                         JsonWebKey.import_key
+#
+# Note on `when:` conditionals: none are declared. The "alg"/"enc" header
+# values and the kty argument select crypto algorithms and key classes, never
+# a different Python return type at the granularity this KB models (the shared
+# authlib.jose.Key base covers the kty dispatch).
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── JsonWebSignature ───────────────────────────────────────────────────────
+
+  # `import authlib.jose; authlib.jose.JsonWebSignature(...)` — attr spelling.
+  - method: authlib.jose.JsonWebSignature
+    arity: 0
+    return:
+      type: authlib.jose.JsonWebSignature
+      confidence: high
+    role: factory
+
+  # `from authlib.jose import JsonWebSignature; JsonWebSignature(...)`.
+  - method: authlib.jose.JsonWebSignature.<init>
+    arity: 0
+    return:
+      type: authlib.jose.JsonWebSignature
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.JsonWebSignature.register_algorithm
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: authlib.jose.JsonWebSignature.serialize_compact
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebSignature.serialize_json
+    arity: 3
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  # serialize dispatches compact vs JSON on the header shape; the dominant
+  # compact path (bytes) is modeled.
+  - method: authlib.jose.JsonWebSignature.serialize
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebSignature.deserialize_compact
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebSignature.deserialize_json
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebSignature.deserialize
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  # ── JsonWebEncryption ──────────────────────────────────────────────────────
+
+  - method: authlib.jose.JsonWebEncryption
+    arity: 0
+    return:
+      type: authlib.jose.JsonWebEncryption
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.JsonWebEncryption.<init>
+    arity: 0
+    return:
+      type: authlib.jose.JsonWebEncryption
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.JsonWebEncryption.register_algorithm
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: authlib.jose.JsonWebEncryption.serialize_compact
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebEncryption.serialize_json
+    arity: 3
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebEncryption.serialize
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebEncryption.deserialize_compact
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebEncryption.deserialize_json
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebEncryption.deserialize
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  # ── JsonWebToken and the module-level jwt instance ─────────────────────────
+
+  - method: authlib.jose.JsonWebToken
+    arity: 1
+    return:
+      type: authlib.jose.JsonWebToken
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.JsonWebToken.<init>
+    arity: 1
+    return:
+      type: authlib.jose.JsonWebToken
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.JsonWebToken.encode
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.JsonWebToken.decode
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  # Module-level pre-instantiated `jwt` (authlib/jose/__init__.py):
+  # `from authlib.jose import jwt; jwt.encode(header, payload, key)`.
+  - method: authlib.jose.jwt.encode
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.jwt.decode
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  # ── JsonWebKey — key generation and import ─────────────────────────────────
+
+  - method: authlib.jose.JsonWebKey.generate_key
+    arity: 2
+    return:
+      type: authlib.jose.Key
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: kty
+        role: metadata-contributing
+        contributes:
+          property: keyType
+          derivation: argument_value
+
+  - method: authlib.jose.JsonWebKey.import_key
+    arity: 1
+    return:
+      type: authlib.jose.Key
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.JsonWebKey.import_key_set
+    arity: 1
+    return:
+      type: authlib.jose.KeySet
+      confidence: high
+    role: factory
+
+  # ── concrete key classes ───────────────────────────────────────────────────
+
+  - method: authlib.jose.OctKey.generate_key
+    arity: 0
+    return:
+      type: authlib.jose.OctKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.OctKey.import_key
+    arity: 1
+    return:
+      type: authlib.jose.OctKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.RSAKey.generate_key
+    arity: 0
+    return:
+      type: authlib.jose.RSAKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.RSAKey.import_key
+    arity: 1
+    return:
+      type: authlib.jose.RSAKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.ECKey.generate_key
+    arity: 0
+    return:
+      type: authlib.jose.ECKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.ECKey.import_key
+    arity: 1
+    return:
+      type: authlib.jose.ECKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.ECKey.exchange_shared_key
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.OKPKey.generate_key
+    arity: 0
+    return:
+      type: authlib.jose.OKPKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.OKPKey.import_key
+    arity: 1
+    return:
+      type: authlib.jose.OKPKey
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.OKPKey.exchange_shared_key
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  # ── shared key surface (authlib.jose.Key base) ─────────────────────────────
+
+  - method: authlib.jose.Key.thumbprint
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: operation
+
+  - method: authlib.jose.Key.as_json
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  - method: authlib.jose.Key.as_dict
+    arity: 0
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: authlib.jose.Key.as_bytes
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: authlib.jose.Key.as_pem
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: authlib.jose.Key.as_der
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  # ── KeySet ─────────────────────────────────────────────────────────────────
+
+  - method: authlib.jose.KeySet
+    arity: 1
+    return:
+      type: authlib.jose.KeySet
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.KeySet.<init>
+    arity: 1
+    return:
+      type: authlib.jose.KeySet
+      confidence: high
+    role: factory
+
+  - method: authlib.jose.KeySet.find_by_kid
+    arity: 1
+    return:
+      type: authlib.jose.Key
+      confidence: high
+    role: output
+
+  - method: authlib.jose.KeySet.as_dict
+    arity: 0
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: authlib.jose.KeySet.as_json
+    arity: 0
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+hierarchy:
+  authlib.jose.OctKey:
+    - authlib.jose.Key
+  authlib.jose.RSAKey:
+    - authlib.jose.AsymmetricKey
+  authlib.jose.ECKey:
+    - authlib.jose.AsymmetricKey
+  authlib.jose.OKPKey:
+    - authlib.jose.AsymmetricKey
+  authlib.jose.AsymmetricKey:
+    - authlib.jose.Key
+  authlib.jose.Key:
+    - builtins.object
+  authlib.jose.JsonWebSignature:
+    - builtins.object
+  authlib.jose.JsonWebEncryption:
+    - builtins.object
+  authlib.jose.JsonWebToken:
+    - builtins.object
+  authlib.jose.KeySet:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.dict:
+    - builtins.object
+  builtins.NoneType:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/ecdsa.yaml
+++ b/internal/callgraph/contracts/python/ecdsa.yaml
@@ -1,0 +1,427 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: ecdsa
+  coordinates:
+    - ecdsa
+  version_range: ">=0.18,<1.0"
+  description: >-
+    python-ecdsa lifecycle contracts — SigningKey/VerifyingKey generation,
+    loading, signing, verification, serialization, and the ECDH key-agreement
+    wrapper. Verified against ecdsa 0.19.2 (ecdsa/keys.py, ecdsa/ecdh.py).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#208)
+#
+# Scope: the caller-visible surface re-exported by ecdsa/__init__.py —
+# SigningKey, VerifyingKey (keys.py) and ECDH (ecdh.py). Every public
+# (non "_"-prefixed) method was inventoried against the ecdsa 0.19.2 wheel
+# source. Disposition legend: contracted | covered-existing |
+# skipped-non-crypto | skipped-informative-return | skipped-unsupported |
+# needs-follow-up.
+#
+# ecdsa.SigningKey (keys.py; direct SigningKey() raises — factories only)
+#   generate                          contracted (factory)   — rules api anchor;
+#                                                              default curve NIST192p,
+#                                                              default hash sha1
+#   from_secret_exponent              contracted (factory)   — rules api anchor
+#   from_string                       contracted (factory)   — rules api anchor
+#   from_pem / from_der               contracted (factory)   — rules api anchors
+#   sign                              contracted (operation) — rules api anchor
+#   sign_deterministic                contracted (operation) — rules api anchor (RFC 6979)
+#   sign_digest                       contracted (operation) — rules api anchor
+#   sign_digest_deterministic         contracted (operation) — rules api anchor
+#   sign_number                       contracted (operation) — raw (r, s) tuple
+#   get_verifying_key                 contracted (output)    — extracts the paired
+#                                                              VerifyingKey
+#   to_string / to_pem / to_der / to_ssh
+#                                     contracted (output)    — key-material serialization
+#   privkey / verifying_key / curve / default_hashfunc / baselen attributes
+#                                     skipped-informative-return — attributes, not calls
+#
+# ecdsa.VerifyingKey (keys.py; direct VerifyingKey() raises — factories only)
+#   from_string / from_pem / from_der contracted (factory)   — rules api anchors
+#   from_public_point                 contracted (factory)   — rules api anchor
+#   from_public_key_recovery          contracted (factory)   — returns a LIST of
+#   from_public_key_recovery_with_digest                        candidate keys; modeled
+#                                     contracted (factory)      as builtins.list
+#   verify / verify_digest            contracted (operation) — rules api anchors; return
+#                                                              True or raise
+#                                                              BadSignatureError
+#   precompute                        skipped-unsupported    — returns None and only
+#                                                              mutates internal tables;
+#                                                              no lifecycle information
+#   to_string / to_pem / to_der / to_ssh
+#                                     contracted (output)
+#   pubkey / curve / default_hashfunc attributes
+#                                     skipped-informative-return — attributes, not calls
+#
+# ecdsa.ECDH (ecdh.py; the only directly-constructed class)
+#   <init>                            contracted (factory)   — attr-call and <init>
+#                                                              spellings
+#   generate_private_key              contracted (factory)   — generates own key pair,
+#                                                              returns own public key
+#   load_private_key[_bytes|_der|_pem]
+#                                     contracted (config)    — mutates the ECDH object,
+#                                                              returns own public key
+#   load_received_public_key[_bytes|_der|_pem]
+#                                     contracted (config)    — mutates, returns None
+#   set_curve                         contracted (config)
+#   get_public_key                    contracted (output)
+#   generate_sharedsecret_bytes       contracted (operation) — rules-relevant KEX terminal
+#   generate_sharedsecret             contracted (operation) — int-domain variant
+#
+# ecdsa.curves (Curve class, NIST*/SECP*/BRAINPOOL*/Ed* constants, find_curve,
+# curve_by_name)                      skipped-non-crypto     — curve parameter objects
+#                                                              passed as arguments; the
+#                                                              curve NAME reaches findings
+#                                                              via rules metadata, not via
+#                                                              return-type inference
+# ecdsa.eddsa (PrivateKey/PublicKey)  needs-follow-up        — internal EdDSA engine,
+#                                                              reached via curve=Ed25519 on
+#                                                              SigningKey; direct use is
+#                                                              rare and rules don't cover
+#                                                              it yet
+# ecdsa.util sigencode_*/sigdecode_*  skipped-non-crypto     — encoding strategy callables
+# ecdsa.der / ellipticcurve / numbertheory
+#                                     skipped-non-crypto     — low-level internals
+#
+# Note on `when:` conditionals: none are declared. Return types never depend
+# on argument values (the curve argument selects key parameters, not the
+# return type).
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── ecdsa.SigningKey — generation and loading ──────────────────────────────
+
+  - method: ecdsa.SigningKey.generate
+    arity: 0
+    return:
+      type: ecdsa.SigningKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.SigningKey.from_secret_exponent
+    arity: 1
+    return:
+      type: ecdsa.SigningKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.SigningKey.from_string
+    arity: 1
+    return:
+      type: ecdsa.SigningKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.SigningKey.from_pem
+    arity: 1
+    return:
+      type: ecdsa.SigningKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.SigningKey.from_der
+    arity: 1
+    return:
+      type: ecdsa.SigningKey
+      confidence: high
+    role: factory
+
+  # ── ecdsa.SigningKey — signing operations ──────────────────────────────────
+
+  - method: ecdsa.SigningKey.sign
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: ecdsa.SigningKey.sign_deterministic
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: ecdsa.SigningKey.sign_digest
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: ecdsa.SigningKey.sign_digest_deterministic
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: ecdsa.SigningKey.sign_number
+    arity: 1
+    return:
+      type: builtins.tuple
+      confidence: high
+    role: operation
+
+  # ── ecdsa.SigningKey — extraction and serialization ────────────────────────
+
+  - method: ecdsa.SigningKey.get_verifying_key
+    arity: 0
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: output
+
+  - method: ecdsa.SigningKey.to_string
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: ecdsa.SigningKey.to_pem
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: ecdsa.SigningKey.to_der
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: ecdsa.SigningKey.to_ssh
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  # ── ecdsa.VerifyingKey — loading ───────────────────────────────────────────
+
+  - method: ecdsa.VerifyingKey.from_string
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.VerifyingKey.from_pem
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.VerifyingKey.from_der
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.VerifyingKey.from_public_point
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: factory
+
+  # Public-key recovery returns a list of candidate VerifyingKeys.
+  - method: ecdsa.VerifyingKey.from_public_key_recovery
+    arity: 3
+    return:
+      type: builtins.list
+      confidence: high
+    role: factory
+
+  - method: ecdsa.VerifyingKey.from_public_key_recovery_with_digest
+    arity: 3
+    return:
+      type: builtins.list
+      confidence: high
+    role: factory
+
+  # ── ecdsa.VerifyingKey — verification ──────────────────────────────────────
+
+  # verify/verify_digest return True or raise BadSignatureError.
+  - method: ecdsa.VerifyingKey.verify
+    arity: 2
+    return:
+      type: builtins.bool
+      confidence: high
+    role: operation
+
+  - method: ecdsa.VerifyingKey.verify_digest
+    arity: 2
+    return:
+      type: builtins.bool
+      confidence: high
+    role: operation
+
+  # ── ecdsa.VerifyingKey — serialization ─────────────────────────────────────
+
+  - method: ecdsa.VerifyingKey.to_string
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: ecdsa.VerifyingKey.to_pem
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: ecdsa.VerifyingKey.to_der
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: ecdsa.VerifyingKey.to_ssh
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  # ── ecdsa.ECDH — key agreement ─────────────────────────────────────────────
+
+  # `import ecdsa; ecdsa.ECDH(...)` — module-attribute call spelling.
+  - method: ecdsa.ECDH
+    arity: 0
+    return:
+      type: ecdsa.ECDH
+      confidence: high
+    role: factory
+
+  # `from ecdsa import ECDH; ECDH(...)` — constructor spelling.
+  - method: ecdsa.ECDH.<init>
+    arity: 0
+    return:
+      type: ecdsa.ECDH
+      confidence: high
+    role: factory
+
+  - method: ecdsa.ECDH.set_curve
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.generate_private_key
+    arity: 0
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: factory
+
+  - method: ecdsa.ECDH.load_private_key
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.load_private_key_bytes
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.load_private_key_der
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.load_private_key_pem
+    arity: 1
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.get_public_key
+    arity: 0
+    return:
+      type: ecdsa.VerifyingKey
+      confidence: high
+    role: output
+
+  - method: ecdsa.ECDH.load_received_public_key
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.load_received_public_key_bytes
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.load_received_public_key_der
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.load_received_public_key_pem
+    arity: 1
+    return:
+      type: builtins.NoneType
+      confidence: high
+    role: config
+
+  - method: ecdsa.ECDH.generate_sharedsecret_bytes
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: ecdsa.ECDH.generate_sharedsecret
+    arity: 0
+    return:
+      type: builtins.int
+      confidence: high
+    role: operation
+
+hierarchy:
+  ecdsa.SigningKey:
+    - builtins.object
+  ecdsa.VerifyingKey:
+    - builtins.object
+  ecdsa.ECDH:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.bool:
+    - builtins.object
+  builtins.int:
+    - builtins.object
+  builtins.list:
+    - builtins.object
+  builtins.tuple:
+    - builtins.object
+  builtins.NoneType:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/google-cloud-kms.yaml
+++ b/internal/callgraph/contracts/python/google-cloud-kms.yaml
@@ -1,0 +1,470 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: google-cloud-kms
+  coordinates:
+    - google-cloud-kms
+  version_range: ">=2.0,<4.0"
+  description: >-
+    Google Cloud KMS client lifecycle contracts — KeyManagementServiceClient
+    construction (sync and async), remote encryption, decryption, signing,
+    MAC, KEM decapsulation, random-bytes generation, public-key retrieval,
+    and key-lifecycle management. Verified against google-cloud-kms 3.13.0
+    (google/cloud/kms_v1/services/key_management_service/client.py,
+    async_client.py, kms_v1/types/service.py).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#208)
+#
+# Scope: KeyManagementServiceClient (sync + async) — constructors,
+# service-account factories, every data-plane crypto operation, and the
+# key-lifecycle RPCs. Every public method was inventoried against the
+# google-cloud-kms 3.13.0 wheel source. Disposition legend: contracted |
+# covered-existing | skipped-non-crypto | skipped-informative-return |
+# skipped-unsupported | needs-follow-up.
+#
+# Import-shape note: `from google.cloud import kms` and
+# `from google.cloud import kms_v1` expose the SAME client classes, so both
+# spellings are contracted for entry points. Instance methods are keyed on
+# the canonical semantic type google.cloud.kms_v1.KeyManagementServiceClient
+# (respectively ...AsyncClient), which the factory contracts return.
+#
+# All RPCs take `(request=None, *, flattened kwargs)` — required positional
+# count is 0 for every method; the arity-tolerant Python lookup covers the
+# request-object-positional call shape (arity 1).
+#
+# KeyManagementServiceClient (client.py)
+#   <init> / kms.X / kms_v1.X          contracted (factory)
+#   from_service_account_file/info/json contracted (factory) — both module
+#                                                              spellings; json is an
+#                                                              alias of file
+#   encrypt / decrypt                   contracted (operation) — rules api anchors
+#   raw_encrypt / raw_decrypt           contracted (operation) — request-only params
+#   asymmetric_sign                     contracted (operation)
+#   asymmetric_decrypt                  contracted (operation) — rules api anchor
+#   mac_sign / mac_verify               contracted (operation) — rules api anchors
+#   decapsulate                         contracted (operation) — ML-KEM (PQC)
+#   generate_random_bytes               contracted (operation) — rules api anchor
+#   get_public_key                      contracted (output)    — rules api anchor
+#   create_crypto_key                   contracted (factory)   — creates key material
+#   create_crypto_key_version           contracted (factory)
+#   import_crypto_key_version           contracted (factory)
+#   create_key_ring / create_import_job contracted (config)    — containers/jobs
+#   update_crypto_key[_version|_primary_version]
+#                                       contracted (config)
+#   destroy/restore_crypto_key_version  contracted (config)
+#   delete_crypto_key[_version]         contracted (config)    — LRO handle return
+#   get_/list_* read accessors          skipped-non-crypto     — resource reads
+#                                                                (get_public_key is the
+#                                                                crypto exception, above)
+#   IAM/location/operation helpers      skipped-non-crypto
+#
+# KeyManagementServiceAsyncClient (async_client.py)
+#   constructors + the same 11 crypto operations
+#                                       contracted             — awaitable results modeled
+#                                                                as the same response types
+#   async key-lifecycle RPCs            needs-follow-up        — mirror the sync surface;
+#                                                                omitted to keep the async
+#                                                                KB to data-plane crypto
+#
+# EkmServiceClient / AutokeyClient / AutokeyAdminClient / HsmManagementClient
+#                                       skipped-non-crypto     — connectivity/config
+#                                                                management, no data-plane
+#                                                                crypto operations
+# kms_v1.types request/response classes skipped-informative-return — proto value
+#                                                                objects, not operations
+#
+# Note on `when:` conditionals: none are declared. The remote key's algorithm
+# determines the crypto semantics server-side; the client-visible response
+# type per method is fixed.
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── sync client construction ───────────────────────────────────────────────
+
+  # `from google.cloud import kms; kms.KeyManagementServiceClient()`.
+  - method: google.cloud.kms.KeyManagementServiceClient
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  # `from google.cloud import kms_v1; kms_v1.KeyManagementServiceClient()`.
+  - method: google.cloud.kms_v1.KeyManagementServiceClient
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  # `from google.cloud.kms import KeyManagementServiceClient; KeyManagementServiceClient()`.
+  - method: google.cloud.kms.KeyManagementServiceClient.<init>
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.<init>
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms.KeyManagementServiceClient.from_service_account_file
+    arity: 1
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.from_service_account_file
+    arity: 1
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms.KeyManagementServiceClient.from_service_account_json
+    arity: 1
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.from_service_account_json
+    arity: 1
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms.KeyManagementServiceClient.from_service_account_info
+    arity: 1
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.from_service_account_info
+    arity: 1
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  # ── sync client — crypto operations ────────────────────────────────────────
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.encrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.EncryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.decrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.DecryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.raw_encrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.RawEncryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.raw_decrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.RawDecryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.asymmetric_sign
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.AsymmetricSignResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.asymmetric_decrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.AsymmetricDecryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.mac_sign
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.MacSignResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.mac_verify
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.MacVerifyResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.decapsulate
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.DecapsulateResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.generate_random_bytes
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.GenerateRandomBytesResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.get_public_key
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.PublicKey
+      confidence: high
+    role: output
+
+  # ── sync client — key lifecycle ────────────────────────────────────────────
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.create_crypto_key
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKey
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.create_crypto_key_version
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKeyVersion
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.import_crypto_key_version
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKeyVersion
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.create_key_ring
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.KeyRing
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.create_import_job
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.ImportJob
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.update_crypto_key
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKey
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.update_crypto_key_version
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKeyVersion
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.update_crypto_key_primary_version
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKey
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.destroy_crypto_key_version
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKeyVersion
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.restore_crypto_key_version
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.CryptoKeyVersion
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.delete_crypto_key
+    arity: 0
+    return:
+      type: google.api_core.operation.Operation
+      confidence: high
+    role: config
+
+  - method: google.cloud.kms_v1.KeyManagementServiceClient.delete_crypto_key_version
+    arity: 0
+    return:
+      type: google.api_core.operation.Operation
+      confidence: high
+    role: config
+
+  # ── async client construction ──────────────────────────────────────────────
+
+  - method: google.cloud.kms.KeyManagementServiceAsyncClient
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceAsyncClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceAsyncClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms.KeyManagementServiceAsyncClient.<init>
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceAsyncClient
+      confidence: high
+    role: factory
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.<init>
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.KeyManagementServiceAsyncClient
+      confidence: high
+    role: factory
+
+  # ── async client — crypto operations (awaitable results) ───────────────────
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.encrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.EncryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.decrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.DecryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.raw_encrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.RawEncryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.raw_decrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.RawDecryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.asymmetric_sign
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.AsymmetricSignResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.asymmetric_decrypt
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.AsymmetricDecryptResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.mac_sign
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.MacSignResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.mac_verify
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.MacVerifyResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.decapsulate
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.DecapsulateResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.generate_random_bytes
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.GenerateRandomBytesResponse
+      confidence: high
+    role: operation
+
+  - method: google.cloud.kms_v1.KeyManagementServiceAsyncClient.get_public_key
+    arity: 0
+    return:
+      type: google.cloud.kms_v1.types.PublicKey
+      confidence: high
+    role: output
+
+hierarchy:
+  google.cloud.kms_v1.KeyManagementServiceClient:
+    - builtins.object
+  google.cloud.kms_v1.KeyManagementServiceAsyncClient:
+    - builtins.object
+  google.cloud.kms_v1.types.EncryptResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.DecryptResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.RawEncryptResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.RawDecryptResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.AsymmetricSignResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.AsymmetricDecryptResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.MacSignResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.MacVerifyResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.DecapsulateResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.GenerateRandomBytesResponse:
+    - builtins.object
+  google.cloud.kms_v1.types.PublicKey:
+    - builtins.object
+  google.cloud.kms_v1.types.CryptoKey:
+    - builtins.object
+  google.cloud.kms_v1.types.CryptoKeyVersion:
+    - builtins.object
+  google.cloud.kms_v1.types.KeyRing:
+    - builtins.object
+  google.cloud.kms_v1.types.ImportJob:
+    - builtins.object
+  google.api_core.operation.Operation:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/hvac.yaml
+++ b/internal/callgraph/contracts/python/hvac.yaml
@@ -1,0 +1,302 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: hvac
+  coordinates:
+    - hvac
+  version_range: ">=1.0,<3.0"
+  description: >-
+    hvac (HashiCorp Vault client) lifecycle contracts — Client construction
+    and the Transit secrets engine's key management, encryption, signing,
+    hashing, HMAC, and random-bytes operations, plus the Transform engine's
+    encode/decode terminals. Verified against hvac 2.4.0 (hvac/v1/__init__.py,
+    hvac/api/secrets_engines/transit.py, transform.py).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#208)
+#
+# Scope: hvac.Client construction plus the crypto-relevant secrets engines
+# (Transit; Transform encode/decode). Auth methods and non-crypto secret
+# engines are out of scope. Every public (non "_"-prefixed) Transit method was
+# inventoried against the hvac 2.4.0 wheel source. Disposition legend:
+# contracted | covered-existing | skipped-non-crypto |
+# skipped-informative-return | skipped-unsupported | needs-follow-up.
+#
+# KNOWN PARSER LIMITATION (spike, issue #208): hvac's dominant call shape is
+# an attribute chain — `client.secrets.transit.encrypt_data(...)` — where
+# `.secrets` (property) and `.transit` (__getattr__-backed attribute) are NOT
+# calls. The Python parser records neither a ChainID nor a ReceiverVar for the
+# terminal call, so the Transit instance-method contracts below cannot be
+# selected by receiver type today; they document the canonical lifecycle and
+# activate for direct-construction call shapes
+# (`Transit(adapter).encrypt_data(...)`) and once attribute-chain receiver
+# resolution lands (parser follow-up). Detection and line-level reachability
+# are unaffected.
+#
+# Return-type note: hvac's default JSONAdapter returns a parsed dict for JSON
+# (HTTP 200) endpoints and the raw requests.Response for 204/empty endpoints;
+# contracts model that default-adapter behavior.
+#
+# hvac.Client (hvac/v1/__init__.py; re-exported at hvac/__init__.py)
+#   Client(...)               contracted (factory)     — `hvac.Client` attr spelling,
+#                                                         `hvac.Client.<init>` and
+#                                                         `hvac.v1.Client.<init>`
+#                                                         from-import spellings
+#   Client.secrets            skipped-unsupported      — property access, not a call
+#   Client auth/sys/read/write surface
+#                             skipped-non-crypto       — Vault API plumbing
+#
+# hvac.api.secrets_engines.Transit (transit.py)
+#   Transit(adapter)          contracted (factory)     — both module spellings
+#   create_key                contracted (factory)     — creates named key material
+#   read_key                  contracted (output)
+#   list_keys                 skipped-non-crypto       — key-name listing
+#   delete_key                contracted (config)
+#   update_key_configuration  contracted (config)
+#   rotate_key                contracted (config)      — key-version lifecycle
+#   export_key                contracted (output)      — key_type param carries the
+#                                                         exported key flavor
+#   encrypt_data              contracted (operation)   — rules api anchor
+#   decrypt_data              contracted (operation)   — rules api anchor
+#   rewrap_data               contracted (operation)
+#   generate_data_key         contracted (operation)   — rules api anchor
+#   generate_random_bytes     contracted (operation)   — rules api anchor
+#   hash_data                 contracted (operation)   — rules api anchor
+#   generate_hmac             contracted (operation)   — rules api anchor
+#   sign_data                 contracted (operation)   — rules api anchor
+#   verify_signed_data        contracted (operation)   — rules api anchor
+#   backup_key                contracted (output)
+#   restore_key               contracted (config)
+#   trim_key                  contracted (config)
+#
+# hvac.api.secrets_engines.Transform (transform.py; Vault Enterprise FPE)
+#   encode / decode           contracted (operation)   — crypto terminals
+#   create_or_update_* / rotate_tokenization_key / read_* / list_* / delete_*
+#                             needs-follow-up          — transform-role/config surface;
+#                                                         no detection rules cover them
+#                                                         yet, revisit with a Transform
+#                                                         rules ticket
+#
+# Note on `when:` conditionals: none are declared. Vault selects algorithms
+# from request parameters server-side; the client-visible return type is
+# always the adapter-shaped response.
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── hvac.Client construction ───────────────────────────────────────────────
+
+  # `import hvac; hvac.Client(url=...)` — module-attribute call spelling.
+  - method: hvac.Client
+    arity: 0
+    return:
+      type: hvac.v1.Client
+      confidence: high
+    role: factory
+
+  # `from hvac import Client; Client(url=...)` — constructor spelling.
+  - method: hvac.Client.<init>
+    arity: 0
+    return:
+      type: hvac.v1.Client
+      confidence: high
+    role: factory
+
+  # `from hvac.v1 import Client; Client(url=...)`.
+  - method: hvac.v1.Client.<init>
+    arity: 0
+    return:
+      type: hvac.v1.Client
+      confidence: high
+    role: factory
+
+  # ── Transit engine construction ────────────────────────────────────────────
+
+  # `from hvac.api.secrets_engines import Transit; Transit(adapter=...)`.
+  - method: hvac.api.secrets_engines.Transit.<init>
+    arity: 1
+    return:
+      type: hvac.api.secrets_engines.transit.Transit
+      confidence: high
+    role: factory
+
+  # `from hvac.api.secrets_engines.transit import Transit; Transit(...)`.
+  - method: hvac.api.secrets_engines.transit.Transit.<init>
+    arity: 1
+    return:
+      type: hvac.api.secrets_engines.transit.Transit
+      confidence: high
+    role: factory
+
+  # ── Transit — key lifecycle ────────────────────────────────────────────────
+
+  - method: hvac.api.secrets_engines.transit.Transit.create_key
+    arity: 1
+    return:
+      type: requests.Response
+      confidence: high
+    role: factory
+
+  - method: hvac.api.secrets_engines.transit.Transit.read_key
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: hvac.api.secrets_engines.transit.Transit.delete_key
+    arity: 1
+    return:
+      type: requests.Response
+      confidence: high
+    role: config
+
+  - method: hvac.api.secrets_engines.transit.Transit.update_key_configuration
+    arity: 1
+    return:
+      type: requests.Response
+      confidence: high
+    role: config
+
+  - method: hvac.api.secrets_engines.transit.Transit.rotate_key
+    arity: 1
+    return:
+      type: requests.Response
+      confidence: high
+    role: config
+
+  - method: hvac.api.secrets_engines.transit.Transit.export_key
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+    parameters:
+      - index: 1
+        name: key_type
+        role: metadata-contributing
+        contributes:
+          property: keyType
+          derivation: argument_value
+
+  - method: hvac.api.secrets_engines.transit.Transit.backup_key
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: hvac.api.secrets_engines.transit.Transit.restore_key
+    arity: 1
+    return:
+      type: requests.Response
+      confidence: high
+    role: config
+
+  - method: hvac.api.secrets_engines.transit.Transit.trim_key
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: config
+
+  # ── Transit — crypto operations ────────────────────────────────────────────
+
+  - method: hvac.api.secrets_engines.transit.Transit.encrypt_data
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.decrypt_data
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.rewrap_data
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.generate_data_key
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: key_type
+        role: metadata-contributing
+        contributes:
+          property: keyType
+          derivation: argument_value
+
+  - method: hvac.api.secrets_engines.transit.Transit.generate_random_bytes
+    arity: 0
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.hash_data
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.generate_hmac
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.sign_data
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transit.Transit.verify_signed_data
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  # ── Transform engine — FPE terminals ───────────────────────────────────────
+
+  - method: hvac.api.secrets_engines.transform.Transform.encode
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: hvac.api.secrets_engines.transform.Transform.decode
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+hierarchy:
+  hvac.v1.Client:
+    - builtins.object
+  hvac.api.secrets_engines.transit.Transit:
+    - builtins.object
+  hvac.api.secrets_engines.transform.Transform:
+    - builtins.object
+  requests.Response:
+    - builtins.object
+  builtins.dict:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/python-jose.yaml
+++ b/internal/callgraph/contracts/python/python-jose.yaml
@@ -1,0 +1,340 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: python-jose
+  coordinates:
+    - python-jose
+  version_range: ">=3.0,<4.0"
+  description: >-
+    python-jose JOSE (JWT/JWS/JWE/JWK) lifecycle contracts — token encode and
+    decode, signing and verification, encryption and decryption, and key
+    construction. Verified against python-jose 3.5.0 (jose/jwt.py, jws.py,
+    jwe.py, jwk.py, backends/base.py).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#208)
+#
+# Scope: the public module-level functions of jose.jwt, jose.jws, jose.jwe and
+# jose.jwk, plus the caller-visible key classes. Every public
+# (non "_"-prefixed) name was inventoried against the python-jose 3.5.0 wheel
+# source. Disposition legend: contracted | covered-existing |
+# skipped-non-crypto | skipped-informative-return | skipped-unsupported |
+# needs-follow-up.
+#
+# IMPORTANT — namespace discipline vs pyjwt: python-jose call sites resolve to
+# `jose.jwt.*` because the library is imported as `from jose import jwt`. The
+# bare `jwt.encode`/`jwt.decode` FQNs belong to PyJWT (pyjwt.yaml) and MUST NOT
+# be declared here: authlib returns bytes and PyJWT returns str for the same
+# bare spelling, so a bare declaration would either mis-attribute or hard-fail
+# the cross-library merge.
+#
+# jose.jwt (jwt.py)
+#   encode                    contracted (operation)   — rules api anchor; returns str
+#   decode                    contracted (operation)   — rules api anchor; returns dict
+#   get_unverified_header     contracted (output)
+#   get_unverified_headers    contracted (output)      — alias of the above
+#   get_unverified_claims     contracted (output)      — json-loaded dict at jwt level
+#
+# jose.jws (jws.py)
+#   sign                      contracted (operation)   — rules api anchor; returns str
+#   verify                    contracted (operation)   — returns the raw payload BYTES
+#   get_unverified_header     contracted (output)
+#   get_unverified_headers    contracted (output)
+#   get_unverified_claims     contracted (output)      — raw payload bytes at jws level
+#
+# jose.jwe (jwe.py)
+#   encrypt                   contracted (operation)   — rules api anchor; returns BYTES
+#                                                         (compact serialization is bytes
+#                                                         in 3.5.0, docstrings notwithstanding)
+#   decrypt                   contracted (operation)   — returns bytes (None only when the
+#                                                         CEK is invalid — error path)
+#   get_unverified_header     contracted (output)
+#
+# jose.jwk (jwk.py)
+#   construct                 contracted (factory)     — returns a Key-subclass instance
+#   get_key                   skipped-unsupported      — returns a CLASS object
+#                                                         (type[Key]), not an instance;
+#                                                         no instance lifecycle to model
+#   register_key              skipped-non-crypto       — global registry plumbing
+#
+# Key classes (jose/backends; re-exported as jose.jwk.RSAKey etc.)
+#   jose.jwk.{HMACKey,RSAKey,ECKey,AESKey}(key, algorithm)
+#                             contracted (factory)     — module-attribute spelling
+#   jose.backends.{HMACKey,RSAKey,ECKey,AESKey}.<init>
+#                             contracted (factory)     — from-import constructor spelling
+#   DIRKey                    needs-follow-up          — alg "dir" passthrough key; direct
+#                                                         construction is rare in the wild
+#
+# jose.backends.base.Key shared instance surface (base.py; concrete backends
+# override — contracts declared once on the shared base per KB convention)
+#   sign / verify             contracted (operation)
+#   encrypt                   contracted (operation)   — returns (iv, ciphertext, tag)
+#                                                         tuple per the base contract
+#   decrypt                   contracted (operation)
+#   wrap_key / unwrap_key     contracted (operation)
+#   public_key                contracted (output)      — public-half projection
+#   to_pem                    contracted (output)
+#   to_dict                   contracted (output)
+#
+# jose.constants (ALGORITHMS), jose.exceptions, jose.utils
+#                             skipped-non-crypto       — constants/exceptions/helpers
+#
+# Note on `when:` conditionals: none are declared. The algorithm argument
+# selects the crypto algorithm, never the Python return type.
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── jose.jwt — token encode/decode ─────────────────────────────────────────
+
+  - method: jose.jwt.encode
+    arity: 2
+    return:
+      type: builtins.str
+      confidence: high
+    role: operation
+
+  - method: jose.jwt.decode
+    arity: 2
+    return:
+      type: builtins.dict
+      confidence: high
+    role: operation
+
+  - method: jose.jwt.get_unverified_header
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: jose.jwt.get_unverified_headers
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: jose.jwt.get_unverified_claims
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  # ── jose.jws — signing/verification ────────────────────────────────────────
+
+  - method: jose.jws.sign
+    arity: 2
+    return:
+      type: builtins.str
+      confidence: high
+    role: operation
+
+  - method: jose.jws.verify
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.jws.get_unverified_header
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: jose.jws.get_unverified_headers
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  - method: jose.jws.get_unverified_claims
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  # ── jose.jwe — encryption/decryption ───────────────────────────────────────
+
+  - method: jose.jwe.encrypt
+    arity: 2
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.jwe.decrypt
+    arity: 2
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.jwe.get_unverified_header
+    arity: 1
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+  # ── jose.jwk — key construction ────────────────────────────────────────────
+
+  - method: jose.jwk.construct
+    arity: 1
+    return:
+      type: jose.backends.base.Key
+      confidence: high
+    role: factory
+
+  # Module-attribute spellings: `from jose import jwk; jwk.RSAKey(key, alg)`.
+  - method: jose.jwk.HMACKey
+    arity: 2
+    return:
+      type: jose.backends.HMACKey
+      confidence: high
+    role: factory
+
+  - method: jose.jwk.RSAKey
+    arity: 2
+    return:
+      type: jose.backends.RSAKey
+      confidence: high
+    role: factory
+
+  - method: jose.jwk.ECKey
+    arity: 2
+    return:
+      type: jose.backends.ECKey
+      confidence: high
+    role: factory
+
+  - method: jose.jwk.AESKey
+    arity: 2
+    return:
+      type: jose.backends.AESKey
+      confidence: high
+    role: factory
+
+  # Constructor spellings: `from jose.backends import RSAKey; RSAKey(key, alg)`.
+  - method: jose.backends.HMACKey.<init>
+    arity: 2
+    return:
+      type: jose.backends.HMACKey
+      confidence: high
+    role: factory
+
+  - method: jose.backends.RSAKey.<init>
+    arity: 2
+    return:
+      type: jose.backends.RSAKey
+      confidence: high
+    role: factory
+
+  - method: jose.backends.ECKey.<init>
+    arity: 2
+    return:
+      type: jose.backends.ECKey
+      confidence: high
+    role: factory
+
+  - method: jose.backends.AESKey.<init>
+    arity: 2
+    return:
+      type: jose.backends.AESKey
+      confidence: high
+    role: factory
+
+  # ── jose.backends.base.Key — shared instance surface ──────────────────────
+
+  - method: jose.backends.base.Key.sign
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.backends.base.Key.verify
+    arity: 2
+    return:
+      type: builtins.bool
+      confidence: high
+    role: operation
+
+  # encrypt returns the (iv, ciphertext, auth_tag) tuple defined by the base
+  # contract (backends/base.py).
+  - method: jose.backends.base.Key.encrypt
+    arity: 1
+    return:
+      type: builtins.tuple
+      confidence: high
+    role: operation
+
+  - method: jose.backends.base.Key.decrypt
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.backends.base.Key.wrap_key
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.backends.base.Key.unwrap_key
+    arity: 1
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: jose.backends.base.Key.public_key
+    arity: 0
+    return:
+      type: jose.backends.base.Key
+      confidence: high
+    role: output
+
+  - method: jose.backends.base.Key.to_pem
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: jose.backends.base.Key.to_dict
+    arity: 0
+    return:
+      type: builtins.dict
+      confidence: high
+    role: output
+
+hierarchy:
+  jose.backends.HMACKey:
+    - jose.backends.base.Key
+  jose.backends.RSAKey:
+    - jose.backends.base.Key
+  jose.backends.ECKey:
+    - jose.backends.base.Key
+  jose.backends.AESKey:
+    - jose.backends.base.Key
+  jose.backends.base.Key:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.dict:
+    - builtins.object
+  builtins.bool:
+    - builtins.object
+  builtins.tuple:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python/rsa.yaml
+++ b/internal/callgraph/contracts/python/rsa.yaml
@@ -1,0 +1,264 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: rsa
+  coordinates:
+    - rsa
+  version_range: ">=4.0,<5.0"
+  description: >-
+    python-rsa PKCS#1 v1.5 lifecycle contracts — key-pair generation, key
+    loading and serialization, encryption and decryption, signing and
+    verification. Verified against rsa 4.9.1 (rsa/key.py, rsa/pkcs1.py).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exhaustive API audit (scanoss/crypto-finder#208)
+#
+# Scope: the caller-visible `rsa` top-level surface (rsa/__init__.py
+# re-exports) plus the PublicKey/PrivateKey classmethods. Every public
+# (non "_"-prefixed) name was inventoried against the rsa 4.9.1 wheel source.
+# Disposition legend: contracted | covered-existing | skipped-non-crypto |
+# skipped-informative-return | skipped-unsupported | needs-follow-up.
+#
+# Module-level functions (rsa/pkcs1.py, rsa/key.py)
+#   newkeys                   contracted (factory)      — returns (PublicKey, PrivateKey)
+#                                                          tuple; modeled as builtins.tuple
+#   encrypt / decrypt          contracted (operation)    — rules api anchors
+#   sign / sign_hash           contracted (operation)    — rules api anchors; hash_method
+#                                                          param carries the hash algorithm
+#   verify                     contracted (operation)    — returns the hash-name str
+#   find_signature_hash        contracted (output)
+#   compute_hash               contracted (operation)
+#   yield_fixedblocks          skipped-non-crypto        — file-chunking iterator helper
+#
+# rsa.PublicKey / rsa.PrivateKey (rsa/key.py)
+#   PublicKey(n, e)            contracted (factory)      — attr-call and <init> spellings
+#   PrivateKey(n, e, d, p, q)  contracted (factory)      — attr-call and <init> spellings
+#   load_pkcs1                 contracted (factory)      — per-subclass (AbstractKey
+#                                                          dispatch; calling it on
+#                                                          AbstractKey directly is not a
+#                                                          caller-visible pattern)
+#   load_pkcs1_openssl_pem     contracted (factory)      — PublicKey only in 4.9.1
+#   load_pkcs1_openssl_der     contracted (factory)      — PublicKey only in 4.9.1
+#   save_pkcs1                 contracted (output)
+#   blinded_encrypt/decrypt    contracted (operation)    — PrivateKey int-domain primitives
+#   blind / unblind            skipped-non-crypto        — low-level blinding helpers on
+#                                                          AbstractKey, not a caller pattern
+#
+# rsa.key internals (find_p_q, calculate_keys, calculate_keys_custom_exponent,
+# gen_keys)                    skipped-non-crypto        — key-math internals reached via
+#                                                          newkeys; `rsa.key.*` spellings
+#                                                          are not caller-typical
+# rsa.pkcs1_v2.mgf1            needs-follow-up           — MGF1 mask generation is real
+#                                                          crypto but 4.9.1 ships no OAEP
+#                                                          around it; revisit if rules land
+# rsa.randnum                  skipped-non-crypto        — RNG helpers, out of rules scope
+# DecryptionError/VerificationError re-exports
+#                              skipped-non-crypto        — exception types, not calls
+#
+# Note on `when:` conditionals: none are declared. Every contracted method's
+# return type is stable regardless of argument values (`sign`'s hash_method
+# selects the digest, never the return type).
+# ─────────────────────────────────────────────────────────────────────────────
+
+contracts:
+  # ── key-pair generation ────────────────────────────────────────────────────
+
+  - method: rsa.newkeys
+    arity: 1
+    return:
+      type: builtins.tuple
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: nbits
+        role: metadata-contributing
+        contributes:
+          property: keySize
+          derivation: argument_value
+
+  # ── key construction and loading ───────────────────────────────────────────
+
+  # `import rsa; rsa.PublicKey(n, e)` — module-attribute call spelling.
+  - method: rsa.PublicKey
+    arity: 2
+    return:
+      type: rsa.PublicKey
+      confidence: high
+    role: factory
+
+  # `from rsa import PublicKey; PublicKey(n, e)` — constructor spelling.
+  - method: rsa.PublicKey.<init>
+    arity: 2
+    return:
+      type: rsa.PublicKey
+      confidence: high
+    role: factory
+
+  - method: rsa.PrivateKey
+    arity: 5
+    return:
+      type: rsa.PrivateKey
+      confidence: high
+    role: factory
+
+  - method: rsa.PrivateKey.<init>
+    arity: 5
+    return:
+      type: rsa.PrivateKey
+      confidence: high
+    role: factory
+
+  - method: rsa.PublicKey.load_pkcs1
+    arity: 1
+    return:
+      type: rsa.PublicKey
+      confidence: high
+    role: factory
+
+  - method: rsa.PrivateKey.load_pkcs1
+    arity: 1
+    return:
+      type: rsa.PrivateKey
+      confidence: high
+    role: factory
+
+  - method: rsa.PublicKey.load_pkcs1_openssl_pem
+    arity: 1
+    return:
+      type: rsa.PublicKey
+      confidence: high
+    role: factory
+
+  - method: rsa.PublicKey.load_pkcs1_openssl_der
+    arity: 1
+    return:
+      type: rsa.PublicKey
+      confidence: high
+    role: factory
+
+  # ── key serialization ──────────────────────────────────────────────────────
+
+  - method: rsa.PublicKey.save_pkcs1
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  - method: rsa.PrivateKey.save_pkcs1
+    arity: 0
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: output
+
+  # ── encryption / decryption ────────────────────────────────────────────────
+
+  - method: rsa.encrypt
+    arity: 2
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  - method: rsa.decrypt
+    arity: 2
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+
+  # ── signing / verification ─────────────────────────────────────────────────
+
+  - method: rsa.sign
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+    parameters:
+      - index: 2
+        name: hash_method
+        role: metadata-contributing
+        contributes:
+          property: hashAlgorithm
+          derivation: argument_value
+
+  - method: rsa.sign_hash
+    arity: 3
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+    parameters:
+      - index: 2
+        name: hash_method
+        role: metadata-contributing
+        contributes:
+          property: hashAlgorithm
+          derivation: argument_value
+
+  # verify returns the name of the hash used (e.g. "SHA-256"); it raises
+  # VerificationError on mismatch instead of returning False.
+  - method: rsa.verify
+    arity: 3
+    return:
+      type: builtins.str
+      confidence: high
+    role: operation
+
+  - method: rsa.find_signature_hash
+    arity: 2
+    return:
+      type: builtins.str
+      confidence: high
+    role: output
+
+  # ── hashing ────────────────────────────────────────────────────────────────
+
+  - method: rsa.compute_hash
+    arity: 2
+    return:
+      type: builtins.bytes
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: method_name
+        role: metadata-contributing
+        contributes:
+          property: hashAlgorithm
+          derivation: argument_value
+
+  # ── blinded int-domain primitives (PrivateKey) ─────────────────────────────
+
+  - method: rsa.PrivateKey.blinded_encrypt
+    arity: 1
+    return:
+      type: builtins.int
+      confidence: high
+    role: operation
+
+  - method: rsa.PrivateKey.blinded_decrypt
+    arity: 1
+    return:
+      type: builtins.int
+      confidence: high
+    role: operation
+
+hierarchy:
+  rsa.PublicKey:
+    - builtins.object
+  rsa.PrivateKey:
+    - builtins.object
+  builtins.bytes:
+    - builtins.object
+  builtins.str:
+    - builtins.object
+  builtins.int:
+    - builtins.object
+  builtins.tuple:
+    - builtins.object
+  builtins.object: []

--- a/internal/callgraph/contracts/python_libraries_test.go
+++ b/internal/callgraph/contracts/python_libraries_test.go
@@ -729,3 +729,137 @@ func TestLoadEmbedded_Python_Boto3KMSClientCondition(t *testing.T) {
 		t.Errorf("boto3.client#1 return type = %q, want botocore.client.KMS", c.Return.Type)
 	}
 }
+
+// TestLoadEmbedded_Python_RuleOnlyBacklog verifies the six RULE_ONLY-backlog
+// contract KBs (scanoss/crypto-finder#208): rsa, ecdsa, python-jose, authlib,
+// hvac, and google-cloud-kms. For each library it asserts the key factory and
+// operation entries, including their lifecycle roles.
+func TestLoadEmbedded_Python_RuleOnlyBacklog(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	tests := []struct {
+		method     string
+		arity      int
+		wantReturn string
+		wantRole   string
+		wantLib    string
+	}{
+		// rsa — key-pair generation, PKCS#1 operations
+		{"rsa.newkeys", 1, "builtins.tuple", "factory", "rsa"},
+		{"rsa.encrypt", 2, "builtins.bytes", "operation", "rsa"},
+		{"rsa.decrypt", 2, "builtins.bytes", "operation", "rsa"},
+		{"rsa.sign", 3, "builtins.bytes", "operation", "rsa"},
+		{"rsa.verify", 3, "builtins.str", "operation", "rsa"},
+		{"rsa.PublicKey.load_pkcs1", 1, "rsa.PublicKey", "factory", "rsa"},
+		{"rsa.PrivateKey.load_pkcs1", 1, "rsa.PrivateKey", "factory", "rsa"},
+		{"rsa.PrivateKey.save_pkcs1", 0, "builtins.bytes", "output", "rsa"},
+
+		// ecdsa — SigningKey/VerifyingKey lifecycle, ECDH
+		{"ecdsa.SigningKey.generate", 0, "ecdsa.SigningKey", "factory", "ecdsa"},
+		{"ecdsa.SigningKey.from_pem", 1, "ecdsa.SigningKey", "factory", "ecdsa"},
+		{"ecdsa.SigningKey.sign", 1, "builtins.bytes", "operation", "ecdsa"},
+		{"ecdsa.SigningKey.sign_deterministic", 1, "builtins.bytes", "operation", "ecdsa"},
+		{"ecdsa.SigningKey.get_verifying_key", 0, "ecdsa.VerifyingKey", "output", "ecdsa"},
+		{"ecdsa.VerifyingKey.from_string", 1, "ecdsa.VerifyingKey", "factory", "ecdsa"},
+		{"ecdsa.VerifyingKey.verify", 2, "builtins.bool", "operation", "ecdsa"},
+		{"ecdsa.ECDH.<init>", 0, "ecdsa.ECDH", "factory", "ecdsa"},
+		{"ecdsa.ECDH.generate_sharedsecret_bytes", 0, "builtins.bytes", "operation", "ecdsa"},
+
+		// python-jose — jose.jwt/jws/jwe module operations, jwk factory
+		{"jose.jwt.encode", 2, "builtins.str", "operation", "python-jose"},
+		{"jose.jwt.decode", 2, "builtins.dict", "operation", "python-jose"},
+		{"jose.jws.sign", 2, "builtins.str", "operation", "python-jose"},
+		{"jose.jws.verify", 3, "builtins.bytes", "operation", "python-jose"},
+		{"jose.jwe.encrypt", 2, "builtins.bytes", "operation", "python-jose"},
+		{"jose.jwe.decrypt", 2, "builtins.bytes", "operation", "python-jose"},
+		{"jose.jwk.construct", 1, "jose.backends.base.Key", "factory", "python-jose"},
+		{"jose.backends.base.Key.sign", 1, "builtins.bytes", "operation", "python-jose"},
+
+		// authlib — JWS/JWE/JWT lifecycle, JsonWebKey factories
+		{"authlib.jose.JsonWebSignature.<init>", 0, "authlib.jose.JsonWebSignature", "factory", "authlib"},
+		{"authlib.jose.JsonWebSignature.serialize_compact", 3, "builtins.bytes", "operation", "authlib"},
+		{"authlib.jose.JsonWebEncryption.<init>", 0, "authlib.jose.JsonWebEncryption", "factory", "authlib"},
+		{"authlib.jose.JsonWebEncryption.serialize_compact", 3, "builtins.bytes", "operation", "authlib"},
+		{"authlib.jose.JsonWebToken.<init>", 1, "authlib.jose.JsonWebToken", "factory", "authlib"},
+		{"authlib.jose.jwt.encode", 3, "builtins.bytes", "operation", "authlib"},
+		{"authlib.jose.jwt.decode", 2, "builtins.dict", "operation", "authlib"},
+		{"authlib.jose.JsonWebKey.import_key", 1, "authlib.jose.Key", "factory", "authlib"},
+		{"authlib.jose.RSAKey.generate_key", 0, "authlib.jose.RSAKey", "factory", "authlib"},
+		{"authlib.jose.ECKey.exchange_shared_key", 1, "builtins.bytes", "operation", "authlib"},
+
+		// hvac — Client factory, Transit engine lifecycle
+		{"hvac.Client", 0, "hvac.v1.Client", "factory", "hvac"},
+		{"hvac.Client.<init>", 0, "hvac.v1.Client", "factory", "hvac"},
+		{"hvac.api.secrets_engines.transit.Transit.create_key", 1, "requests.Response", "factory", "hvac"},
+		{"hvac.api.secrets_engines.transit.Transit.encrypt_data", 1, "builtins.dict", "operation", "hvac"},
+		{"hvac.api.secrets_engines.transit.Transit.sign_data", 1, "builtins.dict", "operation", "hvac"},
+		{"hvac.api.secrets_engines.transit.Transit.generate_hmac", 2, "builtins.dict", "operation", "hvac"},
+		{"hvac.api.secrets_engines.transit.Transit.export_key", 2, "builtins.dict", "output", "hvac"},
+
+		// google-cloud-kms — client factories (both import spellings), remote ops
+		{"google.cloud.kms.KeyManagementServiceClient", 0, "google.cloud.kms_v1.KeyManagementServiceClient", "factory", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceClient", 0, "google.cloud.kms_v1.KeyManagementServiceClient", "factory", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceClient.encrypt", 0, "google.cloud.kms_v1.types.EncryptResponse", "operation", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceClient.asymmetric_sign", 0, "google.cloud.kms_v1.types.AsymmetricSignResponse", "operation", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceClient.mac_sign", 0, "google.cloud.kms_v1.types.MacSignResponse", "operation", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceClient.get_public_key", 0, "google.cloud.kms_v1.types.PublicKey", "output", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceClient.create_crypto_key", 0, "google.cloud.kms_v1.types.CryptoKey", "factory", "google-cloud-kms"},
+		{"google.cloud.kms_v1.KeyManagementServiceAsyncClient.encrypt", 0, "google.cloud.kms_v1.types.EncryptResponse", "operation", "google-cloud-kms"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) == 0 {
+				t.Fatalf("%s#%d: no contracts found", tt.method, tt.arity)
+			}
+			c := got[0]
+			if c.Return.Type != tt.wantReturn {
+				t.Errorf("%s#%d return type = %q, want %q", tt.method, tt.arity, c.Return.Type, tt.wantReturn)
+			}
+			if c.Role != tt.wantRole {
+				t.Errorf("%s#%d role = %q, want %q", tt.method, tt.arity, c.Role, tt.wantRole)
+			}
+			if c.SourceLibrary != tt.wantLib {
+				t.Errorf("%s#%d source library = %q, want %q", tt.method, tt.arity, c.SourceLibrary, tt.wantLib)
+			}
+			if c.Return.Confidence != "high" {
+				t.Errorf("%s#%d confidence = %q, want high", tt.method, tt.arity, c.Return.Confidence)
+			}
+		})
+	}
+}
+
+// TestLoadEmbedded_Python_BareJWTNamespaceStaysPyjwt guards the namespace
+// discipline that keeps the #208 backlog KBs merge-safe: the bare
+// `jwt.encode`/`jwt.decode` FQNs (produced by PyJWT's `import jwt`) must stay
+// owned exclusively by pyjwt. python-jose resolves to `jose.jwt.*` and
+// authlib to `authlib.jose.jwt.*`; if either ever declared the bare spelling,
+// their divergent return types (authlib: bytes, pyjwt: str) would hard-fail
+// the merge or silently mis-attribute call sites.
+func TestLoadEmbedded_Python_BareJWTNamespaceStaysPyjwt(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+
+	for _, tt := range []struct {
+		method string
+		arity  int
+	}{
+		{"jwt.encode", 2},
+		{"jwt.decode", 1},
+	} {
+		got := kb.ContractsFor(tt.method, tt.arity)
+		if len(got) == 0 {
+			t.Fatalf("%s#%d: no contracts found", tt.method, tt.arity)
+		}
+		for _, c := range got {
+			if c.SourceLibrary != "pyjwt" {
+				t.Errorf("%s#%d: contract owned by %q, want pyjwt only", tt.method, tt.arity, c.SourceLibrary)
+			}
+		}
+	}
+}


### PR DESCRIPTION
  closes #208
  
  
  ecdsa 0.19.2, python-jose 3.5.0, Authlib 1.6.12, hvac 2.4.0, and
  google-cloud-kms 3.13.0 — covering key generation/loading factories,
  sign/verify/encrypt/decrypt operations, serialization outputs, and
  key-lifecycle config roles, with hierarchy edges and per-parameter
  keySize/keyType/hashAlgorithm metadata roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added callgraph contract coverage for Python RSA, ECDSA, JOSE, Authlib, Vault, and Google Cloud KMS libraries.
  - Improved recognition of cryptographic operations, including key generation, signing, verification, encryption, decryption, serialization, key exchange, and lifecycle workflows.
  - Added support for synchronous and asynchronous Google Cloud KMS operations.

- **Tests**
  - Added validation for contract availability, return types, lifecycle roles, confidence, and namespace isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->