### PR TITLE
feat(contracts/java): java-jwt + jwks-rsa lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Java callgraph contracts now model the Auth0 java-jwt 4.x token creation, signing, decoding, and verification lifecycles, and the jwks-rsa JWKS provider construction and signing-key resolution lifecycles. (#203)
-- Python callgraph contracts now model the python-rsa 4.x key-pair generation, PKCS#1 encryption, signing, and key-serialization lifecycles. (#208)
-- Python callgraph contracts now model the python-ecdsa 0.19 SigningKey/VerifyingKey generation, signing, verification, serialization, and ECDH key-agreement lifecycles. (#208)
-- Python callgraph contracts now model the python-jose 3.5 JWT/JWS/JWE operations and JWK key-construction lifecycles. (#208)
-- Python callgraph contracts now model the Authlib 1.6 JOSE serialization, JWT encode/decode, and JsonWebKey generation and import lifecycles. (#208)
-- Python callgraph contracts now model the hvac 2.4 Vault client construction and Transit/Transform secrets-engine key-management and crypto-operation lifecycles. (#208)
-- Python callgraph contracts now model the google-cloud-kms 3.x synchronous and asynchronous client construction, remote encryption, signing, MAC, KEM, random-bytes, and key-lifecycle operations. (#208)
+- Java callgraph contracts now model the Auth0 java-jwt 4.x token creation, signing, decoding, and verification lifecycles, and the jwks-rsa JWKS provider construction and signing-key resolution lifecycles.
+- Python callgraph contracts now model the python-rsa 4.x key-pair generation, PKCS#1 encryption, signing, and key-serialization lifecycles.
+- Python callgraph contracts now model the python-ecdsa 0.19 SigningKey/VerifyingKey generation, signing, verification, serialization, and ECDH key-agreement lifecycles.
+- Python callgraph contracts now model the python-jose 3.5 JWT/JWS/JWE operations and JWK key-construction lifecycles.
+- Python callgraph contracts now model the Authlib 1.6 JOSE serialization, JWT encode/decode, and JsonWebKey generation and import lifecycles.
+- Python callgraph contracts now model the hvac 2.4 Vault client construction and Transit/Transform secrets-engine key-management and crypto-operation lifecycles.
+- Python callgraph contracts now model the google-cloud-kms 3.x synchronous and asynchronous client construction, remote encryption, signing, MAC, KEM, random-bytes, and key-lifecycle operations. 
 
 ## [0.18.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the Auth0 java-jwt 4.x token creation, signing, decoding, and verification lifecycles, and the jwks-rsa JWKS provider construction and signing-key resolution lifecycles. (#203)
 - Python callgraph contracts now model the python-rsa 4.x key-pair generation, PKCS#1 encryption, signing, and key-serialization lifecycles. (#208)
 - Python callgraph contracts now model the python-ecdsa 0.19 SigningKey/VerifyingKey generation, signing, verification, serialization, and ECDH key-agreement lifecycles. (#208)
 - Python callgraph contracts now model the python-jose 3.5 JWT/JWS/JWE operations and JWK key-construction lifecycles. (#208)

--- a/internal/callgraph/contracts/java/java-jwt.yaml
+++ b/internal/callgraph/contracts/java/java-jwt.yaml
@@ -1,0 +1,538 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: java-jwt
+  coordinates:
+    - "com.auth0:java-jwt"
+  # Covers the java-jwt 4.x API surface, verified against library source at
+  # release 4.6.0. The RSA*PSS factories exist only from 4.6.0 (annotated
+  # inline); older 4.x code simply never calls them.
+  version_range: ">=4.0,<5.0"
+  description: "Auth0 java-jwt contracts for JWT creation, signing, decoding, and verification lifecycles"
+
+contracts:
+  # --- Entry points (com.auth0.jwt.JWT) ---
+  - method: com.auth0.jwt.JWT.<init>
+    arity: 0
+    canonical_return_type: com.auth0.jwt.JWT
+    return:
+      type: com.auth0.jwt.JWT
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.JWT.decode
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.interfaces.DecodedJWT
+    return:
+      type: com.auth0.jwt.interfaces.DecodedJWT
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.JWT.decodeJwt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.interfaces.DecodedJWT
+    return:
+      type: com.auth0.jwt.interfaces.DecodedJWT
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.JWT.create
+    arity: 0
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.JWT.require
+    arity: 1
+    parameter_types: [com.auth0.jwt.algorithms.Algorithm]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: factory
+
+  # --- Algorithm factories (com.auth0.jwt.algorithms.Algorithm) ---
+  # HMAC factories are overloaded (String / byte[]) at the same arity, RSA and
+  # ECDSA factories at arity 1 accept either a KeyProvider or a Key — canonical
+  # signature fields are omitted where more than one same-arity overload exists.
+  - method: com.auth0.jwt.algorithms.Algorithm.HMAC256
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.HMAC384
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.HMAC512
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA256
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA256
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.RSAPublicKey,
+        java.security.interfaces.RSAPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA384
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA384
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.RSAPublicKey,
+        java.security.interfaces.RSAPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA512
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA512
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.RSAPublicKey,
+        java.security.interfaces.RSAPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  # RSA-PSS (PS256/PS384/PS512) factories were added in java-jwt 4.6.0.
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA256PSS
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA256PSS
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.RSAPublicKey,
+        java.security.interfaces.RSAPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA384PSS
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA384PSS
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.RSAPublicKey,
+        java.security.interfaces.RSAPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA512PSS
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.RSA512PSS
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.RSAPublicKey,
+        java.security.interfaces.RSAPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.ECDSA256
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.ECDSA256
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.ECPublicKey,
+        java.security.interfaces.ECPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.ECDSA384
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.ECDSA384
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.ECPublicKey,
+        java.security.interfaces.ECPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.ECDSA512
+    arity: 1
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.ECDSA512
+    arity: 2
+    parameter_types:
+      [
+        java.security.interfaces.ECPublicKey,
+        java.security.interfaces.ECPrivateKey,
+      ]
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+  - method: com.auth0.jwt.algorithms.Algorithm.none
+    arity: 0
+    canonical_return_type: com.auth0.jwt.algorithms.Algorithm
+    return:
+      type: com.auth0.jwt.algorithms.Algorithm
+      confidence: high
+    role: factory
+
+  # --- Algorithm raw sign/verify operations ---
+  - method: com.auth0.jwt.algorithms.Algorithm.sign
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: com.auth0.jwt.algorithms.Algorithm.sign
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: com.auth0.jwt.algorithms.Algorithm.verify
+    arity: 1
+    parameter_types: [com.auth0.jwt.interfaces.DecodedJWT]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+
+  # --- Token creation builder (com.auth0.jwt.JWTCreator.Builder) ---
+  # withClaim/withArrayClaim/withHeader/withExpiresAt/... are overloaded at the
+  # same arity (String/Date/Instant/Map/...), so canonical signature fields are
+  # omitted on those entries.
+  - method: com.auth0.jwt.JWTCreator.Builder.withHeader
+    arity: 1
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withIssuer
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withSubject
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withAudience
+    arity: 1
+    parameter_types: ["java.lang.String[]"]
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withExpiresAt
+    arity: 1
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withNotBefore
+    arity: 1
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withIssuedAt
+    arity: 1
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withJWTId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withClaim
+    arity: 2
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withNullClaim
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.JWTCreator.Builder
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withArrayClaim
+    arity: 2
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.withPayload
+    arity: 1
+    return:
+      type: com.auth0.jwt.JWTCreator.Builder
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.JWTCreator.Builder.sign
+    arity: 1
+    parameter_types: [com.auth0.jwt.algorithms.Algorithm]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+
+  # --- Verification builder (com.auth0.jwt.interfaces.Verification) ---
+  # Authored on the public interface; JWTVerifier.BaseVerification resolves via
+  # the hierarchy edge below.
+  - method: com.auth0.jwt.interfaces.Verification.withIssuer
+    arity: 1
+    parameter_types: ["java.lang.String[]"]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withSubject
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withAudience
+    arity: 1
+    parameter_types: ["java.lang.String[]"]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withAnyOfAudience
+    arity: 1
+    parameter_types: ["java.lang.String[]"]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.acceptLeeway
+    arity: 1
+    parameter_types: [long]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.acceptExpiresAt
+    arity: 1
+    parameter_types: [long]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.acceptNotBefore
+    arity: 1
+    parameter_types: [long]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.acceptIssuedAt
+    arity: 1
+    parameter_types: [long]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.ignoreIssuedAt
+    arity: 0
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withJWTId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withClaimPresence
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withNullClaim
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwt.interfaces.Verification
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withClaim
+    arity: 2
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.withArrayClaim
+    arity: 2
+    return:
+      type: com.auth0.jwt.interfaces.Verification
+      confidence: high
+    role: config
+  - method: com.auth0.jwt.interfaces.Verification.build
+    arity: 0
+    canonical_return_type: com.auth0.jwt.JWTVerifier
+    return:
+      type: com.auth0.jwt.JWTVerifier
+      confidence: high
+    role: factory
+  # build(Clock) is declared only on the concrete BaseVerification, not the
+  # Verification interface.
+  - method: com.auth0.jwt.JWTVerifier.BaseVerification.build
+    arity: 1
+    canonical_return_type: com.auth0.jwt.JWTVerifier
+    return:
+      type: com.auth0.jwt.JWTVerifier
+      confidence: high
+    role: factory
+
+  # --- Verifier operation (com.auth0.jwt.interfaces.JWTVerifier) ---
+  # verify(String) and verify(DecodedJWT) share arity 1 and both return
+  # DecodedJWT — one unconditional contract, canonical signature omitted.
+  - method: com.auth0.jwt.interfaces.JWTVerifier.verify
+    arity: 1
+    return:
+      type: com.auth0.jwt.interfaces.DecodedJWT
+      confidence: high
+    role: operation
+
+hierarchy:
+  com.auth0.jwt.JWT:
+    - java.lang.Object
+  com.auth0.jwt.JWTCreator:
+    - java.lang.Object
+  com.auth0.jwt.JWTCreator.Builder:
+    - java.lang.Object
+  com.auth0.jwt.algorithms.Algorithm:
+    - java.lang.Object
+  com.auth0.jwt.interfaces.Verification:
+    - java.lang.Object
+  com.auth0.jwt.JWTVerifier.BaseVerification:
+    - com.auth0.jwt.interfaces.Verification
+  com.auth0.jwt.interfaces.JWTVerifier:
+    - java.lang.Object
+  com.auth0.jwt.JWTVerifier:
+    - com.auth0.jwt.interfaces.JWTVerifier
+  com.auth0.jwt.interfaces.Payload:
+    - java.lang.Object
+  com.auth0.jwt.interfaces.Header:
+    - java.lang.Object
+  com.auth0.jwt.interfaces.DecodedJWT:
+    - com.auth0.jwt.interfaces.Payload
+    - com.auth0.jwt.interfaces.Header
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/java-jwt.yaml
+++ b/internal/callgraph/contracts/java/java-jwt.yaml
@@ -62,18 +62,33 @@ contracts:
       type: com.auth0.jwt.algorithms.Algorithm
       confidence: high
     role: factory
+    parameters:
+      - index: 0
+        name: secret
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
   - method: com.auth0.jwt.algorithms.Algorithm.HMAC384
     arity: 1
     return:
       type: com.auth0.jwt.algorithms.Algorithm
       confidence: high
     role: factory
+    parameters:
+      - index: 0
+        name: secret
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
   - method: com.auth0.jwt.algorithms.Algorithm.HMAC512
     arity: 1
     return:
       type: com.auth0.jwt.algorithms.Algorithm
       confidence: high
     role: factory
+    parameters:
+      - index: 0
+        name: secret
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
   - method: com.auth0.jwt.algorithms.Algorithm.RSA256
     arity: 1
     return:

--- a/internal/callgraph/contracts/java/jwks-rsa.yaml
+++ b/internal/callgraph/contracts/java/jwks-rsa.yaml
@@ -1,0 +1,244 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: jwks-rsa
+  coordinates:
+    - "com.auth0:jwks-rsa"
+  # Lower bound verified against the upstream CHANGELOG: every contracted API
+  # exists from 0.21.0 except the JwksHttpClient surface (0.24.0), annotated
+  # inline. Verified against library source at release 0.24.1.
+  version_range: ">=0.21,<1.0"
+  description: "Auth0 jwks-rsa contracts for JWKS provider construction and signing-key resolution"
+
+contracts:
+  # --- Provider builder (com.auth0.jwk.JwkProviderBuilder) ---
+  # The arity-1 constructor is overloaded (URL / String domain), so canonical
+  # signature fields are omitted there.
+  - method: com.auth0.jwk.JwkProviderBuilder.<init>
+    arity: 1
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.JwkProviderBuilder.cached
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.cached
+    arity: 2
+    parameter_types: [long, java.time.Duration]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.cached
+    arity: 3
+    parameter_types: [long, long, java.util.concurrent.TimeUnit]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.rateLimited
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.rateLimited
+    arity: 3
+    parameter_types: [long, long, java.util.concurrent.TimeUnit]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.proxied
+    arity: 1
+    parameter_types: [java.net.Proxy]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.timeouts
+    arity: 2
+    parameter_types: [int, int]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.headers
+    arity: 1
+    parameter_types: [java.util.Map]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  # httpClient(JwksHttpClient) was added in jwks-rsa 0.24.0.
+  - method: com.auth0.jwk.JwkProviderBuilder.httpClient
+    arity: 1
+    parameter_types: [com.auth0.jwk.JwksHttpClient]
+    canonical_return_type: com.auth0.jwk.JwkProviderBuilder
+    return:
+      type: com.auth0.jwk.JwkProviderBuilder
+      confidence: high
+    role: config
+  - method: com.auth0.jwk.JwkProviderBuilder.build
+    arity: 0
+    canonical_return_type: com.auth0.jwk.JwkProvider
+    return:
+      type: com.auth0.jwk.JwkProvider
+      confidence: high
+    role: factory
+
+  # --- Key resolution (com.auth0.jwk.JwkProvider) ---
+  # Authored on the interface; UrlJwkProvider, GuavaCachedJwkProvider, and
+  # RateLimitedJwkProvider resolve through the hierarchy edges below.
+  - method: com.auth0.jwk.JwkProvider.get
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.auth0.jwk.Jwk
+    return:
+      type: com.auth0.jwk.Jwk
+      confidence: high
+    role: factory
+
+  # --- Concrete providers ---
+  # UrlJwkProvider's arity-1 constructor is overloaded (URL / String domain).
+  - method: com.auth0.jwk.UrlJwkProvider.<init>
+    arity: 1
+    return:
+      type: com.auth0.jwk.UrlJwkProvider
+      confidence: high
+    role: factory
+  # UrlJwkProvider(URL, JwksHttpClient) was added in jwks-rsa 0.24.0.
+  - method: com.auth0.jwk.UrlJwkProvider.<init>
+    arity: 2
+    parameter_types: [java.net.URL, com.auth0.jwk.JwksHttpClient]
+    canonical_return_type: com.auth0.jwk.UrlJwkProvider
+    return:
+      type: com.auth0.jwk.UrlJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.UrlJwkProvider.<init>
+    arity: 3
+    parameter_types: [java.net.URL, java.lang.Integer, java.lang.Integer]
+    canonical_return_type: com.auth0.jwk.UrlJwkProvider
+    return:
+      type: com.auth0.jwk.UrlJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.UrlJwkProvider.<init>
+    arity: 4
+    parameter_types:
+      [java.net.URL, java.lang.Integer, java.lang.Integer, java.net.Proxy]
+    canonical_return_type: com.auth0.jwk.UrlJwkProvider
+    return:
+      type: com.auth0.jwk.UrlJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.UrlJwkProvider.<init>
+    arity: 5
+    parameter_types:
+      [
+        java.net.URL,
+        java.lang.Integer,
+        java.lang.Integer,
+        java.net.Proxy,
+        java.util.Map,
+      ]
+    canonical_return_type: com.auth0.jwk.UrlJwkProvider
+    return:
+      type: com.auth0.jwk.UrlJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.GuavaCachedJwkProvider.<init>
+    arity: 1
+    parameter_types: [com.auth0.jwk.JwkProvider]
+    canonical_return_type: com.auth0.jwk.GuavaCachedJwkProvider
+    return:
+      type: com.auth0.jwk.GuavaCachedJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.GuavaCachedJwkProvider.<init>
+    arity: 3
+    parameter_types: [com.auth0.jwk.JwkProvider, long, java.time.Duration]
+    canonical_return_type: com.auth0.jwk.GuavaCachedJwkProvider
+    return:
+      type: com.auth0.jwk.GuavaCachedJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.GuavaCachedJwkProvider.<init>
+    arity: 4
+    parameter_types:
+      [com.auth0.jwk.JwkProvider, long, long, java.util.concurrent.TimeUnit]
+    canonical_return_type: com.auth0.jwk.GuavaCachedJwkProvider
+    return:
+      type: com.auth0.jwk.GuavaCachedJwkProvider
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.RateLimitedJwkProvider.<init>
+    arity: 2
+    parameter_types: [com.auth0.jwk.JwkProvider, com.auth0.jwk.Bucket]
+    canonical_return_type: com.auth0.jwk.RateLimitedJwkProvider
+    return:
+      type: com.auth0.jwk.RateLimitedJwkProvider
+      confidence: high
+    role: factory
+
+  # --- JWK material (com.auth0.jwk.Jwk) ---
+  # Both arity-9 constructors (List vs String operations) share the return type.
+  - method: com.auth0.jwk.Jwk.<init>
+    arity: 9
+    return:
+      type: com.auth0.jwk.Jwk
+      confidence: high
+    role: factory
+  - method: com.auth0.jwk.Jwk.fromValues
+    arity: 1
+    parameter_types: [java.util.Map]
+    canonical_return_type: com.auth0.jwk.Jwk
+    return:
+      type: com.auth0.jwk.Jwk
+      confidence: high
+    role: factory
+  # Declared return is the generic java.security.PublicKey; the concrete key is
+  # RSA or EC depending on the JWK's kty, which is runtime data — the contract
+  # intentionally stays at the declared supertype.
+  - method: com.auth0.jwk.Jwk.getPublicKey
+    arity: 0
+    canonical_return_type: java.security.PublicKey
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: output
+
+hierarchy:
+  com.auth0.jwk.JwkProviderBuilder:
+    - java.lang.Object
+  com.auth0.jwk.JwkProvider:
+    - java.lang.Object
+  com.auth0.jwk.UrlJwkProvider:
+    - com.auth0.jwk.JwkProvider
+  com.auth0.jwk.GuavaCachedJwkProvider:
+    - com.auth0.jwk.JwkProvider
+  com.auth0.jwk.RateLimitedJwkProvider:
+    - com.auth0.jwk.JwkProvider
+  com.auth0.jwk.Jwk:
+    - java.lang.Object
+  java.security.PublicKey:
+    - java.security.Key
+  java.security.Key:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -745,6 +745,18 @@ func TestLoadEmbeddedJava_JavaJwtAndJwksRsaLifecycle(t *testing.T) {
 		})
 	}
 
+	// The HMAC factories take the key material directly; the secret argument
+	// contributes the key size by bit length, mirroring the byte[]-key factory
+	// convention in the bouncycastle-openpgp and go KBs.
+	hmac := kb.ContractsFor("com.auth0.jwt.algorithms.Algorithm.HMAC256", 1)
+	if len(hmac) != 1 || len(hmac[0].Parameters) != 1 {
+		t.Fatalf("Algorithm.HMAC256#1 parameters = %#v, want one secret parameter role", hmac)
+	}
+	p := hmac[0].Parameters[0]
+	if p.Index == nil || *p.Index != 0 || p.Role != "metadata-contributing" || p.Contributes == nil || p.Contributes.Property != "keySize" || p.Contributes.Derivation != "argument_bit_length" {
+		t.Fatalf("Algorithm.HMAC256#1 parameters[0] = %#v, want index=0 keySize/argument_bit_length", p)
+	}
+
 	// BaseVerification implements Verification; the concrete verifier and the
 	// concrete JWKS providers must resolve to their interface declarations.
 	if parents := kb.Hierarchy["com.auth0.jwt.JWTVerifier.BaseVerification"]; len(parents) != 1 || parents[0] != "com.auth0.jwt.interfaces.Verification" {

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -677,3 +677,89 @@ func TestLoadEmbeddedJava_SpringSecurityCrypto71EncoderLifecycle(t *testing.T) {
 		t.Fatalf("DelegatingPasswordEncoder hierarchy = %v, want [PasswordEncoder]", parents)
 	}
 }
+
+// TestLoadEmbeddedJava_JavaJwtAndJwksRsaLifecycle verifies the Auth0 java-jwt
+// and jwks-rsa contracts (scanoss/crypto-finder#203): the JWT.create fluent
+// signing chain, the JWT.require verification chain built on the Verification
+// interface, the Algorithm factories, and the JWKS key-resolution surface
+// (JwkProviderBuilder fluent chain, JwkProvider.get, Jwk.getPublicKey) —
+// including return types, lifecycle roles, and the hierarchy edges that let
+// concrete providers and BaseVerification resolve to their interface
+// declarations.
+func TestLoadEmbeddedJava_JavaJwtAndJwksRsaLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+		lib    string
+	}{
+		// java-jwt: creation + signing chain.
+		{"com.auth0.jwt.JWT.create", 0, "com.auth0.jwt.JWTCreator.Builder", "factory", "java-jwt"},
+		{"com.auth0.jwt.JWTCreator.Builder.withIssuer", 1, "com.auth0.jwt.JWTCreator.Builder", "config", "java-jwt"},
+		{"com.auth0.jwt.JWTCreator.Builder.withClaim", 2, "com.auth0.jwt.JWTCreator.Builder", "config", "java-jwt"},
+		{"com.auth0.jwt.JWTCreator.Builder.sign", 1, "java.lang.String", "operation", "java-jwt"},
+		// java-jwt: algorithm factories (HMAC/RSA/ECDSA/PSS/none).
+		{"com.auth0.jwt.algorithms.Algorithm.HMAC256", 1, "com.auth0.jwt.algorithms.Algorithm", "factory", "java-jwt"},
+		{"com.auth0.jwt.algorithms.Algorithm.RSA256", 2, "com.auth0.jwt.algorithms.Algorithm", "factory", "java-jwt"},
+		{"com.auth0.jwt.algorithms.Algorithm.RSA512PSS", 2, "com.auth0.jwt.algorithms.Algorithm", "factory", "java-jwt"},
+		{"com.auth0.jwt.algorithms.Algorithm.ECDSA256", 1, "com.auth0.jwt.algorithms.Algorithm", "factory", "java-jwt"},
+		{"com.auth0.jwt.algorithms.Algorithm.none", 0, "com.auth0.jwt.algorithms.Algorithm", "factory", "java-jwt"},
+		// java-jwt: raw sign/verify operations on the Algorithm base.
+		{"com.auth0.jwt.algorithms.Algorithm.sign", 2, "byte[]", "operation", "java-jwt"},
+		{"com.auth0.jwt.algorithms.Algorithm.verify", 1, "void", "operation", "java-jwt"},
+		// java-jwt: verification chain (Verification interface -> JWTVerifier).
+		{"com.auth0.jwt.JWT.require", 1, "com.auth0.jwt.interfaces.Verification", "factory", "java-jwt"},
+		{"com.auth0.jwt.interfaces.Verification.withIssuer", 1, "com.auth0.jwt.interfaces.Verification", "config", "java-jwt"},
+		{"com.auth0.jwt.interfaces.Verification.acceptLeeway", 1, "com.auth0.jwt.interfaces.Verification", "config", "java-jwt"},
+		{"com.auth0.jwt.interfaces.Verification.build", 0, "com.auth0.jwt.JWTVerifier", "factory", "java-jwt"},
+		{"com.auth0.jwt.interfaces.JWTVerifier.verify", 1, "com.auth0.jwt.interfaces.DecodedJWT", "operation", "java-jwt"},
+		{"com.auth0.jwt.JWT.decode", 1, "com.auth0.jwt.interfaces.DecodedJWT", "factory", "java-jwt"},
+		// jwks-rsa: provider construction + key resolution.
+		{"com.auth0.jwk.JwkProviderBuilder.<init>", 1, "com.auth0.jwk.JwkProviderBuilder", "factory", "jwks-rsa"},
+		{"com.auth0.jwk.JwkProviderBuilder.cached", 3, "com.auth0.jwk.JwkProviderBuilder", "config", "jwks-rsa"},
+		{"com.auth0.jwk.JwkProviderBuilder.rateLimited", 3, "com.auth0.jwk.JwkProviderBuilder", "config", "jwks-rsa"},
+		{"com.auth0.jwk.JwkProviderBuilder.build", 0, "com.auth0.jwk.JwkProvider", "factory", "jwks-rsa"},
+		{"com.auth0.jwk.JwkProvider.get", 1, "com.auth0.jwk.Jwk", "factory", "jwks-rsa"},
+		{"com.auth0.jwk.UrlJwkProvider.<init>", 1, "com.auth0.jwk.UrlJwkProvider", "factory", "jwks-rsa"},
+		{"com.auth0.jwk.Jwk.fromValues", 1, "com.auth0.jwk.Jwk", "factory", "jwks-rsa"},
+		{"com.auth0.jwk.Jwk.getPublicKey", 0, "java.security.PublicKey", "output", "jwks-rsa"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != tt.lib {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from %q", tt.method, tt.arity, got[0], tt.want, tt.role, tt.lib)
+			}
+		})
+	}
+
+	// BaseVerification implements Verification; the concrete verifier and the
+	// concrete JWKS providers must resolve to their interface declarations.
+	if parents := kb.Hierarchy["com.auth0.jwt.JWTVerifier.BaseVerification"]; len(parents) != 1 || parents[0] != "com.auth0.jwt.interfaces.Verification" {
+		t.Fatalf("BaseVerification hierarchy = %v, want [Verification]", parents)
+	}
+	if parents := kb.Hierarchy["com.auth0.jwt.JWTVerifier"]; len(parents) != 1 || parents[0] != "com.auth0.jwt.interfaces.JWTVerifier" {
+		t.Fatalf("JWTVerifier hierarchy = %v, want [interfaces.JWTVerifier]", parents)
+	}
+	for _, provider := range []string{
+		"com.auth0.jwk.UrlJwkProvider",
+		"com.auth0.jwk.GuavaCachedJwkProvider",
+		"com.auth0.jwk.RateLimitedJwkProvider",
+	} {
+		if parents := kb.Hierarchy[provider]; len(parents) != 1 || parents[0] != "com.auth0.jwk.JwkProvider" {
+			t.Fatalf("%s hierarchy = %v, want [JwkProvider]", provider, parents)
+		}
+	}
+}


### PR DESCRIPTION
Closes #203

## What

Adds callgraph inferred-types contracts for **Auth0 java-jwt** (`com.auth0:java-jwt`, 4.x) and **jwks-rsa** (`com.auth0:jwks-rsa`, >=0.21) — detection rules already exist; this fills the contract gap so reachability and supporting-call derivation work for both libraries.

- `internal/callgraph/contracts/java/java-jwt.yaml` — 51 contracts: `JWT.create()` fluent signing chain (`JWTCreator.Builder` config methods + `sign` operation), `Algorithm` HMAC/RSA/ECDSA/RSA-PSS/none factories, raw `Algorithm.sign`/`verify` operations, and the verification chain (`JWT.require` → `Verification` config methods → `build()` → `JWTVerifier.verify`), authored on the public interfaces with hierarchy edges resolving `BaseVerification` and the concrete `JWTVerifier`.
- `internal/callgraph/contracts/java/jwks-rsa.yaml` — 24 contracts: `JwkProviderBuilder` fluent chain, `JwkProvider.get(keyId)` key resolution authored on the interface (with `UrlJwkProvider`/`GuavaCachedJwkProvider`/`RateLimitedJwkProvider` hierarchy edges), concrete provider constructors, `Jwk.fromValues`, and `Jwk.getPublicKey()` → `java.security.PublicKey`.
- `TestLoadEmbeddedJava_JavaJwtAndJwksRsaLifecycle` asserts key entries (return type, lifecycle role, source library) and the interface-resolution hierarchy edges.
- CHANGELOG `[Unreleased]` entry.

Signatures verified against upstream sources at java-jwt **4.6.0** and jwks-rsa **0.24.1**; version-introduction bounds (`RSA*PSS` @4.6.0, `httpClient` @0.24.0, jwks-rsa lower bound 0.21) verified against upstream CHANGELOGs and annotated inline.

## API audit (dispositions)

**java-jwt** (`com.auth0.jwt`):
- `contracted`: `JWT.<init>/create/require/decode/decodeJwt`; all `Algorithm` factories (HMAC256/384/512, RSA256/384/512 ×2 arities, RSA256/384/512PSS ×2, ECDSA256/384/512 ×2, `none`); `Algorithm.sign#1/#2`, `Algorithm.verify#1`; `JWTCreator.Builder` withHeader/withKeyId/withIssuer/withSubject/withAudience/withExpiresAt/withNotBefore/withIssuedAt/withJWTId/withClaim/withNullClaim/withArrayClaim/withPayload/sign; `Verification` withIssuer/withSubject/withAudience/withAnyOfAudience/acceptLeeway/acceptExpiresAt/acceptNotBefore/acceptIssuedAt/ignoreIssuedAt/withJWTId/withClaimPresence/withNullClaim/withClaim/withArrayClaim/build; `BaseVerification.build(Clock)`; `interfaces.JWTVerifier.verify#1` (String and DecodedJWT overloads share arity + return).
- `skipped-informative-return`: `DecodedJWT`/`Claim`/`Header`/`Payload` getters, `Algorithm.getName/getSigningKeyId`, `BaseVerification.getLeewayFor`; `KeyProvider`/`RSAKeyProvider`/`ECDSAKeyProvider` SPI getters (declared returns already concrete key types).
- `skipped-non-crypto`: `TokenUtils`, exception types, serializer/deserializer `impl` classes (not public API surface).

**jwks-rsa** (`com.auth0.jwk`):
- `contracted`: `JwkProviderBuilder.<init>#1` (URL/String), `cached#1/#2/#3`, `rateLimited#1/#3`, `proxied`, `timeouts`, `headers`, `httpClient`, `build`; `JwkProvider.get#1` (interface); `UrlJwkProvider.<init>#1..#5`; `GuavaCachedJwkProvider.<init>#1/#3/#4`; `RateLimitedJwkProvider.<init>#2`; `Jwk.<init>#9` (both overloads), `Jwk.fromValues`, `Jwk.getPublicKey`.
- `skipped-unsupported`: `UrlJwkProvider.getAll()` → `List<Jwk>` (generic container element type not modelable).
- `skipped-informative-return`: `Jwk` getters (getId/getType/getAlgorithm/...), package-private `getBaseProvider`.
- `skipped-non-crypto`: `Bucket`/`BucketImpl`, `JwksHttpClient`/`JwksHttpResponse` transport, `Util`, exception types.

Source: cloned upstream repos (`auth0/java-jwt` @4.6.0, `auth0/jwks-rsa-java` @0.24.1) + upstream CHANGELOGs.

## Testing

- `go test ./internal/callgraph/contracts/...` green.
- Full `go test ./...` green except the pre-existing `internal/engine` Postgres testcontainers failures (require a running Docker daemon; identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Java call-graph support for Auth0 `java-jwt` 4.x token creation, signing, decoding, and verification workflows.
  * Added support for `jwks-rsa` provider configuration, key lookup, and public-key extraction.
  * Improved recognition of related algorithms, builders, providers, and type hierarchies.
* **Tests**
  * Added coverage validating JWT and JWKS lifecycle analysis, return types, and provider relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->