### PR TITLE
feat(contracts/java): hutool-crypto, i2p-eddsa, and pgpainless lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the Hutool-crypto 5.8 SecureUtil/DigestUtil/SmUtil/KeyUtil factories and the symmetric, digest, MAC, asymmetric, signing, and SM2 lifecycles.
+- Java callgraph contracts now model the I2P ed25519-java (net.i2p.crypto:eddsa) 0.3 EdDSA signing engine, key-pair generation, and key/spec construction lifecycles.
+- Java callgraph contracts now model the PGPainless 1.7 OpenPGP encrypt/sign, decrypt/verify, key-generation, and key-parsing fluent lifecycles.
 - Java callgraph contracts now model the Auth0 java-jwt 4.x token creation, signing, decoding, and verification lifecycles, and the jwks-rsa JWKS provider construction and signing-key resolution lifecycles.
 - Python callgraph contracts now model the python-rsa 4.x key-pair generation, PKCS#1 encryption, signing, and key-serialization lifecycles.
 - Python callgraph contracts now model the python-ecdsa 0.19 SigningKey/VerifyingKey generation, signing, verification, serialization, and ECDH key-agreement lifecycles.

--- a/internal/callgraph/contracts/java/hutool-crypto.yaml
+++ b/internal/callgraph/contracts/java/hutool-crypto.yaml
@@ -1,0 +1,2209 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: hutool-crypto
+  coordinates:
+    - "cn.hutool:hutool-crypto"
+    - "cn.hutool:hutool-all"
+  # Verified against upstream source at release 5.8.47 (branch v5-master).
+  # hutool 6.x renamed the packages to org.dromara.hutool.crypto and is a
+  # different KB if ever needed; detection rules target the cn.hutool 5.x tree.
+  version_range: ">=5.8,<6.0"
+  description: "Hutool-crypto contracts for SecureUtil/DigestUtil/SmUtil/KeyUtil factories and the symmetric, digest, MAC, asymmetric, and SM2 lifecycles"
+
+contracts:
+  # =========================================================================
+  # SecureUtil static factories (cn.hutool.crypto.SecureUtil)
+  # Most methods are overloaded at the same arity (String/byte[]/KeySpec...)
+  # with a single declared return — canonical signature fields are omitted on
+  # those entries.
+  # =========================================================================
+  - method: cn.hutool.crypto.SecureUtil.generateKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generateKey
+    arity: 2
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generateDESKey
+    arity: 2
+    parameter_types: [java.lang.String, "byte[]"]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generatePBEKey
+    arity: 2
+    parameter_types: [java.lang.String, "char[]"]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generatePrivateKey
+    arity: 2
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generatePrivateKey
+    arity: 3
+    parameter_types: [java.security.KeyStore, java.lang.String, "char[]"]
+    canonical_return_type: java.security.PrivateKey
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generatePublicKey
+    arity: 2
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generateKeyPair
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.KeyPair
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generateKeyPair
+    arity: 2
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generateKeyPair
+    arity: 3
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.generateSignature
+    arity: 2
+    canonical_return_type: java.security.Signature
+    return:
+      type: java.security.Signature
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.readJKSKeyStore
+    arity: 2
+    parameter_types: [java.io.InputStream, "char[]"]
+    canonical_return_type: java.security.KeyStore
+    return:
+      type: java.security.KeyStore
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.readKeyStore
+    arity: 3
+    parameter_types: [java.lang.String, java.io.InputStream, "char[]"]
+    canonical_return_type: java.security.KeyStore
+    return:
+      type: java.security.KeyStore
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.readX509Certificate
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.readX509Certificate
+    arity: 3
+    parameter_types: [java.io.InputStream, "char[]", java.lang.String]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.readCertificate
+    arity: 2
+    parameter_types: [java.lang.String, java.io.InputStream]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.readCertificate
+    arity: 4
+    parameter_types:
+      [java.lang.String, java.io.InputStream, "char[]", java.lang.String]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.getCertificate
+    arity: 2
+    parameter_types: [java.security.KeyStore, java.lang.String]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.aes
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.AES
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.aes
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.AES
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.des
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.DES
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.des
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.DES
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.desede
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.DESede
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.desede
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.DESede
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  # md5/sha1/sha256 split by arity: arity 0 returns the digester object,
+  # arity 1 performs the digest and returns the hex string.
+  - method: cn.hutool.crypto.SecureUtil.md5
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.MD5
+    return:
+      type: cn.hutool.crypto.digest.MD5
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.md5
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.sha1
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.sha1
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.sha256
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.sha256
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.hmac
+    arity: 2
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.hmacMd5
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.HMac
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.hmacMd5
+    arity: 1
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.hmacSha1
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.HMac
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.hmacSha1
+    arity: 1
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.hmacSha256
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.HMac
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.hmacSha256
+    arity: 1
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.rsa
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.RSA
+    return:
+      type: cn.hutool.crypto.asymmetric.RSA
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.rsa
+    arity: 2
+    return:
+      type: cn.hutool.crypto.asymmetric.RSA
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.sign
+    arity: 1
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.sign
+    arity: 3
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.signParams
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.signParams
+    arity: 6
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.signParamsMd5
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.signParamsSha1
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.signParamsSha256
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.createCipher
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: javax.crypto.Cipher
+    return:
+      type: javax.crypto.Cipher
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.createMessageDigest
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.MessageDigest
+    return:
+      type: java.security.MessageDigest
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.createJdkMessageDigest
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.MessageDigest
+    return:
+      type: java.security.MessageDigest
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.createMac
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: javax.crypto.Mac
+    return:
+      type: javax.crypto.Mac
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.createSignature
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.Signature
+    return:
+      type: java.security.Signature
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.rc4
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: cn.hutool.crypto.symmetric.RC4
+    return:
+      type: cn.hutool.crypto.symmetric.RC4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.pbkdf2
+    arity: 2
+    parameter_types: ["char[]", "byte[]"]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SecureUtil.fpe
+    arity: 4
+    canonical_return_type: cn.hutool.crypto.symmetric.fpe.FPE
+    return:
+      type: cn.hutool.crypto.symmetric.fpe.FPE
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SecureUtil.zuc128
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.ZUC
+    return:
+      type: cn.hutool.crypto.symmetric.ZUC
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SecureUtil.zuc256
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.ZUC
+    return:
+      type: cn.hutool.crypto.symmetric.ZUC
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  # SignUtil hosts the sign/signParams family; SecureUtil delegates to it and
+  # both spellings appear in consumer code.
+  - method: cn.hutool.crypto.SignUtil.sign
+    arity: 1
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SignUtil.sign
+    arity: 3
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SignUtil.signParams
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SignUtil.signParams
+    arity: 6
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SignUtil.signParamsMd5
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SignUtil.signParamsSha1
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SignUtil.signParamsSha256
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # DigestUtil static digests (cn.hutool.crypto.digest.DigestUtil)
+  # =========================================================================
+  - method: cn.hutool.crypto.digest.DigestUtil.md5
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.md5
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.md5Hex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.md5Hex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.md5Hex16
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.md5Hex16
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha1
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha1
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha1Hex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha1Hex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha256
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha256
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha256Hex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha256Hex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha512
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha512
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha512Hex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.sha512Hex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.hmac
+    arity: 2
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.digest.DigestUtil.digester
+    arity: 1
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.DigestUtil.bcrypt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.DigestUtil.bcryptCheck
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # SmUtil static factories (cn.hutool.crypto.SmUtil)
+  # =========================================================================
+  - method: cn.hutool.crypto.SmUtil.sm2
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SmUtil.sm2
+    arity: 2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: factory
+  # sm3 splits by arity: arity 0 returns the SM3 digester, arity 1 digests and
+  # returns the hex string.
+  - method: cn.hutool.crypto.SmUtil.sm3
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SmUtil.sm3
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.SmUtil.sm3WithSalt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SmUtil.sm4
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.SM4
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.SmUtil.sm4
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.SM4
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.SmUtil.hmacSm3
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.digest.HMac
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  # =========================================================================
+  # KeyUtil static key/keystore/certificate factories (cn.hutool.crypto.KeyUtil)
+  # =========================================================================
+  - method: cn.hutool.crypto.KeyUtil.generateKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateKey
+    arity: 2
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateKey
+    arity: 3
+    parameter_types: [java.lang.String, int, java.security.SecureRandom]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateDESKey
+    arity: 2
+    parameter_types: [java.lang.String, "byte[]"]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generatePBEKey
+    arity: 2
+    parameter_types: [java.lang.String, "char[]"]
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateRSAPrivateKey
+    arity: 1
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generatePrivateKey
+    arity: 2
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generatePrivateKey
+    arity: 3
+    parameter_types: [java.security.KeyStore, java.lang.String, "char[]"]
+    canonical_return_type: java.security.PrivateKey
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateRSAPublicKey
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: java.security.PublicKey
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generatePublicKey
+    arity: 2
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateKeyPair
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.KeyPair
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateKeyPair
+    arity: 2
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateKeyPair
+    arity: 3
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.generateKeyPair
+    arity: 4
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getKeyPairGenerator
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.KeyPairGenerator
+    return:
+      type: java.security.KeyPairGenerator
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getKeyFactory
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.KeyFactory
+    return:
+      type: java.security.KeyFactory
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getSecretKeyFactory
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: javax.crypto.SecretKeyFactory
+    return:
+      type: javax.crypto.SecretKeyFactory
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getKeyGenerator
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: javax.crypto.KeyGenerator
+    return:
+      type: javax.crypto.KeyGenerator
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readJKSKeyStore
+    arity: 2
+    return:
+      type: java.security.KeyStore
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readPKCS12KeyStore
+    arity: 2
+    return:
+      type: java.security.KeyStore
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readKeyStore
+    arity: 3
+    return:
+      type: java.security.KeyStore
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getKeyStore
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.KeyStore
+    return:
+      type: java.security.KeyStore
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getKeyPair
+    arity: 3
+    parameter_types: [java.security.KeyStore, "char[]", java.lang.String]
+    canonical_return_type: java.security.KeyPair
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getKeyPair
+    arity: 4
+    parameter_types:
+      [java.lang.String, java.io.InputStream, "char[]", java.lang.String]
+    canonical_return_type: java.security.KeyPair
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readX509Certificate
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readX509Certificate
+    arity: 3
+    parameter_types: [java.io.InputStream, "char[]", java.lang.String]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readPublicKeyFromCert
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: java.security.PublicKey
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readCertificate
+    arity: 2
+    parameter_types: [java.lang.String, java.io.InputStream]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.readCertificate
+    arity: 4
+    parameter_types:
+      [java.lang.String, java.io.InputStream, "char[]", java.lang.String]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getCertificate
+    arity: 2
+    parameter_types: [java.security.KeyStore, java.lang.String]
+    canonical_return_type: java.security.cert.Certificate
+    return:
+      type: java.security.cert.Certificate
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getCertificateFactory
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.cert.CertificateFactory
+    return:
+      type: java.security.cert.CertificateFactory
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.decodeECPoint
+    arity: 2
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getRSAPublicKey
+    arity: 1
+    parameter_types: [java.security.PrivateKey]
+    canonical_return_type: java.security.PublicKey
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.getRSAPublicKey
+    arity: 2
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.KeyUtil.encodeECPublicKey
+    arity: 1
+    parameter_types: [java.security.PublicKey]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: cn.hutool.crypto.KeyUtil.toBase64
+    arity: 1
+    parameter_types: [java.security.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # Symmetric lifecycle (cn.hutool.crypto.symmetric.SymmetricCrypto)
+  # AES/DES/DESede/SM4/ChaCha20/ZUC inherit this surface and resolve through
+  # the hierarchy edges below.
+  # =========================================================================
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.<init>
+    arity: 1
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.<init>
+    arity: 3
+    parameter_types:
+      [
+        java.lang.String,
+        javax.crypto.SecretKey,
+        java.security.spec.AlgorithmParameterSpec,
+      ]
+    canonical_return_type: cn.hutool.crypto.symmetric.SymmetricCrypto
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.init
+    arity: 2
+    parameter_types: [java.lang.String, javax.crypto.SecretKey]
+    canonical_return_type: cn.hutool.crypto.symmetric.SymmetricCrypto
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.setIv
+    arity: 1
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.setParams
+    arity: 1
+    parameter_types: [java.security.spec.AlgorithmParameterSpec]
+    canonical_return_type: cn.hutool.crypto.symmetric.SymmetricCrypto
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.setRandom
+    arity: 1
+    parameter_types: [java.security.SecureRandom]
+    canonical_return_type: cn.hutool.crypto.symmetric.SymmetricCrypto
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.setMode
+    arity: 1
+    canonical_return_type: cn.hutool.crypto.symmetric.SymmetricCrypto
+    return:
+      type: cn.hutool.crypto.symmetric.SymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.update
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.updateHex
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encrypt
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encrypt
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encrypt
+    arity: 3
+    parameter_types: [java.io.InputStream, java.io.OutputStream, boolean]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encryptHex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encryptHex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encryptBase64
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.encryptBase64
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.decrypt
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.decrypt
+    arity: 3
+    parameter_types: [java.io.InputStream, java.io.OutputStream, boolean]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.decryptStr
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.decryptStr
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.getSecretKey
+    arity: 0
+    canonical_return_type: javax.crypto.SecretKey
+    return:
+      type: javax.crypto.SecretKey
+      confidence: high
+    role: output
+  - method: cn.hutool.crypto.symmetric.SymmetricCrypto.getCipher
+    arity: 0
+    canonical_return_type: javax.crypto.Cipher
+    return:
+      type: javax.crypto.Cipher
+      confidence: high
+    role: output
+
+  # --- Symmetric subclass constructors ---
+  - method: cn.hutool.crypto.symmetric.AES.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.AES
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.AES.<init>
+    arity: 1
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.symmetric.AES.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.AES.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.AES.<init>
+    arity: 4
+    return:
+      type: cn.hutool.crypto.symmetric.AES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DES.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.DES
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DES.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.DES
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.symmetric.DES.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DES.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DES.<init>
+    arity: 4
+    return:
+      type: cn.hutool.crypto.symmetric.DES
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DESede.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.DESede
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DESede.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.DESede
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.symmetric.DESede.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DESede.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.DESede.<init>
+    arity: 4
+    return:
+      type: cn.hutool.crypto.symmetric.DESede
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SM4.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.symmetric.SM4
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SM4.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.SM4
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.symmetric.SM4.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SM4.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.SM4.<init>
+    arity: 4
+    return:
+      type: cn.hutool.crypto.symmetric.SM4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.ChaCha20.<init>
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: cn.hutool.crypto.symmetric.ChaCha20
+    return:
+      type: cn.hutool.crypto.symmetric.ChaCha20
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  # --- RC4 (standalone, does NOT extend SymmetricCrypto; decrypt returns
+  # String here, unlike SymmetricCrypto.decrypt) ---
+  - method: cn.hutool.crypto.symmetric.RC4.<init>
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: cn.hutool.crypto.symmetric.RC4
+    return:
+      type: cn.hutool.crypto.symmetric.RC4
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.symmetric.RC4.encrypt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.encrypt
+    arity: 2
+    parameter_types: [java.lang.String, java.nio.charset.Charset]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.encryptHex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.encryptHex
+    arity: 2
+    parameter_types: [java.lang.String, java.nio.charset.Charset]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.encryptBase64
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.encryptBase64
+    arity: 2
+    parameter_types: [java.lang.String, java.nio.charset.Charset]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.decrypt
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.decrypt
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.crypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.symmetric.RC4.setKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+
+  # =========================================================================
+  # Digest lifecycle (cn.hutool.crypto.digest.Digester; MD5/SM3 inherit)
+  # =========================================================================
+  - method: cn.hutool.crypto.digest.Digester.<init>
+    arity: 1
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.Digester.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.Digester.init
+    arity: 2
+    parameter_types: [java.lang.String, java.security.Provider]
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.digest.Digester.setSalt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.digest.Digester.setSaltPosition
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.digest.Digester.setDigestCount
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.digest.Digester.reset
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.Digester
+    return:
+      type: cn.hutool.crypto.digest.Digester
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.digest.Digester.digest
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.Digester.digest
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.Digester.digestHex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.Digester.digestHex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.Digester.getDigest
+    arity: 0
+    canonical_return_type: java.security.MessageDigest
+    return:
+      type: java.security.MessageDigest
+      confidence: high
+    role: output
+  - method: cn.hutool.crypto.digest.MD5.create
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.MD5
+    return:
+      type: cn.hutool.crypto.digest.MD5
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.MD5.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.MD5
+    return:
+      type: cn.hutool.crypto.digest.MD5
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.MD5.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.digest.MD5
+    return:
+      type: cn.hutool.crypto.digest.MD5
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.MD5.<init>
+    arity: 2
+    parameter_types: ["byte[]", int]
+    canonical_return_type: cn.hutool.crypto.digest.MD5
+    return:
+      type: cn.hutool.crypto.digest.MD5
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.MD5.<init>
+    arity: 3
+    parameter_types: ["byte[]", int, int]
+    canonical_return_type: cn.hutool.crypto.digest.MD5
+    return:
+      type: cn.hutool.crypto.digest.MD5
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.MD5.digestHex16
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.MD5.digestHex16
+    arity: 2
+    parameter_types: [java.lang.String, java.nio.charset.Charset]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.SM3.create
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.SM3.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.SM3.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.SM3.<init>
+    arity: 2
+    parameter_types: ["byte[]", int]
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.SM3.<init>
+    arity: 3
+    parameter_types: ["byte[]", int, int]
+    canonical_return_type: cn.hutool.crypto.digest.SM3
+    return:
+      type: cn.hutool.crypto.digest.SM3
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # MAC lifecycle (cn.hutool.crypto.digest.mac.Mac base; HMac inherits)
+  # =========================================================================
+  - method: cn.hutool.crypto.digest.HMac.<init>
+    arity: 1
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.HMac.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: cn.hutool.crypto.digest.HMac.<init>
+    arity: 3
+    parameter_types:
+      [
+        java.lang.String,
+        java.security.Key,
+        java.security.spec.AlgorithmParameterSpec,
+      ]
+    canonical_return_type: cn.hutool.crypto.digest.HMac
+    return:
+      type: cn.hutool.crypto.digest.HMac
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.digest.mac.Mac.digest
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.mac.Mac.digest
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.mac.Mac.digestHex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.mac.Mac.digestHex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.mac.Mac.digestBase64
+    arity: 2
+    parameter_types: [java.lang.String, boolean]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.mac.Mac.digestBase64
+    arity: 3
+    parameter_types: [java.lang.String, java.nio.charset.Charset, boolean]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.digest.mac.Mac.verify
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Asymmetric lifecycle (cn.hutool.crypto.asymmetric.AsymmetricCrypto;
+  # RSA inherits and resolves through hierarchy)
+  # =========================================================================
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.<init>
+    arity: 1
+    return:
+      type: cn.hutool.crypto.asymmetric.AsymmetricCrypto
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.asymmetric.AsymmetricCrypto
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.init
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.security.PrivateKey, java.security.PublicKey]
+    canonical_return_type: cn.hutool.crypto.asymmetric.AsymmetricCrypto
+    return:
+      type: cn.hutool.crypto.asymmetric.AsymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.setRandom
+    arity: 1
+    parameter_types: [java.security.SecureRandom]
+    canonical_return_type: cn.hutool.crypto.asymmetric.AsymmetricCrypto
+    return:
+      type: cn.hutool.crypto.asymmetric.AsymmetricCrypto
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.setAlgorithmParameterSpec
+    arity: 1
+    parameter_types: [java.security.spec.AlgorithmParameterSpec]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.setEncryptBlockSize
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.setDecryptBlockSize
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encrypt
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encrypt
+    arity: 3
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encryptHex
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encryptHex
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encryptBase64
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encryptBase64
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encryptBcd
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.encryptBcd
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decrypt
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decryptStr
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decryptStr
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decryptFromBcd
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decryptFromBcd
+    arity: 3
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decryptStrFromBcd
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.decryptStrFromBcd
+    arity: 3
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.AsymmetricCrypto.getCipher
+    arity: 0
+    canonical_return_type: javax.crypto.Cipher
+    return:
+      type: javax.crypto.Cipher
+      confidence: high
+    role: output
+
+  # --- RSA (extends AsymmetricCrypto) ---
+  - method: cn.hutool.crypto.asymmetric.RSA.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.RSA
+    return:
+      type: cn.hutool.crypto.asymmetric.RSA
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.RSA.<init>
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: cn.hutool.crypto.asymmetric.RSA
+    return:
+      type: cn.hutool.crypto.asymmetric.RSA
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.RSA.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.asymmetric.RSA
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.RSA.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.asymmetric.RSA
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.RSA.generatePrivateKey
+    arity: 2
+    parameter_types: [java.math.BigInteger, java.math.BigInteger]
+    canonical_return_type: java.security.PrivateKey
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.RSA.generatePublicKey
+    arity: 2
+    parameter_types: [java.math.BigInteger, java.math.BigInteger]
+    canonical_return_type: java.security.PublicKey
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: factory
+
+  # --- Sign (extends BaseAsymmetric<Sign>) ---
+  - method: cn.hutool.crypto.asymmetric.Sign.<init>
+    arity: 1
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.Sign.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.Sign.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.Sign.init
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.security.PrivateKey, java.security.PublicKey]
+    canonical_return_type: cn.hutool.crypto.asymmetric.Sign
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.Sign.setParameter
+    arity: 1
+    parameter_types: [java.security.spec.AlgorithmParameterSpec]
+    canonical_return_type: cn.hutool.crypto.asymmetric.Sign
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.Sign.setSignature
+    arity: 1
+    parameter_types: [java.security.Signature]
+    canonical_return_type: cn.hutool.crypto.asymmetric.Sign
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.Sign.setCertificate
+    arity: 1
+    parameter_types: [java.security.cert.Certificate]
+    canonical_return_type: cn.hutool.crypto.asymmetric.Sign
+    return:
+      type: cn.hutool.crypto.asymmetric.Sign
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.Sign.sign
+    arity: 1
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.Sign.sign
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.Sign.signHex
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.Sign.signHex
+    arity: 2
+    parameter_types: [java.lang.String, java.nio.charset.Charset]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.Sign.verify
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.Sign.getSignature
+    arity: 0
+    canonical_return_type: java.security.Signature
+    return:
+      type: java.security.Signature
+      confidence: high
+    role: output
+
+  # --- SM2 (extends AbstractAsymmetricCrypto<SM2>) ---
+  - method: cn.hutool.crypto.asymmetric.SM2.<init>
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.SM2.<init>
+    arity: 2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.SM2.<init>
+    arity: 3
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: factory
+  - method: cn.hutool.crypto.asymmetric.SM2.init
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.SM2.initKeys
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.SM2.encrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.encrypt
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.decrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.decrypt
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.sign
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.sign
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.signHex
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.signHex
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.verify
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.verify
+    arity: 3
+    parameter_types: ["byte[]", "byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.verifyHex
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.verifyHex
+    arity: 3
+    parameter_types: [java.lang.String, java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: cn.hutool.crypto.asymmetric.SM2.setPrivateKey
+    arity: 1
+    parameter_types: [java.security.PrivateKey]
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.SM2.setPublicKey
+    arity: 1
+    parameter_types: [java.security.PublicKey]
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.SM2.usePlainEncoding
+    arity: 0
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: config
+  - method: cn.hutool.crypto.asymmetric.SM2.setMode
+    arity: 1
+    canonical_return_type: cn.hutool.crypto.asymmetric.SM2
+    return:
+      type: cn.hutool.crypto.asymmetric.SM2
+      confidence: high
+    role: config
+
+hierarchy:
+  # Symmetric family
+  cn.hutool.crypto.symmetric.SymmetricCrypto:
+    - java.lang.Object
+  cn.hutool.crypto.symmetric.AES:
+    - cn.hutool.crypto.symmetric.SymmetricCrypto
+  cn.hutool.crypto.symmetric.DES:
+    - cn.hutool.crypto.symmetric.SymmetricCrypto
+  cn.hutool.crypto.symmetric.DESede:
+    - cn.hutool.crypto.symmetric.SymmetricCrypto
+  cn.hutool.crypto.symmetric.SM4:
+    - cn.hutool.crypto.symmetric.SymmetricCrypto
+  cn.hutool.crypto.symmetric.ChaCha20:
+    - cn.hutool.crypto.symmetric.SymmetricCrypto
+  cn.hutool.crypto.symmetric.ZUC:
+    - cn.hutool.crypto.symmetric.SymmetricCrypto
+  cn.hutool.crypto.symmetric.RC4:
+    - java.lang.Object
+  cn.hutool.crypto.symmetric.fpe.FPE:
+    - java.lang.Object
+
+  # Digest family
+  cn.hutool.crypto.digest.Digester:
+    - java.lang.Object
+  cn.hutool.crypto.digest.MD5:
+    - cn.hutool.crypto.digest.Digester
+  cn.hutool.crypto.digest.SM3:
+    - cn.hutool.crypto.digest.Digester
+  cn.hutool.crypto.digest.mac.Mac:
+    - java.lang.Object
+  cn.hutool.crypto.digest.HMac:
+    - cn.hutool.crypto.digest.mac.Mac
+
+  # Asymmetric family
+  cn.hutool.crypto.asymmetric.BaseAsymmetric:
+    - java.lang.Object
+  cn.hutool.crypto.asymmetric.AbstractAsymmetricCrypto:
+    - cn.hutool.crypto.asymmetric.BaseAsymmetric
+  cn.hutool.crypto.asymmetric.AsymmetricCrypto:
+    - cn.hutool.crypto.asymmetric.AbstractAsymmetricCrypto
+  cn.hutool.crypto.asymmetric.RSA:
+    - cn.hutool.crypto.asymmetric.AsymmetricCrypto
+  cn.hutool.crypto.asymmetric.SM2:
+    - cn.hutool.crypto.asymmetric.AbstractAsymmetricCrypto
+  cn.hutool.crypto.asymmetric.Sign:
+    - cn.hutool.crypto.asymmetric.BaseAsymmetric
+
+  # JCA types referenced as returns (edges identical to jdk-crypto where they
+  # overlap, so the merge stays idempotent)
+  javax.crypto.SecretKey:
+    - java.security.Key
+  java.security.PrivateKey:
+    - java.security.Key
+  java.security.PublicKey:
+    - java.security.Key
+  java.security.Key:
+    - java.lang.Object
+  java.security.KeyPair:
+    - java.lang.Object
+  java.security.KeyStore:
+    - java.lang.Object
+  java.security.cert.Certificate:
+    - java.lang.Object
+  java.security.cert.CertificateFactory:
+    - java.lang.Object
+  javax.crypto.Cipher:
+    - java.lang.Object
+  javax.crypto.Mac:
+    - java.lang.Object
+  javax.crypto.KeyGenerator:
+    - java.lang.Object
+  javax.crypto.SecretKeyFactory:
+    - java.lang.Object
+  java.security.MessageDigest:
+    - java.security.MessageDigestSpi
+    - java.lang.Object
+  java.security.Signature:
+    - java.security.SignatureSpi
+    - java.lang.Object
+  java.security.KeyPairGenerator:
+    - java.security.KeyPairGeneratorSpi
+    - java.lang.Object
+  java.security.KeyFactory:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/i2p-eddsa.yaml
+++ b/internal/callgraph/contracts/java/i2p-eddsa.yaml
@@ -1,0 +1,289 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: i2p-eddsa
+  coordinates:
+    - "net.i2p.crypto:eddsa"
+  # Verified against upstream source at release 0.3.0 (str4d/ed25519-java).
+  version_range: ">=0.3.0,<0.4.0"
+  description: "I2P ed25519-java contracts for EdDSA signing engine, key-pair generation, and key/spec construction"
+
+contracts:
+  # --- Signing engine (net.i2p.crypto.eddsa.EdDSAEngine) ---
+  # EdDSAEngine extends java.security.Signature directly, so initSign/initVerify/
+  # update/sign/verify are inherited public finals resolved through the
+  # hierarchy edge below against the jdk-crypto Signature contracts. Only the
+  # EdDSA-specific surface is contracted here.
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.<init>
+    arity: 0
+    canonical_return_type: net.i2p.crypto.eddsa.EdDSAEngine
+    return:
+      type: net.i2p.crypto.eddsa.EdDSAEngine
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.<init>
+    arity: 1
+    parameter_types: [java.security.MessageDigest]
+    canonical_return_type: net.i2p.crypto.eddsa.EdDSAEngine
+    return:
+      type: net.i2p.crypto.eddsa.EdDSAEngine
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.signOneShot
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.signOneShot
+    arity: 3
+    parameter_types: ["byte[]", int, int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.verifyOneShot
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  # verifyOneShot#4 is overloaded ((data,off,len,sig) vs (data,sig,sigoff,siglen))
+  # with the same boolean return — canonical signature omitted.
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.verifyOneShot
+    arity: 4
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: net.i2p.crypto.eddsa.EdDSAEngine.verifyOneShot
+    arity: 6
+    parameter_types: ["byte[]", int, int, "byte[]", int, int]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # --- Key-pair generation (net.i2p.crypto.eddsa.KeyPairGenerator) ---
+  # Extends KeyPairGeneratorSpi (not java.security.KeyPairGenerator), so its
+  # generateKeyPair needs its own contract.
+  - method: net.i2p.crypto.eddsa.KeyPairGenerator.<init>
+    arity: 0
+    canonical_return_type: net.i2p.crypto.eddsa.KeyPairGenerator
+    return:
+      type: net.i2p.crypto.eddsa.KeyPairGenerator
+      confidence: high
+    role: factory
+  # initialize#2 is overloaded ((int,SecureRandom) vs
+  # (AlgorithmParameterSpec,SecureRandom)) — canonical signature omitted.
+  - method: net.i2p.crypto.eddsa.KeyPairGenerator.initialize
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.i2p.crypto.eddsa.KeyPairGenerator.generateKeyPair
+    arity: 0
+    canonical_return_type: java.security.KeyPair
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: factory
+
+  # --- Keys (net.i2p.crypto.eddsa.EdDSAPrivateKey / EdDSAPublicKey) ---
+  # Both arity-1 constructors are overloaded (EdDSA spec vs encoded JCA spec) —
+  # canonical signatures omitted.
+  - method: net.i2p.crypto.eddsa.EdDSAPrivateKey.<init>
+    arity: 1
+    return:
+      type: net.i2p.crypto.eddsa.EdDSAPrivateKey
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.EdDSAPublicKey.<init>
+    arity: 1
+    return:
+      type: net.i2p.crypto.eddsa.EdDSAPublicKey
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.EdDSAPrivateKey.getSeed
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: net.i2p.crypto.eddsa.EdDSAPrivateKey.getH
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: net.i2p.crypto.eddsa.EdDSAPrivateKey.getAbyte
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: net.i2p.crypto.eddsa.EdDSAPublicKey.getAbyte
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+
+  # --- Curve table and specs (net.i2p.crypto.eddsa.spec) ---
+  - method: net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.getByName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.defineCurve
+    arity: 1
+    parameter_types: [net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.i2p.crypto.eddsa.spec.EdDSAParameterSpec.<init>
+    arity: 4
+    parameter_types:
+      [
+        net.i2p.crypto.eddsa.math.Curve,
+        java.lang.String,
+        net.i2p.crypto.eddsa.math.ScalarOps,
+        net.i2p.crypto.eddsa.math.GroupElement,
+      ]
+    canonical_return_type: net.i2p.crypto.eddsa.spec.EdDSAParameterSpec
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSAParameterSpec
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec.<init>
+    arity: 5
+    parameter_types:
+      [
+        java.lang.String,
+        net.i2p.crypto.eddsa.math.Curve,
+        java.lang.String,
+        net.i2p.crypto.eddsa.math.ScalarOps,
+        net.i2p.crypto.eddsa.math.GroupElement,
+      ]
+    canonical_return_type: net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec
+      confidence: high
+    role: factory
+  # EdDSAPrivateKeySpec#2 is overloaded ((seed,spec) vs (spec,hash), same types
+  # in swapped order) — canonical signature omitted, and no parameter role is
+  # tagged because the key-material index differs between the overloads.
+  - method: net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec.<init>
+    arity: 2
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec.<init>
+    arity: 5
+    parameter_types:
+      [
+        "byte[]",
+        "byte[]",
+        "byte[]",
+        net.i2p.crypto.eddsa.math.GroupElement,
+        net.i2p.crypto.eddsa.spec.EdDSAParameterSpec,
+      ]
+    canonical_return_type: net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec
+      confidence: high
+    role: factory
+  # EdDSAPublicKeySpec#2 is overloaded ((byte[],spec) vs (GroupElement,spec)) —
+  # canonical signature omitted.
+  - method: net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec.<init>
+    arity: 2
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec
+      confidence: high
+    role: factory
+  - method: net.i2p.crypto.eddsa.spec.EdDSAGenParameterSpec.<init>
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: net.i2p.crypto.eddsa.spec.EdDSAGenParameterSpec
+    return:
+      type: net.i2p.crypto.eddsa.spec.EdDSAGenParameterSpec
+      confidence: high
+    role: factory
+
+  # --- JCA provider (net.i2p.crypto.eddsa.EdDSASecurityProvider) ---
+  - method: net.i2p.crypto.eddsa.EdDSASecurityProvider.<init>
+    arity: 0
+    canonical_return_type: net.i2p.crypto.eddsa.EdDSASecurityProvider
+    return:
+      type: net.i2p.crypto.eddsa.EdDSASecurityProvider
+      confidence: high
+    role: factory
+
+hierarchy:
+  # EdDSAEngine extends the public java.security.Signature class directly, so
+  # inherited initSign/update/sign/verify calls resolve to the jdk-crypto
+  # Signature contracts through this edge.
+  net.i2p.crypto.eddsa.EdDSAEngine:
+    - java.security.Signature
+  java.security.Signature:
+    - java.security.SignatureSpi
+    - java.lang.Object
+  net.i2p.crypto.eddsa.KeyPairGenerator:
+    - java.security.KeyPairGeneratorSpi
+  java.security.KeyPairGeneratorSpi:
+    - java.lang.Object
+  net.i2p.crypto.eddsa.EdDSAKey:
+    - java.lang.Object
+  net.i2p.crypto.eddsa.EdDSAPrivateKey:
+    - net.i2p.crypto.eddsa.EdDSAKey
+    - java.security.PrivateKey
+  net.i2p.crypto.eddsa.EdDSAPublicKey:
+    - net.i2p.crypto.eddsa.EdDSAKey
+    - java.security.PublicKey
+  java.security.PrivateKey:
+    - java.security.Key
+  java.security.PublicKey:
+    - java.security.Key
+  java.security.Key:
+    - java.lang.Object
+  java.security.KeyPair:
+    - java.lang.Object
+  net.i2p.crypto.eddsa.EdDSASecurityProvider:
+    - java.security.Provider
+  java.security.Provider:
+    - java.lang.Object
+  net.i2p.crypto.eddsa.spec.EdDSAParameterSpec:
+    - java.security.spec.AlgorithmParameterSpec
+  net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec:
+    - net.i2p.crypto.eddsa.spec.EdDSAParameterSpec
+  net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable:
+    - java.lang.Object
+  net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec:
+    - java.security.spec.KeySpec
+  net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec:
+    - java.security.spec.KeySpec
+  net.i2p.crypto.eddsa.spec.EdDSAGenParameterSpec:
+    - java.security.spec.AlgorithmParameterSpec
+  java.security.spec.AlgorithmParameterSpec:
+    - java.lang.Object
+  java.security.spec.KeySpec:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/pgpainless.yaml
+++ b/internal/callgraph/contracts/java/pgpainless.yaml
@@ -1,0 +1,878 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: pgpainless
+  coordinates:
+    - "org.pgpainless:pgpainless-core"
+  # Verified against upstream source at release 1.7.8 (Kotlin sources; the
+  # JVM-visible surface is contracted, with @JvmOverloads default parameters
+  # expanded into their per-arity Java overloads). pgpainless 2.x changes key
+  # returns (KeyRingTemplates produce org.bouncycastle.openpgp.api.OpenPGPKey
+  # instead of PGPSecretKeyRing) and deprecates the static entry points — a 2.x
+  # KB would conflict on method+arity and needs its own follow-up decision.
+  version_range: ">=1.7,<2.0"
+  description: "PGPainless contracts for the OpenPGP encrypt/sign, decrypt/verify, key-generation, and key-parsing fluent lifecycles"
+
+contracts:
+  # --- Entry points (org.pgpainless.PGPainless statics) ---
+  - method: org.pgpainless.PGPainless.encryptAndOrSign
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionBuilder
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionBuilder
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.decryptAndOrVerify
+    arity: 0
+    canonical_return_type: org.pgpainless.decryption_verification.DecryptionBuilder
+    return:
+      type: org.pgpainless.decryption_verification.DecryptionBuilder
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.generateKeyRing
+    arity: 0
+    canonical_return_type: org.pgpainless.key.generation.KeyRingTemplates
+    return:
+      type: org.pgpainless.key.generation.KeyRingTemplates
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.buildKeyRing
+    arity: 0
+    canonical_return_type: org.pgpainless.key.generation.KeyRingBuilder
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.readKeyRing
+    arity: 0
+    canonical_return_type: org.pgpainless.key.parsing.KeyRingReader
+    return:
+      type: org.pgpainless.key.parsing.KeyRingReader
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.modifyKeyRing
+    arity: 1
+    parameter_types: [org.bouncycastle.openpgp.PGPSecretKeyRing]
+    canonical_return_type: org.pgpainless.key.modification.secretkeyring.SecretKeyRingEditor
+    return:
+      type: org.pgpainless.key.modification.secretkeyring.SecretKeyRingEditor
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.modifyKeyRing
+    arity: 2
+    parameter_types: [org.bouncycastle.openpgp.PGPSecretKeyRing, java.util.Date]
+    canonical_return_type: org.pgpainless.key.modification.secretkeyring.SecretKeyRingEditor
+    return:
+      type: org.pgpainless.key.modification.secretkeyring.SecretKeyRingEditor
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.inspectKeyRing
+    arity: 1
+    parameter_types: [org.bouncycastle.openpgp.PGPKeyRing]
+    canonical_return_type: org.pgpainless.key.info.KeyRingInfo
+    return:
+      type: org.pgpainless.key.info.KeyRingInfo
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.inspectKeyRing
+    arity: 2
+    parameter_types: [org.bouncycastle.openpgp.PGPKeyRing, java.util.Date]
+    canonical_return_type: org.pgpainless.key.info.KeyRingInfo
+    return:
+      type: org.pgpainless.key.info.KeyRingInfo
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.extractCertificate
+    arity: 1
+    parameter_types: [org.bouncycastle.openpgp.PGPSecretKeyRing]
+    canonical_return_type: org.bouncycastle.openpgp.PGPPublicKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.PGPainless.mergeCertificate
+    arity: 2
+    parameter_types:
+      [
+        org.bouncycastle.openpgp.PGPPublicKeyRing,
+        org.bouncycastle.openpgp.PGPPublicKeyRing,
+      ]
+    canonical_return_type: org.bouncycastle.openpgp.PGPPublicKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRing
+      confidence: high
+    role: factory
+  # asciiArmor#1 is overloaded (PGPKeyRing / PGPSignature), both returning
+  # String — canonical signature omitted.
+  - method: org.pgpainless.PGPainless.asciiArmor
+    arity: 1
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: org.pgpainless.PGPainless.asciiArmor
+    arity: 2
+    parameter_types: [org.bouncycastle.openpgp.PGPKeyRing, java.io.OutputStream]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: output
+
+  # --- Encryption chain ---
+  - method: org.pgpainless.encryption_signing.EncryptionBuilder.<init>
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionBuilder
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionBuilder
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.EncryptionBuilder.onOutputStream
+    arity: 1
+    parameter_types: [java.io.OutputStream]
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions
+      confidence: high
+    role: config
+  # Authored on the chain interface; EncryptionBuilder.WithOptionsImpl resolves
+  # through the hierarchy edge below.
+  - method: org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions.withOptions
+    arity: 1
+    parameter_types: [org.pgpainless.encryption_signing.ProducerOptions]
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionStream
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionStream
+      confidence: high
+    role: factory
+  # close() finalizes the OpenPGP message (writes trailing packets); getResult
+  # is only valid afterwards.
+  - method: org.pgpainless.encryption_signing.EncryptionStream.close
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: org.pgpainless.encryption_signing.EncryptionStream.getResult
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionResult
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionResult
+      confidence: high
+    role: output
+
+  # --- ProducerOptions ---
+  - method: org.pgpainless.encryption_signing.ProducerOptions.signAndEncrypt
+    arity: 2
+    parameter_types:
+      [
+        org.pgpainless.encryption_signing.EncryptionOptions,
+        org.pgpainless.encryption_signing.SigningOptions,
+      ]
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.ProducerOptions.sign
+    arity: 1
+    parameter_types: [org.pgpainless.encryption_signing.SigningOptions]
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.ProducerOptions.encrypt
+    arity: 1
+    parameter_types: [org.pgpainless.encryption_signing.EncryptionOptions]
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.ProducerOptions.noEncryptionNoSigning
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.ProducerOptions.setAsciiArmor
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.ProducerOptions.setCleartextSigned
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.ProducerOptions.setFileName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.ProducerOptions.setModificationDate
+    arity: 1
+    parameter_types: [java.util.Date]
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.ProducerOptions.applyCRLFEncoding
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.ProducerOptions.overrideCompressionAlgorithm
+    arity: 1
+    canonical_return_type: org.pgpainless.encryption_signing.ProducerOptions
+    return:
+      type: org.pgpainless.encryption_signing.ProducerOptions
+      confidence: high
+    role: config
+
+  # --- EncryptionOptions ---
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.get
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.encryptCommunications
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.encryptDataAtRest
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: factory
+  # addRecipient(s) are overloaded per arity (key vs key+userId vs
+  # key+selector) — canonical signatures omitted.
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addRecipient
+    arity: 1
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addRecipient
+    arity: 2
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addRecipient
+    arity: 3
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addRecipients
+    arity: 1
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addRecipients
+    arity: 2
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addPassphrase
+    arity: 1
+    parameter_types: [org.pgpainless.util.Passphrase]
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.addMessagePassphrase
+    arity: 1
+    parameter_types: [org.pgpainless.util.Passphrase]
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.EncryptionOptions.overrideEncryptionAlgorithm
+    arity: 1
+    canonical_return_type: org.pgpainless.encryption_signing.EncryptionOptions
+    return:
+      type: org.pgpainless.encryption_signing.EncryptionOptions
+      confidence: high
+    role: config
+
+  # --- SigningOptions ---
+  # addInlineSignature/addDetachedSignature carry @JvmOverloads defaults, so
+  # the Java-visible overloads span arities 2..5; every variant returns
+  # SigningOptions. Canonical signatures omitted on the overloaded arities.
+  - method: org.pgpainless.encryption_signing.SigningOptions.get
+    arity: 0
+    canonical_return_type: org.pgpainless.encryption_signing.SigningOptions
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.encryption_signing.SigningOptions.overrideHashAlgorithm
+    arity: 1
+    canonical_return_type: org.pgpainless.encryption_signing.SigningOptions
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addSignature
+    arity: 2
+    canonical_return_type: org.pgpainless.encryption_signing.SigningOptions
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addInlineSignatures
+    arity: 3
+    canonical_return_type: org.pgpainless.encryption_signing.SigningOptions
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addInlineSignature
+    arity: 2
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addInlineSignature
+    arity: 3
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addInlineSignature
+    arity: 4
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addInlineSignature
+    arity: 5
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addDetachedSignatures
+    arity: 3
+    canonical_return_type: org.pgpainless.encryption_signing.SigningOptions
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addDetachedSignature
+    arity: 2
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addDetachedSignature
+    arity: 3
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addDetachedSignature
+    arity: 4
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.encryption_signing.SigningOptions.addDetachedSignature
+    arity: 5
+    return:
+      type: org.pgpainless.encryption_signing.SigningOptions
+      confidence: high
+    role: config
+
+  # --- Decryption chain ---
+  - method: org.pgpainless.decryption_verification.DecryptionBuilder.<init>
+    arity: 0
+    canonical_return_type: org.pgpainless.decryption_verification.DecryptionBuilder
+    return:
+      type: org.pgpainless.decryption_verification.DecryptionBuilder
+      confidence: high
+    role: factory
+  - method: org.pgpainless.decryption_verification.DecryptionBuilder.onInputStream
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: org.pgpainless.decryption_verification.DecryptionBuilderInterface.DecryptWith
+    return:
+      type: org.pgpainless.decryption_verification.DecryptionBuilderInterface.DecryptWith
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.DecryptionBuilderInterface.DecryptWith.withOptions
+    arity: 1
+    parameter_types: [org.pgpainless.decryption_verification.ConsumerOptions]
+    canonical_return_type: org.pgpainless.decryption_verification.DecryptionStream
+    return:
+      type: org.pgpainless.decryption_verification.DecryptionStream
+      confidence: high
+    role: factory
+  # close() performs the integrity verification of the consumed message;
+  # getMetadata is only valid afterwards.
+  - method: org.pgpainless.decryption_verification.DecryptionStream.close
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: org.pgpainless.decryption_verification.DecryptionStream.getMetadata
+    arity: 0
+    canonical_return_type: org.pgpainless.decryption_verification.MessageMetadata
+    return:
+      type: org.pgpainless.decryption_verification.MessageMetadata
+      confidence: high
+    role: output
+
+  # --- ConsumerOptions ---
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.get
+    arity: 0
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: factory
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addDecryptionKey
+    arity: 1
+    parameter_types: [org.bouncycastle.openpgp.PGPSecretKeyRing]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addDecryptionKey
+    arity: 2
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addDecryptionKeys
+    arity: 1
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addDecryptionKeys
+    arity: 2
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addDecryptionPassphrase
+    arity: 1
+    parameter_types: [org.pgpainless.util.Passphrase]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addMessagePassphrase
+    arity: 1
+    parameter_types: [org.pgpainless.util.Passphrase]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addVerificationCert
+    arity: 1
+    parameter_types: [org.bouncycastle.openpgp.PGPPublicKeyRing]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addVerificationCerts
+    arity: 1
+    parameter_types: [org.bouncycastle.openpgp.PGPPublicKeyRingCollection]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  # addVerificationOfDetachedSignatures#1 is overloaded (InputStream /
+  # List<PGPSignature>) — canonical signature omitted.
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addVerificationOfDetachedSignatures
+    arity: 1
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.addVerificationOfDetachedSignature
+    arity: 1
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.setSessionKey
+    arity: 1
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.verifyNotBefore
+    arity: 1
+    parameter_types: [java.util.Date]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.verifyNotAfter
+    arity: 1
+    parameter_types: [java.util.Date]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.setMissingKeyPassphraseStrategy
+    arity: 1
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+  - method: org.pgpainless.decryption_verification.ConsumerOptions.setIgnoreMDCErrors
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: org.pgpainless.decryption_verification.ConsumerOptions
+    return:
+      type: org.pgpainless.decryption_verification.ConsumerOptions
+      confidence: high
+    role: config
+
+  # --- Key generation ---
+  # Template methods carry @JvmOverloads passphrase defaults plus a deprecated
+  # String-password overload at the higher arity — every variant returns
+  # PGPSecretKeyRing; canonical signatures omitted on overloaded arities.
+  - method: org.pgpainless.key.generation.KeyRingTemplates.<init>
+    arity: 0
+    canonical_return_type: org.pgpainless.key.generation.KeyRingTemplates
+    return:
+      type: org.pgpainless.key.generation.KeyRingTemplates
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.rsaKeyRing
+    arity: 2
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.rsaKeyRing
+    arity: 3
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.simpleRsaKeyRing
+    arity: 2
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.simpleRsaKeyRing
+    arity: 3
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.simpleEcKeyRing
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.simpleEcKeyRing
+    arity: 2
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.modernKeyRing
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingTemplates.modernKeyRing
+    arity: 2
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingBuilder.<init>
+    arity: 0
+    canonical_return_type: org.pgpainless.key.generation.KeyRingBuilder
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.generation.KeyRingBuilder.setPrimaryKey
+    arity: 1
+    canonical_return_type: org.pgpainless.key.generation.KeyRingBuilder
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: config
+  - method: org.pgpainless.key.generation.KeyRingBuilder.addSubkey
+    arity: 1
+    canonical_return_type: org.pgpainless.key.generation.KeyRingBuilder
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: config
+  # addUserId#1 is overloaded (CharSequence / byte[]) — canonical omitted.
+  - method: org.pgpainless.key.generation.KeyRingBuilder.addUserId
+    arity: 1
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: config
+  - method: org.pgpainless.key.generation.KeyRingBuilder.setExpirationDate
+    arity: 1
+    parameter_types: [java.util.Date]
+    canonical_return_type: org.pgpainless.key.generation.KeyRingBuilder
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: config
+  - method: org.pgpainless.key.generation.KeyRingBuilder.setPassphrase
+    arity: 1
+    parameter_types: [org.pgpainless.util.Passphrase]
+    canonical_return_type: org.pgpainless.key.generation.KeyRingBuilder
+    return:
+      type: org.pgpainless.key.generation.KeyRingBuilder
+      confidence: high
+    role: config
+  - method: org.pgpainless.key.generation.KeyRingBuilder.build
+    arity: 0
+    canonical_return_type: org.bouncycastle.openpgp.PGPSecretKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+
+  # --- Key parsing (org.pgpainless.key.parsing.KeyRingReader) ---
+  # Instance readers are overloaded at arity 1 (InputStream / byte[] / String)
+  # with a single return each; the static read* variants carry a @JvmOverloads
+  # maxIterations default (arities 1 and 2).
+  - method: org.pgpainless.key.parsing.KeyRingReader.<init>
+    arity: 0
+    canonical_return_type: org.pgpainless.key.parsing.KeyRingReader
+    return:
+      type: org.pgpainless.key.parsing.KeyRingReader
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.keyRing
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.publicKeyRing
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.publicKeyRingCollection
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.secretKeyRing
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.secretKeyRingCollection
+    arity: 1
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRingCollection
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readKeyRing
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: org.bouncycastle.openpgp.PGPKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readKeyRing
+    arity: 2
+    parameter_types: [java.io.InputStream, int]
+    canonical_return_type: org.bouncycastle.openpgp.PGPKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readPublicKeyRing
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: org.bouncycastle.openpgp.PGPPublicKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readPublicKeyRing
+    arity: 2
+    parameter_types: [java.io.InputStream, int]
+    canonical_return_type: org.bouncycastle.openpgp.PGPPublicKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readPublicKeyRingCollection
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readPublicKeyRingCollection
+    arity: 2
+    parameter_types: [java.io.InputStream, int]
+    canonical_return_type: org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+    return:
+      type: org.bouncycastle.openpgp.PGPPublicKeyRingCollection
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readSecretKeyRing
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: org.bouncycastle.openpgp.PGPSecretKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readSecretKeyRing
+    arity: 2
+    parameter_types: [java.io.InputStream, int]
+    canonical_return_type: org.bouncycastle.openpgp.PGPSecretKeyRing
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRing
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readSecretKeyRingCollection
+    arity: 1
+    parameter_types: [java.io.InputStream]
+    canonical_return_type: org.bouncycastle.openpgp.PGPSecretKeyRingCollection
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRingCollection
+      confidence: high
+    role: factory
+  - method: org.pgpainless.key.parsing.KeyRingReader.readSecretKeyRingCollection
+    arity: 2
+    parameter_types: [java.io.InputStream, int]
+    canonical_return_type: org.bouncycastle.openpgp.PGPSecretKeyRingCollection
+    return:
+      type: org.bouncycastle.openpgp.PGPSecretKeyRingCollection
+      confidence: high
+    role: factory
+
+hierarchy:
+  org.pgpainless.PGPainless:
+    - java.lang.Object
+  # Encryption chain: the builder implements its interface; the WithOptionsImpl
+  # nested class implements the WithOptions chain interface the contracts are
+  # authored on.
+  org.pgpainless.encryption_signing.EncryptionBuilderInterface:
+    - java.lang.Object
+  org.pgpainless.encryption_signing.EncryptionBuilder:
+    - org.pgpainless.encryption_signing.EncryptionBuilderInterface
+  org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions:
+    - java.lang.Object
+  org.pgpainless.encryption_signing.EncryptionBuilder.WithOptionsImpl:
+    - org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions
+  org.pgpainless.encryption_signing.EncryptionStream:
+    - java.io.OutputStream
+  java.io.OutputStream:
+    - java.lang.Object
+  org.pgpainless.encryption_signing.ProducerOptions:
+    - java.lang.Object
+  org.pgpainless.encryption_signing.EncryptionOptions:
+    - java.lang.Object
+  org.pgpainless.encryption_signing.SigningOptions:
+    - java.lang.Object
+  org.pgpainless.encryption_signing.EncryptionResult:
+    - java.lang.Object
+  # Decryption chain
+  org.pgpainless.decryption_verification.DecryptionBuilderInterface:
+    - java.lang.Object
+  org.pgpainless.decryption_verification.DecryptionBuilder:
+    - org.pgpainless.decryption_verification.DecryptionBuilderInterface
+  org.pgpainless.decryption_verification.DecryptionBuilderInterface.DecryptWith:
+    - java.lang.Object
+  org.pgpainless.decryption_verification.DecryptionBuilder.DecryptWithImpl:
+    - org.pgpainless.decryption_verification.DecryptionBuilderInterface.DecryptWith
+  org.pgpainless.decryption_verification.DecryptionStream:
+    - java.io.InputStream
+  org.pgpainless.decryption_verification.OpenPgpMessageInputStream:
+    - org.pgpainless.decryption_verification.DecryptionStream
+  java.io.InputStream:
+    - java.lang.Object
+  org.pgpainless.decryption_verification.ConsumerOptions:
+    - java.lang.Object
+  org.pgpainless.decryption_verification.MessageMetadata:
+    - java.lang.Object
+  # Key generation / parsing / inspection
+  org.pgpainless.key.generation.KeyRingTemplates:
+    - java.lang.Object
+  org.pgpainless.key.generation.KeyRingBuilder:
+    - java.lang.Object
+  org.pgpainless.key.parsing.KeyRingReader:
+    - java.lang.Object
+  org.pgpainless.key.modification.secretkeyring.SecretKeyRingEditor:
+    - java.lang.Object
+  org.pgpainless.key.info.KeyRingInfo:
+    - java.lang.Object
+  # Bouncy Castle OpenPGP types appearing as returns
+  org.bouncycastle.openpgp.PGPKeyRing:
+    - java.lang.Object
+  org.bouncycastle.openpgp.PGPPublicKeyRing:
+    - org.bouncycastle.openpgp.PGPKeyRing
+  org.bouncycastle.openpgp.PGPSecretKeyRing:
+    - org.bouncycastle.openpgp.PGPKeyRing
+  org.bouncycastle.openpgp.PGPPublicKeyRingCollection:
+    - java.lang.Object
+  org.bouncycastle.openpgp.PGPSecretKeyRingCollection:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -775,3 +775,113 @@ func TestLoadEmbeddedJava_JavaJwtAndJwksRsaLifecycle(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadEmbeddedJava_HutoolEddsaPgpainlessLifecycle verifies the Tier 0
+// RULE_ONLY gap contracts (scanoss/crypto-finder#207): hutool-crypto's
+// SecureUtil/DigestUtil/SmUtil/KeyUtil factories and symmetric/digest/MAC/
+// asymmetric lifecycles, i2p-eddsa's signing engine and key/spec construction,
+// and pgpainless's encrypt/decrypt/keygen fluent chains — including the
+// rule-anchor methods, return types, lifecycle roles, and the hierarchy edges
+// that resolve subclasses and chain interfaces.
+func TestLoadEmbeddedJava_HutoolEddsaPgpainlessLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+		lib    string
+	}{
+		// hutool-crypto: rule anchors (SecureUtil.aes/des/desede/rsa/md5/sha*).
+		{"cn.hutool.crypto.SecureUtil.aes", 1, "cn.hutool.crypto.symmetric.AES", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.SecureUtil.des", 0, "cn.hutool.crypto.symmetric.DES", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.SecureUtil.desede", 1, "cn.hutool.crypto.symmetric.DESede", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.SecureUtil.rsa", 0, "cn.hutool.crypto.asymmetric.RSA", "factory", "hutool-crypto"},
+		// The md5/sha1 arity split: 0 -> digester object, 1 -> hex string.
+		{"cn.hutool.crypto.SecureUtil.md5", 0, "cn.hutool.crypto.digest.MD5", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.SecureUtil.md5", 1, "java.lang.String", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.SecureUtil.hmacSha256", 1, "cn.hutool.crypto.digest.HMac", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.digest.DigestUtil.sha256Hex", 1, "java.lang.String", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.SmUtil.sm2", 0, "cn.hutool.crypto.asymmetric.SM2", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.SmUtil.sm4", 1, "cn.hutool.crypto.symmetric.SM4", "factory", "hutool-crypto"},
+		{"cn.hutool.crypto.KeyUtil.generateKeyPair", 2, "java.security.KeyPair", "factory", "hutool-crypto"},
+		// hutool lifecycle on base classes (subclasses resolve via hierarchy).
+		{"cn.hutool.crypto.symmetric.SymmetricCrypto.encrypt", 1, "byte[]", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.symmetric.SymmetricCrypto.setIv", 1, "cn.hutool.crypto.symmetric.SymmetricCrypto", "config", "hutool-crypto"},
+		{"cn.hutool.crypto.digest.Digester.digestHex", 1, "java.lang.String", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.digest.mac.Mac.digest", 1, "byte[]", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.asymmetric.AsymmetricCrypto.encrypt", 2, "byte[]", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.asymmetric.Sign.sign", 1, "byte[]", "operation", "hutool-crypto"},
+		{"cn.hutool.crypto.asymmetric.SM2.verify", 2, "boolean", "operation", "hutool-crypto"},
+		// i2p-eddsa: rule anchors (new EdDSAEngine, EdDSANamedCurveTable.getByName).
+		{"net.i2p.crypto.eddsa.EdDSAEngine.<init>", 0, "net.i2p.crypto.eddsa.EdDSAEngine", "factory", "i2p-eddsa"},
+		{"net.i2p.crypto.eddsa.EdDSAEngine.<init>", 1, "net.i2p.crypto.eddsa.EdDSAEngine", "factory", "i2p-eddsa"},
+		{"net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable.getByName", 1, "net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec", "factory", "i2p-eddsa"},
+		{"net.i2p.crypto.eddsa.EdDSAEngine.signOneShot", 1, "byte[]", "operation", "i2p-eddsa"},
+		{"net.i2p.crypto.eddsa.EdDSAEngine.verifyOneShot", 2, "boolean", "operation", "i2p-eddsa"},
+		{"net.i2p.crypto.eddsa.KeyPairGenerator.generateKeyPair", 0, "java.security.KeyPair", "factory", "i2p-eddsa"},
+		{"net.i2p.crypto.eddsa.EdDSAPrivateKey.<init>", 1, "net.i2p.crypto.eddsa.EdDSAPrivateKey", "factory", "i2p-eddsa"},
+		// pgpainless: rule anchors and the fluent chains.
+		{"org.pgpainless.PGPainless.encryptAndOrSign", 0, "org.pgpainless.encryption_signing.EncryptionBuilder", "factory", "pgpainless"},
+		{"org.pgpainless.PGPainless.decryptAndOrVerify", 0, "org.pgpainless.decryption_verification.DecryptionBuilder", "factory", "pgpainless"},
+		{"org.pgpainless.PGPainless.generateKeyRing", 0, "org.pgpainless.key.generation.KeyRingTemplates", "factory", "pgpainless"},
+		{"org.pgpainless.encryption_signing.EncryptionBuilder.onOutputStream", 1, "org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions", "config", "pgpainless"},
+		{"org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions.withOptions", 1, "org.pgpainless.encryption_signing.EncryptionStream", "factory", "pgpainless"},
+		{"org.pgpainless.encryption_signing.EncryptionStream.getResult", 0, "org.pgpainless.encryption_signing.EncryptionResult", "output", "pgpainless"},
+		{"org.pgpainless.encryption_signing.ProducerOptions.signAndEncrypt", 2, "org.pgpainless.encryption_signing.ProducerOptions", "factory", "pgpainless"},
+		{"org.pgpainless.encryption_signing.EncryptionOptions.addRecipient", 1, "org.pgpainless.encryption_signing.EncryptionOptions", "config", "pgpainless"},
+		{"org.pgpainless.encryption_signing.SigningOptions.addInlineSignature", 3, "org.pgpainless.encryption_signing.SigningOptions", "config", "pgpainless"},
+		{"org.pgpainless.decryption_verification.DecryptionBuilderInterface.DecryptWith.withOptions", 1, "org.pgpainless.decryption_verification.DecryptionStream", "factory", "pgpainless"},
+		{"org.pgpainless.decryption_verification.ConsumerOptions.addDecryptionKey", 1, "org.pgpainless.decryption_verification.ConsumerOptions", "config", "pgpainless"},
+		{"org.pgpainless.decryption_verification.DecryptionStream.getMetadata", 0, "org.pgpainless.decryption_verification.MessageMetadata", "output", "pgpainless"},
+		{"org.pgpainless.key.generation.KeyRingTemplates.modernKeyRing", 1, "org.bouncycastle.openpgp.PGPSecretKeyRing", "factory", "pgpainless"},
+		{"org.pgpainless.key.generation.KeyRingBuilder.build", 0, "org.bouncycastle.openpgp.PGPSecretKeyRing", "factory", "pgpainless"},
+		{"org.pgpainless.key.parsing.KeyRingReader.secretKeyRing", 1, "org.bouncycastle.openpgp.PGPSecretKeyRing", "factory", "pgpainless"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != tt.lib {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from %q", tt.method, tt.arity, got[0], tt.want, tt.role, tt.lib)
+			}
+		})
+	}
+
+	// Subclasses and chain implementations must resolve to the base/interface
+	// declarations the lifecycle contracts are authored on.
+	hierarchyWants := map[string]string{
+		"cn.hutool.crypto.symmetric.AES":                                      "cn.hutool.crypto.symmetric.SymmetricCrypto",
+		"cn.hutool.crypto.symmetric.SM4":                                      "cn.hutool.crypto.symmetric.SymmetricCrypto",
+		"cn.hutool.crypto.digest.MD5":                                         "cn.hutool.crypto.digest.Digester",
+		"cn.hutool.crypto.digest.HMac":                                        "cn.hutool.crypto.digest.mac.Mac",
+		"cn.hutool.crypto.asymmetric.RSA":                                     "cn.hutool.crypto.asymmetric.AsymmetricCrypto",
+		"net.i2p.crypto.eddsa.EdDSAEngine":                                    "java.security.Signature",
+		"org.pgpainless.encryption_signing.EncryptionBuilder.WithOptionsImpl": "org.pgpainless.encryption_signing.EncryptionBuilderInterface.WithOptions",
+		"org.pgpainless.decryption_verification.OpenPgpMessageInputStream":    "org.pgpainless.decryption_verification.DecryptionStream",
+	}
+	for child, wantParent := range hierarchyWants {
+		if parents := kb.Hierarchy[child]; len(parents) == 0 || parents[0] != wantParent {
+			t.Fatalf("%s hierarchy = %v, want first parent %s", child, kb.Hierarchy[child], wantParent)
+		}
+	}
+
+	// The AES key-material constructor contributes keySize by bit length.
+	aes := kb.ContractsFor("cn.hutool.crypto.symmetric.AES.<init>", 1)
+	if len(aes) != 1 || len(aes[0].Parameters) != 1 {
+		t.Fatalf("AES.<init>#1 parameters = %#v, want one key parameter role", aes)
+	}
+	p := aes[0].Parameters[0]
+	if p.Index == nil || *p.Index != 0 || p.Role != "metadata-contributing" || p.Contributes == nil || p.Contributes.Property != "keySize" || p.Contributes.Derivation != "argument_bit_length" {
+		t.Fatalf("AES.<init>#1 parameters[0] = %#v, want index=0 keySize/argument_bit_length", p)
+	}
+}


### PR DESCRIPTION
Closes #207

## What

Fills the remaining Java RULE_ONLY Tier 0 contract gaps with three schema-v2 KBs. Every signature was verified against the upstream sources (no memory-authored entries); rule-anchor APIs from `crypto_rules` are all covered.

- **`hutool-crypto.yaml`** (verified at 5.8.47, `cn.hutool` 5.x tree — the one the rules target; 6.x renamed packages to `org.dromara`): `SecureUtil`/`SignUtil`/`DigestUtil`/`SmUtil`/`KeyUtil` static factories (incl. rule anchors `SecureUtil.aes/des/desede/rsa/md5/sha*/hmac*`, `DigestUtil.*`), plus the lifecycle surfaces authored on the base classes — `SymmetricCrypto` (encrypt/decrypt/setIv/setMode…), `Digester` (digest/setSalt…), `mac.Mac` (digest/verify), `RC4` (standalone; its `decrypt` returns String, unlike `SymmetricCrypto`), `AsymmetricCrypto`, `Sign`, `SM2` — with hierarchy edges resolving `AES/DES/DESede/SM4/ChaCha20/ZUC`, `MD5/SM3`, `HMac`, and `RSA` to those bases. Key-material factory args tagged `keySize`/`argument_bit_length` per the bouncycastle-openpgp/go precedent.
- **`i2p-eddsa.yaml`** (verified at 0.3.0): `EdDSAEngine` ctors (rule anchor `new EdDSAEngine(...)`) and `signOneShot`/`verifyOneShot`; inherited `initSign/update/sign/verify` resolve through the `EdDSAEngine → java.security.Signature` edge against the existing jdk-crypto contracts instead of being duplicated. `KeyPairGenerator`, `EdDSAPrivateKey`/`EdDSAPublicKey`, `EdDSANamedCurveTable.getByName` (rule anchor), and the spec constructors. All 7 same-arity overload ambiguities annotated with canonical fields omitted.
- **`pgpainless.yaml`** (verified at 1.7.8): the three rule anchors `PGPainless.encryptAndOrSign/decryptAndOrVerify/generateKeyRing` plus `buildKeyRing`/`readKeyRing`/`modifyKeyRing`/`inspectKeyRing`, the full fluent chains (`ProducerOptions`, `EncryptionOptions`, `SigningOptions`, `ConsumerOptions`), stream terminals (`EncryptionStream.close/getResult`, `DecryptionStream.close/getMetadata`), `KeyRingTemplates`, `KeyRingBuilder`, `KeyRingReader`. Sources are Kotlin — `@JvmOverloads` defaults were expanded into their per-arity Java overloads (e.g. `addInlineSignature` arities 2–5, verified annotations in source).

## Version decision (pgpainless 1.x vs 2.x)

The clone HEAD is 2.0.5-SNAPSHOT, where the rule-anchor statics are deprecated and `KeyRingTemplates` returns `org.bouncycastle.openpgp.api.OpenPGPKey` instead of `PGPSecretKeyRing`. A 2.x KB would hard-conflict with a 1.x KB on method+arity with different returns, so only one line can be contracted: **1.7.8** was chosen because the anchors are first-class API there and the OSS consumer base is predominantly 1.x. The 2.x line is flagged `needs-follow-up` in the YAML header comment.

## API audit (dispositions)

**hutool-crypto**: `contracted` — the SecureUtil/SignUtil/DigestUtil/SmUtil/KeyUtil surface listed above + base-class lifecycles + subclass ctors (AES/DES/DESede/SM4 arities 0–4, ChaCha20#2, MD5/SM3 ctors + `create()`, HMac ctors 1–3, RSA ctors 0–3 + static generatePrivateKey/generatePublicKey, Sign ctors + fluent setters + sign/verify, SM2 ctors + full sign/verify/encrypt/decrypt + fluent setters, RC4 full surface). `covered-existing` — none. `skipped-informative-return` — getters (`getSecretKey` and `getCipher`/`getDigest`/`getSignature` ARE contracted as `output`; plain metadata getters like `getAlgorithm`, `getEncryptBlockSize`, key-Base64 getters skipped). `skipped-non-crypto` — `SecureUtil.decode`, `getAlgorithmAfterWith`, `generateAlgorithm`, `addProvider`/`disableBouncyCastle` (provider bootstrap), `SmUtil` C1C2C3/ASN.1 format converters, BCUtil/ECKeyUtil/OpensslKeyUtil/PemUtil/ASN1Util/SpecUtil, enums, exceptions. `skipped-unsupported` — `BaseAsymmetric` generic self-type fluents (`initKeys`/`setPublicKey`/`setPrivateKey`/`setKey`; concrete overrides ARE contracted on SM2 where declared). `needs-follow-up` — Vigenere/XXTEA/FPE/ZUC direct classes (factory entries via SecureUtil contracted), BCrypt/Argon2 direct classes (DigestUtil.bcrypt/bcryptCheck contracted), HOTP/TOTP, digest.mac engine SPI.

**i2p-eddsa**: `contracted` — EdDSAEngine (ctors, signOneShot 1/3, verifyOneShot 2/4/6), KeyPairGenerator (ctor, initialize#2, generateKeyPair), EdDSAPrivateKey/EdDSAPublicKey ctors + key-material getters (getSeed/getH/getAbyte as `output`), EdDSANamedCurveTable (getByName, defineCurve), EdDSAParameterSpec/EdDSANamedCurveSpec/EdDSAPrivateKeySpec/EdDSAPublicKeySpec/EdDSAGenParameterSpec ctors, EdDSASecurityProvider ctor. `covered-existing` — inherited `Signature.sign` etc. via hierarchy edge to jdk-crypto. `skipped-informative-return` — getAlgorithm/getFormat/getParams/getName getters. `skipped-non-crypto` — `Utils` (javadoc: not public API). `skipped-unsupported` — `math` package types as returns (`getA` → GroupElement), protected `KeyFactory` SPI (users reach it via `java.security.KeyFactory`).

**pgpainless**: `contracted` — surface listed above. `skipped-informative-return` — options/metadata getters (`getVerifiedSignatures`, `getSessionKey`, …), `EncryptionResult` getters. `skipped-non-crypto` — `Policy`, algorithm enums, `Passphrase` util factories. `needs-follow-up` — `SecretKeyRingEditor` chain internals and `KeyRingInfo` surface (entry points contracted), `CertifyCertificate` certification workflow, cleartext-signature `MultiPassStrategy` impls, pgpainless 2.x line.

Sources: `dromara/hutool` @5.8.47 (v5-master), `str4d/ed25519-java` @0.3.0 (pom), `pgpainless/pgpainless` @tag 1.7.8. Version-range lower bounds are stated in each YAML header with the verification anchor.

## Testing

- `TestLoadEmbeddedJava_HutoolEddsaPgpainlessLifecycle`: 37 contract assertions (return type + lifecycle role + source library) across the three KBs, 8 hierarchy-resolution assertions, and the AES keySize parameter-role assertion — green.
- `go build ./...` and `go test ./internal/callgraph/... ./internal/scan/...` green (full suite has only the known pre-existing Docker-dependent Postgres failures in `internal/engine`, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)