### PR TITLE
feat(contracts/java): Java contract-gap backlog — password hashers, NaCl bindings, SSH, okhttp TLS, cloud KMS + Vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Java callgraph contracts now model the cloud KMS and secrets-manager facades: AWS KMS across both SDK generations (`software.amazon.awssdk:kms` and `com.amazonaws:aws-java-sdk-kms`), Google Cloud KMS, Azure Key Vault Keys cryptography and key clients, and the HashiCorp `vault-java-driver` client and TLS configuration.
+- Java callgraph contracts now model the cloud KMS and secrets-manager facades: AWS KMS across both SDK generations (`software.amazon.awssdk:kms` and `com.amazonaws:aws-java-sdk-kms`, including the v1 bean setters), Google Cloud KMS, Azure Key Vault Keys synchronous and asynchronous cryptography and key clients, and the HashiCorp `vault-java-driver` client, TLS configuration, and `Logical` secrets-engine operations.
 - Java callgraph contracts now model the OkHttp 5.x TLS surface — certificate pinning, `ConnectionSpec` cipher-suite and TLS-version selection, handshake inspection, the TLS-related `OkHttpClient.Builder` configuration, and the `okhttp-tls` `HeldCertificate`/`HandshakeCertificates` certificate and key generation.
 - Java callgraph contracts now model the JSch (`com.jcraft` and the `com.github.mwiede` fork) session, algorithm-configuration, host-key, and key-pair generation/loading lifecycles, and the sshj 0.40 client connect/auth, algorithm-selection, key-provider, and host-key-verification lifecycles.
 - Java callgraph contracts now model the lazysodium-java 5.2 libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles (both the high-level `Lazy` and buffer-based `Native` surfaces) and the kalium box, secretbox, sealed-box, AEAD, hash, password, and signing-key lifecycles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the jbcrypt, at.favre.lib bcrypt, Lambdaworks scrypt, argon2-jvm, and Jasypt password/KDF facades, including the bcrypt cost, scrypt N/r/p, and Argon2/PBE iteration work factors.
 - Java callgraph contracts now model the Hutool-crypto 5.8 SecureUtil/DigestUtil/SmUtil/KeyUtil factories and the symmetric, digest, MAC, asymmetric, signing, and SM2 lifecycles.
 - Java callgraph contracts now model the I2P ed25519-java (net.i2p.crypto:eddsa) 0.3 EdDSA signing engine, key-pair generation, and key/spec construction lifecycles.
 - Java callgraph contracts now model the PGPainless 1.7 OpenPGP encrypt/sign, decrypt/verify, key-generation, and key-parsing fluent lifecycles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the JSch (`com.jcraft` and the `com.github.mwiede` fork) session, algorithm-configuration, host-key, and key-pair generation/loading lifecycles, and the sshj 0.40 client connect/auth, algorithm-selection, key-provider, and host-key-verification lifecycles.
 - Java callgraph contracts now model the lazysodium-java 5.2 libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles (both the high-level `Lazy` and buffer-based `Native` surfaces) and the kalium box, secretbox, sealed-box, AEAD, hash, password, and signing-key lifecycles.
 - Java callgraph contracts now model the jbcrypt, at.favre.lib bcrypt, Lambdaworks scrypt, argon2-jvm, and Jasypt password/KDF facades, including the bcrypt cost, scrypt N/r/p, and Argon2/PBE iteration work factors.
 - Java callgraph contracts now model the Hutool-crypto 5.8 SecureUtil/DigestUtil/SmUtil/KeyUtil factories and the symmetric, digest, MAC, asymmetric, signing, and SM2 lifecycles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the OkHttp 5.x TLS surface — certificate pinning, `ConnectionSpec` cipher-suite and TLS-version selection, handshake inspection, the TLS-related `OkHttpClient.Builder` configuration, and the `okhttp-tls` `HeldCertificate`/`HandshakeCertificates` certificate and key generation.
 - Java callgraph contracts now model the JSch (`com.jcraft` and the `com.github.mwiede` fork) session, algorithm-configuration, host-key, and key-pair generation/loading lifecycles, and the sshj 0.40 client connect/auth, algorithm-selection, key-provider, and host-key-verification lifecycles.
 - Java callgraph contracts now model the lazysodium-java 5.2 libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles (both the high-level `Lazy` and buffer-based `Native` surfaces) and the kalium box, secretbox, sealed-box, AEAD, hash, password, and signing-key lifecycles.
 - Java callgraph contracts now model the jbcrypt, at.favre.lib bcrypt, Lambdaworks scrypt, argon2-jvm, and Jasypt password/KDF facades, including the bcrypt cost, scrypt N/r/p, and Argon2/PBE iteration work factors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the cloud KMS and secrets-manager facades: AWS KMS across both SDK generations (`software.amazon.awssdk:kms` and `com.amazonaws:aws-java-sdk-kms`), Google Cloud KMS, Azure Key Vault Keys cryptography and key clients, and the HashiCorp `vault-java-driver` client and TLS configuration.
 - Java callgraph contracts now model the OkHttp 5.x TLS surface — certificate pinning, `ConnectionSpec` cipher-suite and TLS-version selection, handshake inspection, the TLS-related `OkHttpClient.Builder` configuration, and the `okhttp-tls` `HeldCertificate`/`HandshakeCertificates` certificate and key generation.
 - Java callgraph contracts now model the JSch (`com.jcraft` and the `com.github.mwiede` fork) session, algorithm-configuration, host-key, and key-pair generation/loading lifecycles, and the sshj 0.40 client connect/auth, algorithm-selection, key-provider, and host-key-verification lifecycles.
 - Java callgraph contracts now model the lazysodium-java 5.2 libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles (both the high-level `Lazy` and buffer-based `Native` surfaces) and the kalium box, secretbox, sealed-box, AEAD, hash, password, and signing-key lifecycles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Java callgraph contracts now model the lazysodium-java 5.2 libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles (both the high-level `Lazy` and buffer-based `Native` surfaces) and the kalium box, secretbox, sealed-box, AEAD, hash, password, and signing-key lifecycles.
 - Java callgraph contracts now model the jbcrypt, at.favre.lib bcrypt, Lambdaworks scrypt, argon2-jvm, and Jasypt password/KDF facades, including the bcrypt cost, scrypt N/r/p, and Argon2/PBE iteration work factors.
 - Java callgraph contracts now model the Hutool-crypto 5.8 SecureUtil/DigestUtil/SmUtil/KeyUtil factories and the symmetric, digest, MAC, asymmetric, signing, and SM2 lifecycles.
 - Java callgraph contracts now model the I2P ed25519-java (net.i2p.crypto:eddsa) 0.3 EdDSA signing engine, key-pair generation, and key/spec construction lifecycles.

--- a/internal/callgraph/contracts/contracts_test.go
+++ b/internal/callgraph/contracts/contracts_test.go
@@ -483,13 +483,16 @@ func TestLoadEmbedded_Java_HierarchyReachability(t *testing.T) {
 	}
 
 	// Known opaque root types that need no hierarchy entry:
-	// - byte[] is a JVM primitive array, not a reference type in the hierarchy
+	// - byte[] / char[] are JVM primitive arrays, not reference types in the
+	//   hierarchy (char[] shows up on password APIs that keep the secret out of
+	//   an immutable String, e.g. BCrypt.Hasher.hashToChar)
 	// - boolean is a JVM primitive (e.g. terminal HashChecker.with* verify calls)
 	// - void / int are JVM primitives (e.g. role:config lifecycle calls like
 	//   GCMBlockCipher.init -> void, SHA256Digest.getDigestSize -> int)
 	// - java.lang.Object is the universal root
 	opaqueRoots := map[string]struct{}{
 		"byte[]":           {},
+		"char[]":           {},
 		"boolean":          {},
 		"void":             {},
 		"int":              {},

--- a/internal/callgraph/contracts/java/argon2-jvm.yaml
+++ b/internal/callgraph/contracts/java/argon2-jvm.yaml
@@ -1,0 +1,430 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: argon2-jvm
+  coordinates:
+    - "de.mkammerer:argon2-jvm"
+    - "de.mkammerer:argon2-jvm-nolibs"
+  # Verified against upstream source at version 2.12 (phxql/argon2-jvm).
+  version_range: ">=2.0,<3.0"
+  description: "argon2-jvm contracts for Argon2 factory selection, password hashing, verification, and raw KDF operations"
+
+contracts:
+  # --- Factory (de.mkammerer.argon2.Argon2Factory) ---
+  # create returns Argon2, createAdvanced returns Argon2Advanced; both share the
+  # same four arities, so the method name is what distinguishes the declared
+  # return (every runtime object implements both interfaces).
+  - method: de.mkammerer.argon2.Argon2Factory.create
+    arity: 0
+    canonical_return_type: de.mkammerer.argon2.Argon2
+    return:
+      type: de.mkammerer.argon2.Argon2
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.Argon2Factory.create
+    arity: 1
+    parameter_types: [de.mkammerer.argon2.Argon2Factory.Argon2Types]
+    canonical_return_type: de.mkammerer.argon2.Argon2
+    return:
+      type: de.mkammerer.argon2.Argon2
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.Argon2Factory.create
+    arity: 2
+    parameter_types: [int, int]
+    canonical_return_type: de.mkammerer.argon2.Argon2
+    return:
+      type: de.mkammerer.argon2.Argon2
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: defaultSaltLength
+        role: metadata-contributing
+        contributes: { property: saltLength, derivation: argument_value }
+      - index: 1
+        name: defaultHashLength
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2Factory.create
+    arity: 3
+    parameter_types: [de.mkammerer.argon2.Argon2Factory.Argon2Types, int, int]
+    canonical_return_type: de.mkammerer.argon2.Argon2
+    return:
+      type: de.mkammerer.argon2.Argon2
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: defaultSaltLength
+        role: metadata-contributing
+        contributes: { property: saltLength, derivation: argument_value }
+      - index: 2
+        name: defaultHashLength
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2Factory.createAdvanced
+    arity: 0
+    canonical_return_type: de.mkammerer.argon2.Argon2Advanced
+    return:
+      type: de.mkammerer.argon2.Argon2Advanced
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.Argon2Factory.createAdvanced
+    arity: 1
+    parameter_types: [de.mkammerer.argon2.Argon2Factory.Argon2Types]
+    canonical_return_type: de.mkammerer.argon2.Argon2Advanced
+    return:
+      type: de.mkammerer.argon2.Argon2Advanced
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.Argon2Factory.createAdvanced
+    arity: 2
+    parameter_types: [int, int]
+    canonical_return_type: de.mkammerer.argon2.Argon2Advanced
+    return:
+      type: de.mkammerer.argon2.Argon2Advanced
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.Argon2Factory.createAdvanced
+    arity: 3
+    parameter_types: [de.mkammerer.argon2.Argon2Factory.Argon2Types, int, int]
+    canonical_return_type: de.mkammerer.argon2.Argon2Advanced
+    return:
+      type: de.mkammerer.argon2.Argon2Advanced
+      confidence: high
+    role: factory
+
+  # --- Hashing and verification (de.mkammerer.argon2.Argon2 interface) ---
+  # Authored on the interface; the concrete Argon2i/Argon2d/Argon2id
+  # implementations are package-private and never nameable at a call site.
+  # hash/verify are overloaded per arity (String/char[]/byte[] password, with or
+  # without an explicit Charset) with one declared return each — canonical
+  # signatures omitted. The Argon2 cost parameters occupy indexes 0..2.
+  - method: de.mkammerer.argon2.Argon2.hash
+    arity: 4
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: iterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 1
+        name: memory
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+      - index: 2
+        name: parallelism
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2.hash
+    arity: 5
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: iterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 1
+        name: memory
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+      - index: 2
+        name: parallelism
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2.verify
+    arity: 2
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2.verify
+    arity: 3
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2.needsRehash
+    arity: 4
+    parameter_types: [java.lang.String, int, int, int]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  # wipeArray#1 is overloaded (char[] / byte[]), both void.
+  - method: de.mkammerer.argon2.Argon2.wipeArray
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: operation
+
+  # --- Advanced surface (de.mkammerer.argon2.Argon2Advanced interface) ---
+  - method: de.mkammerer.argon2.Argon2Advanced.rawHash
+    arity: 5
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: iterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 1
+        name: memory
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+      - index: 2
+        name: parallelism
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2Advanced.rawHash
+    arity: 6
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: iterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 1
+        name: memory
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+      - index: 2
+        name: parallelism
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+  # Argon2Advanced adds a salt-explicit hash at arity 6 (the Argon2 interface
+  # tops out at arity 5), so this arity is unambiguous on the subinterface.
+  - method: de.mkammerer.argon2.Argon2Advanced.hash
+    arity: 6
+    parameter_types:
+      [int, int, int, "char[]", java.nio.charset.Charset, "byte[]"]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2Advanced.pbkdf
+    arity: 6
+    parameter_types: [int, int, int, "byte[]", "byte[]", int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 5
+        name: keyLength
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2Advanced.pbkdf
+    arity: 7
+    parameter_types:
+      [int, int, int, "char[]", java.nio.charset.Charset, "byte[]", int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 6
+        name: keyLength
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: de.mkammerer.argon2.Argon2Advanced.hashAdvanced
+    arity: 7
+    parameter_types:
+      [
+        int,
+        int,
+        int,
+        "byte[]",
+        "byte[]",
+        int,
+        de.mkammerer.argon2.Argon2Version,
+      ]
+    canonical_return_type: de.mkammerer.argon2.HashResult
+    return:
+      type: de.mkammerer.argon2.HashResult
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2Advanced.rawHashAdvanced
+    arity: 8
+    parameter_types:
+      [
+        int,
+        int,
+        int,
+        "char[]",
+        java.nio.charset.Charset,
+        "byte[]",
+        "byte[]",
+        "byte[]",
+      ]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2Advanced.rawHashAdvanced
+    arity: 9
+    parameter_types:
+      [
+        int,
+        int,
+        int,
+        "byte[]",
+        "byte[]",
+        "byte[]",
+        "byte[]",
+        int,
+        de.mkammerer.argon2.Argon2Version,
+      ]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2Advanced.verifyAdvanced
+    arity: 9
+    parameter_types:
+      [
+        int,
+        int,
+        int,
+        "char[]",
+        java.nio.charset.Charset,
+        "byte[]",
+        "byte[]",
+        "byte[]",
+        "byte[]",
+      ]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2Advanced.verifyAdvanced
+    arity: 10
+    parameter_types:
+      [
+        int,
+        int,
+        int,
+        "byte[]",
+        "byte[]",
+        "byte[]",
+        "byte[]",
+        int,
+        de.mkammerer.argon2.Argon2Version,
+        "byte[]",
+      ]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: de.mkammerer.argon2.Argon2Advanced.generateSalt
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.Argon2Advanced.generateSalt
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: lengthInBytes
+        role: metadata-contributing
+        contributes: { property: saltLength, derivation: argument_value }
+
+  # --- Results and helpers ---
+  - method: de.mkammerer.argon2.HashResult.<init>
+    arity: 2
+    parameter_types: ["byte[]", java.lang.String]
+    canonical_return_type: de.mkammerer.argon2.HashResult
+    return:
+      type: de.mkammerer.argon2.HashResult
+      confidence: high
+    role: factory
+  - method: de.mkammerer.argon2.HashResult.getRaw
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: de.mkammerer.argon2.HashResult.getEncoded
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: de.mkammerer.argon2.Argon2Helper.findIterations
+    arity: 4
+    parameter_types: [de.mkammerer.argon2.Argon2, long, int, int]
+    canonical_return_type: int
+    return:
+      type: int
+      confidence: high
+    role: config
+  - method: de.mkammerer.argon2.Argon2Helper.findIterations
+    arity: 5
+    parameter_types:
+      [
+        de.mkammerer.argon2.Argon2,
+        long,
+        int,
+        int,
+        de.mkammerer.argon2.Argon2Helper.IterationLogger,
+      ]
+    canonical_return_type: int
+    return:
+      type: int
+      confidence: high
+    role: config
+
+hierarchy:
+  de.mkammerer.argon2.Argon2:
+    - java.lang.Object
+  de.mkammerer.argon2.Argon2Advanced:
+    - de.mkammerer.argon2.Argon2
+  de.mkammerer.argon2.Argon2Factory:
+    - java.lang.Object
+  de.mkammerer.argon2.Argon2Factory.Argon2Types:
+    - java.lang.Enum
+  de.mkammerer.argon2.Argon2Version:
+    - java.lang.Enum
+  java.lang.Enum:
+    - java.lang.Object
+  de.mkammerer.argon2.HashResult:
+    - java.lang.Object
+  de.mkammerer.argon2.Argon2Helper:
+    - java.lang.Object
+  de.mkammerer.argon2.Argon2Helper.IterationLogger:
+    - java.lang.Object
+  java.nio.charset.Charset:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/aws-kms.yaml
+++ b/internal/callgraph/contracts/java/aws-kms.yaml
@@ -232,6 +232,41 @@ contracts:
       type: software.amazon.awssdk.services.kms.model.EncryptRequest
       confidence: high
     role: factory
+  - method: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder.ciphertextBlob
+    arity: 1
+    parameter_types: [software.amazon.awssdk.core.SdkBytes]
+    canonical_return_type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+      confidence: high
+    role: config
+  - method: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder.keyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+      confidence: high
+    role: config
+  # encryptionAlgorithm#1 is overloaded (String / EncryptionAlgorithmSpec).
+  - method: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder.encryptionAlgorithm
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: encryptionAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder.build
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.DecryptRequest
+    return:
+      type: software.amazon.awssdk.services.kms.model.DecryptRequest
+      confidence: high
+    role: factory
   - method: software.amazon.awssdk.services.kms.model.SignRequest.Builder.keyId
     arity: 1
     parameter_types: [java.lang.String]
@@ -598,6 +633,116 @@ contracts:
     canonical_return_type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
     return:
       type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: numberOfBytes
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_value }
+
+  # v1 also exposes plain bean setters alongside the fluent withX forms, and
+  # AWS's own v1 samples prefer them, so both spellings are contracted.
+  - method: com.amazonaws.services.kms.model.EncryptRequest.setKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.EncryptRequest.setPlaintext
+    arity: 1
+    parameter_types: [java.nio.ByteBuffer]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.EncryptRequest.setEncryptionAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: encryptionAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.DecryptRequest.setCiphertextBlob
+    arity: 1
+    parameter_types: [java.nio.ByteBuffer]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.DecryptRequest.setKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.SignRequest.setKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.SignRequest.setMessage
+    arity: 1
+    parameter_types: [java.nio.ByteBuffer]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.SignRequest.setSigningAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: signingAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.setKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  # setKeySpec#1 is overloaded (String / DataKeySpec).
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.setKeySpec
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: keySpec
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.setNumberOfBytes
+    arity: 1
+    parameter_types: [java.lang.Integer]
+    canonical_return_type: void
+    return:
+      type: void
       confidence: high
     role: config
     parameters:

--- a/internal/callgraph/contracts/java/aws-kms.yaml
+++ b/internal/callgraph/contracts/java/aws-kms.yaml
@@ -1,0 +1,749 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: aws-kms
+  # Coordinate hygiene: AWS ships two independent SDK generations with
+  # disjoint packages, and real projects use either. Both are contracted here
+  # because the FQNs never collide:
+  #   * v2 -> software.amazon.awssdk:kms          (software.amazon.awssdk.services.kms)
+  #   * v1 -> com.amazonaws:aws-java-sdk-kms      (com.amazonaws.services.kms)
+  # v1 is in maintenance mode (end-of-support announced), so a project may pin
+  # either; the KB must resolve both rather than assuming v2.
+  coordinates:
+    - "software.amazon.awssdk:kms"
+    - "com.amazonaws:aws-java-sdk-kms"
+  # Verified with javap against the published kms-2.31.0.jar (v2) and
+  # aws-java-sdk-kms-1.12.780.jar (v1).
+  version_range: ">=1.11"
+  description: "AWS KMS contracts for both SDK generations: client construction, remote encrypt/decrypt, sign/verify, MAC, data-key generation, and random-byte operations"
+
+contracts:
+  # =========================================================================
+  # SDK v2 client (software.amazon.awssdk.services.kms)
+  # rule anchors: KmsClient.create, KmsClient.builder
+  # Every operation has a (XRequest) and a (Consumer<XRequest.Builder>) form at
+  # arity 1 with the same response type, so canonical signatures are omitted.
+  # =========================================================================
+  - method: software.amazon.awssdk.services.kms.KmsClient.create
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.KmsClient
+    return:
+      type: software.amazon.awssdk.services.kms.KmsClient
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.KmsClientBuilder
+    return:
+      type: software.amazon.awssdk.services.kms.KmsClientBuilder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.encrypt
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.decrypt
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.DecryptResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.sign
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.verify
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.VerifyResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateMac
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateMacResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.verifyMac
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.VerifyMacResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.reEncrypt
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.ReEncryptResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.deriveSharedSecret
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.DeriveSharedSecretResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateDataKey
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateDataKeyPair
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateDataKeyPairResponse
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateDataKeyWithoutPlaintext
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateDataKeyWithoutPlaintextResponse
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateDataKeyPairWithoutPlaintext
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateDataKeyPairWithoutPlaintextResponse
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.createKey
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.CreateKeyResponse
+    return:
+      type: software.amazon.awssdk.services.kms.model.CreateKeyResponse
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.createKey
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.CreateKeyResponse
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateRandom
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.GenerateRandomResponse
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateRandomResponse
+      confidence: high
+    role: operation
+  - method: software.amazon.awssdk.services.kms.KmsClient.generateRandom
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateRandomResponse
+      confidence: high
+    role: operation
+
+  # --- v2 request builders (rule anchors: *Request.builder) ---
+  - method: software.amazon.awssdk.services.kms.model.EncryptRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.DecryptRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.DecryptRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.SignRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.VerifyRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.VerifyRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.VerifyRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.GenerateRandomRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.GenerateRandomRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateRandomRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.GenerateMacRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.GenerateMacRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.GenerateMacRequest.Builder
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.CreateKeyRequest.builder
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.CreateKeyRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.CreateKeyRequest.Builder
+      confidence: high
+    role: factory
+  # v2 builder configuration. keyId/plaintext/message carry the key reference and
+  # the data; encryptionAlgorithm/signingAlgorithm select the algorithm and are
+  # each overloaded (String / enum spec) at arity 1.
+  - method: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder.keyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+      confidence: high
+    role: config
+  - method: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder.plaintext
+    arity: 1
+    parameter_types: [software.amazon.awssdk.core.SdkBytes]
+    canonical_return_type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+      confidence: high
+    role: config
+  - method: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder.encryptionAlgorithm
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: encryptionAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: software.amazon.awssdk.services.kms.model.EncryptRequest.Builder.build
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.EncryptRequest
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptRequest
+      confidence: high
+    role: factory
+  - method: software.amazon.awssdk.services.kms.model.SignRequest.Builder.keyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+      confidence: high
+    role: config
+  - method: software.amazon.awssdk.services.kms.model.SignRequest.Builder.message
+    arity: 1
+    parameter_types: [software.amazon.awssdk.core.SdkBytes]
+    canonical_return_type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+      confidence: high
+    role: config
+  - method: software.amazon.awssdk.services.kms.model.SignRequest.Builder.messageType
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+      confidence: high
+    role: config
+  - method: software.amazon.awssdk.services.kms.model.SignRequest.Builder.signingAlgorithm
+    arity: 1
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignRequest.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: signingAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: software.amazon.awssdk.services.kms.model.SignRequest.Builder.build
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.SignRequest
+    return:
+      type: software.amazon.awssdk.services.kms.model.SignRequest
+      confidence: high
+    role: factory
+
+  # --- v2 response material (SdkBytes carries the actual key/cipher/signature) ---
+  - method: software.amazon.awssdk.services.kms.model.EncryptResponse.ciphertextBlob
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.core.SdkBytes
+    return:
+      type: software.amazon.awssdk.core.SdkBytes
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.EncryptResponse.encryptionAlgorithm
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec
+    return:
+      type: software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.DecryptResponse.plaintext
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.core.SdkBytes
+    return:
+      type: software.amazon.awssdk.core.SdkBytes
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.SignResponse.signature
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.core.SdkBytes
+    return:
+      type: software.amazon.awssdk.core.SdkBytes
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.SignResponse.signingAlgorithm
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec
+    return:
+      type: software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.VerifyResponse.signatureValid
+    arity: 0
+    canonical_return_type: java.lang.Boolean
+    return:
+      type: java.lang.Boolean
+      confidence: high
+    role: output
+  # The data-key plaintext accessor is plaintext() in v2 (there is no
+  # plaintextKey()); ciphertextBlob() is the wrapped copy.
+  - method: software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse.plaintext
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.core.SdkBytes
+    return:
+      type: software.amazon.awssdk.core.SdkBytes
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse.ciphertextBlob
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.core.SdkBytes
+    return:
+      type: software.amazon.awssdk.core.SdkBytes
+      confidence: high
+    role: output
+  - method: software.amazon.awssdk.services.kms.model.GenerateRandomResponse.plaintext
+    arity: 0
+    canonical_return_type: software.amazon.awssdk.core.SdkBytes
+    return:
+      type: software.amazon.awssdk.core.SdkBytes
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # SDK v1 client (com.amazonaws.services.kms)
+  # rule anchors: AWSKMSClientBuilder.standard/defaultClient, new *Request()
+  # =========================================================================
+  - method: com.amazonaws.services.kms.AWSKMSClientBuilder.standard
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.AWSKMSClientBuilder
+    return:
+      type: com.amazonaws.services.kms.AWSKMSClientBuilder
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.AWSKMSClientBuilder.defaultClient
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.AWSKMS
+    return:
+      type: com.amazonaws.services.kms.AWSKMS
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.AWSKMS.encrypt
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.EncryptRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.EncryptResult
+    return:
+      type: com.amazonaws.services.kms.model.EncryptResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.decrypt
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.DecryptRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.DecryptResult
+    return:
+      type: com.amazonaws.services.kms.model.DecryptResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.sign
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.SignRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.SignResult
+    return:
+      type: com.amazonaws.services.kms.model.SignResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.verify
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.VerifyRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.VerifyResult
+    return:
+      type: com.amazonaws.services.kms.model.VerifyResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.generateMac
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.GenerateMacRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateMacResult
+    return:
+      type: com.amazonaws.services.kms.model.GenerateMacResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.verifyMac
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.VerifyMacRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.VerifyMacResult
+    return:
+      type: com.amazonaws.services.kms.model.VerifyMacResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.reEncrypt
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.ReEncryptRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.ReEncryptResult
+    return:
+      type: com.amazonaws.services.kms.model.ReEncryptResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.generateDataKey
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.GenerateDataKeyRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateDataKeyResult
+    return:
+      type: com.amazonaws.services.kms.model.GenerateDataKeyResult
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.AWSKMS.generateDataKeyPair
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.GenerateDataKeyPairRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateDataKeyPairResult
+    return:
+      type: com.amazonaws.services.kms.model.GenerateDataKeyPairResult
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.AWSKMS.createKey
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.model.CreateKeyResult
+    return:
+      type: com.amazonaws.services.kms.model.CreateKeyResult
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.AWSKMS.createKey
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.CreateKeyRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.CreateKeyResult
+    return:
+      type: com.amazonaws.services.kms.model.CreateKeyResult
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.AWSKMS.generateRandom
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateRandomResult
+    return:
+      type: com.amazonaws.services.kms.model.GenerateRandomResult
+      confidence: high
+    role: operation
+  - method: com.amazonaws.services.kms.AWSKMS.generateRandom
+    arity: 1
+    parameter_types: [com.amazonaws.services.kms.model.GenerateRandomRequest]
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateRandomResult
+    return:
+      type: com.amazonaws.services.kms.model.GenerateRandomResult
+      confidence: high
+    role: operation
+
+  # --- v1 request objects: plain constructors plus fluent withXxx setters.
+  # withEncryptionAlgorithm/withSigningAlgorithm are overloaded (String / enum
+  # spec) at arity 1, so those omit canonical signatures.
+  - method: com.amazonaws.services.kms.model.EncryptRequest.<init>
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.model.EncryptRequest
+    return:
+      type: com.amazonaws.services.kms.model.EncryptRequest
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.model.EncryptRequest.withKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.amazonaws.services.kms.model.EncryptRequest
+    return:
+      type: com.amazonaws.services.kms.model.EncryptRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.EncryptRequest.withPlaintext
+    arity: 1
+    parameter_types: [java.nio.ByteBuffer]
+    canonical_return_type: com.amazonaws.services.kms.model.EncryptRequest
+    return:
+      type: com.amazonaws.services.kms.model.EncryptRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.EncryptRequest.withEncryptionAlgorithm
+    arity: 1
+    return:
+      type: com.amazonaws.services.kms.model.EncryptRequest
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: encryptionAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.DecryptRequest.<init>
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.model.DecryptRequest
+    return:
+      type: com.amazonaws.services.kms.model.DecryptRequest
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.model.DecryptRequest.withCiphertextBlob
+    arity: 1
+    parameter_types: [java.nio.ByteBuffer]
+    canonical_return_type: com.amazonaws.services.kms.model.DecryptRequest
+    return:
+      type: com.amazonaws.services.kms.model.DecryptRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.DecryptRequest.withKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.amazonaws.services.kms.model.DecryptRequest
+    return:
+      type: com.amazonaws.services.kms.model.DecryptRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.DecryptRequest.withEncryptionAlgorithm
+    arity: 1
+    return:
+      type: com.amazonaws.services.kms.model.DecryptRequest
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: encryptionAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.SignRequest.<init>
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.model.SignRequest
+    return:
+      type: com.amazonaws.services.kms.model.SignRequest
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.model.SignRequest.withKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.amazonaws.services.kms.model.SignRequest
+    return:
+      type: com.amazonaws.services.kms.model.SignRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.SignRequest.withMessage
+    arity: 1
+    parameter_types: [java.nio.ByteBuffer]
+    canonical_return_type: com.amazonaws.services.kms.model.SignRequest
+    return:
+      type: com.amazonaws.services.kms.model.SignRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.SignRequest.withSigningAlgorithm
+    arity: 1
+    return:
+      type: com.amazonaws.services.kms.model.SignRequest
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: signingAlgorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.<init>
+    arity: 0
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+    return:
+      type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+      confidence: high
+    role: factory
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.withKeyId
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+    return:
+      type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+      confidence: high
+    role: config
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.withKeySpec
+    arity: 1
+    return:
+      type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: keySpec
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyRequest.withNumberOfBytes
+    arity: 1
+    parameter_types: [java.lang.Integer]
+    canonical_return_type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+    return:
+      type: com.amazonaws.services.kms.model.GenerateDataKeyRequest
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: numberOfBytes
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_value }
+
+  # --- v1 result material (ByteBuffer in v1, SdkBytes in v2) ---
+  - method: com.amazonaws.services.kms.model.EncryptResult.getCiphertextBlob
+    arity: 0
+    canonical_return_type: java.nio.ByteBuffer
+    return:
+      type: java.nio.ByteBuffer
+      confidence: high
+    role: output
+  - method: com.amazonaws.services.kms.model.DecryptResult.getPlaintext
+    arity: 0
+    canonical_return_type: java.nio.ByteBuffer
+    return:
+      type: java.nio.ByteBuffer
+      confidence: high
+    role: output
+  - method: com.amazonaws.services.kms.model.SignResult.getSignature
+    arity: 0
+    canonical_return_type: java.nio.ByteBuffer
+    return:
+      type: java.nio.ByteBuffer
+      confidence: high
+    role: output
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyResult.getPlaintext
+    arity: 0
+    canonical_return_type: java.nio.ByteBuffer
+    return:
+      type: java.nio.ByteBuffer
+      confidence: high
+    role: output
+  - method: com.amazonaws.services.kms.model.GenerateDataKeyResult.getCiphertextBlob
+    arity: 0
+    canonical_return_type: java.nio.ByteBuffer
+    return:
+      type: java.nio.ByteBuffer
+      confidence: high
+    role: output
+
+hierarchy:
+  # v2
+  software.amazon.awssdk.services.kms.KmsClient:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.KmsClientBuilder:
+    - java.lang.Object
+  software.amazon.awssdk.core.SdkBytes:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.EncryptRequest:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.EncryptRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.DecryptRequest:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.DecryptRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.SignRequest:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.SignRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.VerifyRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateRandomRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateMacRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.CreateKeyRequest.Builder:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.EncryptResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.DecryptResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.SignResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.VerifyResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateMacResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.VerifyMacResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.ReEncryptResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.DeriveSharedSecretResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateDataKeyPairResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateDataKeyWithoutPlaintextResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateDataKeyPairWithoutPlaintextResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.CreateKeyResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.GenerateRandomResponse:
+    - java.lang.Object
+  software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec:
+    - java.lang.Enum
+  software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec:
+    - java.lang.Enum
+  # v1
+  com.amazonaws.services.kms.AWSKMS:
+    - java.lang.Object
+  com.amazonaws.services.kms.AWSKMSClientBuilder:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.EncryptRequest:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.DecryptRequest:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.SignRequest:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.GenerateDataKeyRequest:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.EncryptResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.DecryptResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.SignResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.VerifyResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.GenerateMacResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.VerifyMacResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.ReEncryptResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.GenerateDataKeyResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.GenerateDataKeyPairResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.CreateKeyResult:
+    - java.lang.Object
+  com.amazonaws.services.kms.model.GenerateRandomResult:
+    - java.lang.Object
+  java.nio.ByteBuffer:
+    - java.lang.Object
+  java.lang.Boolean:
+    - java.lang.Object
+  java.lang.Enum:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/azure-keyvault-keys-java.yaml
+++ b/internal/callgraph/contracts/java/azure-keyvault-keys-java.yaml
@@ -1,0 +1,640 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  # The Python ecosystem has its own azure-keyvault-keys KB; library names only
+  # need to be unique per ecosystem, but the -java suffix keeps diagnostics
+  # unambiguous when both appear in one report.
+  name: azure-keyvault-keys-java
+  coordinates:
+    - "com.azure:azure-security-keyvault-keys"
+  # Verified with javap against the published azure-security-keyvault-keys-4.9.2
+  # jar (MANIFEST Implementation-Version 4.9.2).
+  version_range: ">=4.0,<5.0"
+  description: "Azure Key Vault Keys contracts for cryptography and key client construction, remote encrypt/decrypt, sign/verify, key wrapping, and key creation or import"
+
+contracts:
+  # =========================================================================
+  # Cryptography client construction
+  # rule anchor: new CryptographyClientBuilder()
+  # The builder's arity-1 config methods each have a trait-interface bridge
+  # overload (returning TokenCredentialTrait/HttpTrait/ConfigurationTrait); only
+  # the source-visible concrete-builder form is contracted.
+  # =========================================================================
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.<init>
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.keyIdentifier
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.jsonWebKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.JsonWebKey]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.credential
+    arity: 1
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.disableKeyCaching
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+      confidence: high
+    role: config
+  # disableChallengeResourceVerification turns off the authentication-challenge
+  # resource check.
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.disableChallengeResourceVerification
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.buildClient
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyClient
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyClient
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.buildAsyncClient
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Remote crypto operations (CryptographyClient)
+  # encrypt#2 and decrypt#2 are ambiguous by arity: (algorithm, data) and
+  # (parameters, context) both exist and return the same result type, so
+  # canonical signatures are omitted for those two. The remaining operations are
+  # unambiguous per arity.
+  # =========================================================================
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.encrypt
+    arity: 2
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.EncryptResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.encrypt
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm,
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.EncryptResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.EncryptResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.decrypt
+    arity: 2
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.DecryptResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.decrypt
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm,
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.DecryptResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.DecryptResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.sign
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.sign
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.verify
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        "byte[]",
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.verify
+    arity: 4
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+      confidence: high
+    role: operation
+  # signData/verifyData hash the input before signing, unlike sign/verify which
+  # take a pre-computed digest.
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.signData
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.signData
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.SignResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.verifyData
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        "byte[]",
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.verifyData
+    arity: 4
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.VerifyResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.wrapKey
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.WrapResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.WrapResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.wrapKey
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm,
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.WrapResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.WrapResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.unwrapKey
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.UnwrapResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.UnwrapResult
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.unwrapKey
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm,
+        "byte[]",
+        com.azure.core.util.Context,
+      ]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.UnwrapResult
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.UnwrapResult
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyClient.getKey
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # Key management client (rule anchor: new KeyClientBuilder())
+  # =========================================================================
+  - method: com.azure.security.keyvault.keys.KeyClientBuilder.<init>
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.KeyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.KeyClientBuilder
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClientBuilder.vaultUrl
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.azure.security.keyvault.keys.KeyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.KeyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.KeyClientBuilder.credential
+    arity: 1
+    return:
+      type: com.azure.security.keyvault.keys.KeyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.KeyClientBuilder.disableChallengeResourceVerification
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.KeyClientBuilder
+    return:
+      type: com.azure.security.keyvault.keys.KeyClientBuilder
+      confidence: high
+    role: config
+  - method: com.azure.security.keyvault.keys.KeyClientBuilder.buildClient
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.KeyClient
+    return:
+      type: com.azure.security.keyvault.keys.KeyClient
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClientBuilder.buildAsyncClient
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.KeyAsyncClient
+    return:
+      type: com.azure.security.keyvault.keys.KeyAsyncClient
+      confidence: high
+    role: factory
+  # createKey#1 takes a CreateKeyOptions; createKey#2 takes (name, KeyType).
+  - method: com.azure.security.keyvault.keys.KeyClient.createKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateKeyOptions]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClient.createKey
+    arity: 2
+    parameter_types:
+      [java.lang.String, com.azure.security.keyvault.keys.models.KeyType]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: keyType
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.KeyClient.createRsaKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateRsaKeyOptions]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClient.createEcKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateEcKeyOptions]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClient.createOctKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateOctKeyOptions]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClient.importKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.ImportKeyOptions]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClient.importKey
+    arity: 2
+    parameter_types:
+      [java.lang.String, com.azure.security.keyvault.keys.models.JsonWebKey]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyClient.getKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.KeyClient.backupKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.KeyClient.restoreKeyBackup
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
+    return:
+      type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Algorithm selectors (rule anchors: EncryptionAlgorithm.$C, SignatureAlgorithm.$C)
+  # These are ExpandableStringEnum types, so fromString accepts arbitrary names
+  # rather than being limited to the declared constants.
+  # =========================================================================
+  - method: com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm.fromString
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: name
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm.fromString
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: name
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm.fromString
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: name
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+
+  # =========================================================================
+  # Result material
+  # =========================================================================
+  - method: com.azure.security.keyvault.keys.cryptography.models.EncryptResult.getCipherText
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.EncryptResult.getIv
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.EncryptResult.getAuthenticationTag
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.EncryptResult.getAlgorithm
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.DecryptResult.getPlainText
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.SignResult.getSignature
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.SignResult.getAlgorithm
+    arity: 0
+    canonical_return_type: com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm
+    return:
+      type: com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.VerifyResult.isValid
+    arity: 0
+    canonical_return_type: java.lang.Boolean
+    return:
+      type: java.lang.Boolean
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.WrapResult.getEncryptedKey
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.cryptography.models.UnwrapResult.getKey
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+
+hierarchy:
+  com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.CryptographyClient:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.KeyClientBuilder:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.KeyClient:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.KeyAsyncClient:
+    - java.lang.Object
+  # The algorithm selectors are ExpandableStringEnum, not java.lang.Enum.
+  com.azure.core.util.ExpandableStringEnum:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm:
+    - com.azure.core.util.ExpandableStringEnum
+  com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm:
+    - com.azure.core.util.ExpandableStringEnum
+  com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm:
+    - com.azure.core.util.ExpandableStringEnum
+  com.azure.security.keyvault.keys.models.KeyType:
+    - com.azure.core.util.ExpandableStringEnum
+  com.azure.security.keyvault.keys.cryptography.models.EncryptResult:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.DecryptResult:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.SignResult:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.VerifyResult:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.WrapResult:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.UnwrapResult:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.models.KeyVaultKey:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.models.JsonWebKey:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.models.CreateKeyOptions:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.models.CreateRsaKeyOptions:
+    - com.azure.security.keyvault.keys.models.CreateKeyOptions
+  com.azure.security.keyvault.keys.models.CreateEcKeyOptions:
+    - com.azure.security.keyvault.keys.models.CreateKeyOptions
+  com.azure.security.keyvault.keys.models.CreateOctKeyOptions:
+    - com.azure.security.keyvault.keys.models.CreateKeyOptions
+  com.azure.security.keyvault.keys.models.ImportKeyOptions:
+    - java.lang.Object
+  com.azure.core.util.Context:
+    - java.lang.Object
+  java.lang.Boolean:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/azure-keyvault-keys-java.yaml
+++ b/internal/callgraph/contracts/java/azure-keyvault-keys-java.yaml
@@ -331,6 +331,162 @@ contracts:
     role: output
 
   # =========================================================================
+  # Async cryptography client (CryptographyAsyncClient)
+  # Every method returns reactor.core.publisher.Mono; the concrete result type
+  # is only recoverable from the Mono's type argument, which the contract schema
+  # cannot express, so the declared container type is what is modelled. The
+  # lifecycle role is the load-bearing part here.
+  # encrypt#1/decrypt#1 take a Parameters object; the arity-2 forms take
+  # (algorithm, data).
+  # =========================================================================
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.encrypt
+    arity: 1
+    parameter_types:
+      [com.azure.security.keyvault.keys.cryptography.models.EncryptParameters]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.encrypt
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.decrypt
+    arity: 1
+    parameter_types:
+      [com.azure.security.keyvault.keys.cryptography.models.DecryptParameters]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.decrypt
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.sign
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.verify
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.signData
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.verifyData
+    arity: 3
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm,
+        "byte[]",
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.wrapKey
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.unwrapKey
+    arity: 2
+    parameter_types:
+      [
+        com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm,
+        "byte[]",
+      ]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+
+  # =========================================================================
   # Key management client (rule anchor: new KeyClientBuilder())
   # =========================================================================
   - method: com.azure.security.keyvault.keys.KeyClientBuilder.<init>
@@ -461,6 +617,96 @@ contracts:
     canonical_return_type: com.azure.security.keyvault.keys.models.KeyVaultKey
     return:
       type: com.azure.security.keyvault.keys.models.KeyVaultKey
+      confidence: high
+    role: factory
+
+  # --- Async key management (KeyAsyncClient); same Mono caveat as above ---
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.createKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateKeyOptions]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.createKey
+    arity: 2
+    parameter_types:
+      [java.lang.String, com.azure.security.keyvault.keys.models.KeyType]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: keyType
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.createRsaKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateRsaKeyOptions]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.createEcKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateEcKeyOptions]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.createOctKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.CreateOctKeyOptions]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+  # importKey#1 takes ImportKeyOptions; #2 takes (name, JsonWebKey).
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.importKey
+    arity: 1
+    parameter_types: [com.azure.security.keyvault.keys.models.ImportKeyOptions]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.importKey
+    arity: 2
+    parameter_types:
+      [java.lang.String, com.azure.security.keyvault.keys.models.JsonWebKey]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: factory
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.getKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.backupKey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
+      confidence: high
+    role: output
+  - method: com.azure.security.keyvault.keys.KeyAsyncClient.restoreKeyBackup
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: reactor.core.publisher.Mono
+    return:
+      type: reactor.core.publisher.Mono
       confidence: high
     role: factory
 
@@ -634,6 +880,14 @@ hierarchy:
   com.azure.security.keyvault.keys.models.ImportKeyOptions:
     - java.lang.Object
   com.azure.core.util.Context:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.EncryptParameters:
+    - java.lang.Object
+  com.azure.security.keyvault.keys.cryptography.models.DecryptParameters:
+    - java.lang.Object
+  # Async results are reactor Mono containers; the concrete result type lives in
+  # the type argument, which the schema cannot express.
+  reactor.core.publisher.Mono:
     - java.lang.Object
   java.lang.Boolean:
     - java.lang.Object

--- a/internal/callgraph/contracts/java/favre-bcrypt.yaml
+++ b/internal/callgraph/contracts/java/favre-bcrypt.yaml
@@ -1,0 +1,265 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: favre-bcrypt
+  coordinates:
+    - "at.favre.lib:bcrypt"
+  # Verified against upstream source at release 0.10.2 (patrickfav/bcrypt).
+  version_range: ">=0.9,<1.0"
+  description: "at.favre.lib bcrypt fluent hasher/verifyer contracts for bcrypt hashing and verification"
+
+contracts:
+  # --- Entry points (at.favre.lib.crypto.bcrypt.BCrypt statics) ---
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.withDefaults
+    arity: 0
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+      confidence: high
+    role: factory
+  # with#1 is overloaded (Version / SecureRandom / LongPasswordStrategy), all
+  # returning Hasher — canonical signature omitted.
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.with
+    arity: 1
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.with
+    arity: 2
+    parameter_types:
+      [
+        at.favre.lib.crypto.bcrypt.BCrypt.Version,
+        at.favre.lib.crypto.bcrypt.LongPasswordStrategy,
+      ]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.with
+    arity: 3
+    parameter_types:
+      [
+        at.favre.lib.crypto.bcrypt.BCrypt.Version,
+        java.security.SecureRandom,
+        at.favre.lib.crypto.bcrypt.LongPasswordStrategy,
+      ]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Hasher
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.verifyer
+    arity: 0
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.verifyer
+    arity: 1
+    parameter_types: [at.favre.lib.crypto.bcrypt.BCrypt.Version]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.verifyer
+    arity: 2
+    parameter_types:
+      [
+        at.favre.lib.crypto.bcrypt.BCrypt.Version,
+        at.favre.lib.crypto.bcrypt.LongPasswordStrategy,
+      ]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer
+      confidence: high
+    role: factory
+
+  # --- Hashing (BCrypt.Hasher) ---
+  # Every hasher method takes the bcrypt cost factor at index 0.
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hashToString
+    arity: 2
+    parameter_types: [int, "char[]"]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hashToChar
+    arity: 2
+    parameter_types: [int, "char[]"]
+    canonical_return_type: char[]
+    return:
+      type: char[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  # hash#2 is overloaded ((int,char[]) / (int,byte[])), both returning byte[] —
+  # canonical signature omitted.
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hash
+    arity: 2
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hash
+    arity: 3
+    parameter_types: [int, "byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hashRaw
+    arity: 3
+    parameter_types: [int, "byte[]", "byte[]"]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.HashData
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.HashData
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+
+  # --- Verification (BCrypt.Verifyer) ---
+  # Every verify overload returns BCrypt.Result (never a bare boolean); the
+  # boolean lives in Result.verified, so consumers follow the returned object.
+  # verify#2 has five same-arity overloads — canonical signature omitted.
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer.verify
+    arity: 2
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Result
+      confidence: high
+    role: operation
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer.verify
+    arity: 4
+    parameter_types: ["byte[]", int, "byte[]", "byte[]"]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.Result
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Result
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.Verifyer.verifyStrict
+    arity: 2
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.Result
+      confidence: high
+    role: operation
+
+  # --- Hash material (BCrypt.HashData) ---
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.HashData.<init>
+    arity: 4
+    parameter_types:
+      [int, at.favre.lib.crypto.bcrypt.BCrypt.Version, "byte[]", "byte[]"]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.BCrypt.HashData
+    return:
+      type: at.favre.lib.crypto.bcrypt.BCrypt.HashData
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: cost
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  - method: at.favre.lib.crypto.bcrypt.BCrypt.HashData.wipe
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+
+  # --- Long-password strategies (config objects consumed by with/verifyer) ---
+  - method: at.favre.lib.crypto.bcrypt.LongPasswordStrategies.truncate
+    arity: 1
+    parameter_types: [at.favre.lib.crypto.bcrypt.BCrypt.Version]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+    return:
+      type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.LongPasswordStrategies.hashSha512
+    arity: 1
+    parameter_types: [at.favre.lib.crypto.bcrypt.BCrypt.Version]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+    return:
+      type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.LongPasswordStrategies.strict
+    arity: 1
+    parameter_types: [at.favre.lib.crypto.bcrypt.BCrypt.Version]
+    canonical_return_type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+    return:
+      type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.LongPasswordStrategies.none
+    arity: 0
+    canonical_return_type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+    return:
+      type: at.favre.lib.crypto.bcrypt.LongPasswordStrategy
+      confidence: high
+    role: factory
+  - method: at.favre.lib.crypto.bcrypt.LongPasswordStrategy.derive
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+hierarchy:
+  at.favre.lib.crypto.bcrypt.BCrypt:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.BCrypt.Hasher:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.BCrypt.Verifyer:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.BCrypt.Result:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.BCrypt.HashData:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.BCrypt.Version:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.LongPasswordStrategies:
+    - java.lang.Object
+  at.favre.lib.crypto.bcrypt.LongPasswordStrategy:
+    - java.lang.Object
+  java.security.SecureRandom:
+    - java.util.Random
+  java.util.Random:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/gcp-kms.yaml
+++ b/internal/callgraph/contracts/java/gcp-kms.yaml
@@ -1,0 +1,496 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: gcp-kms
+  # Coordinate hygiene: the client lives in google-cloud-kms, but every request,
+  # response, and resource proto type lives in the generated proto artifact,
+  # which google-cloud-kms pins transitively. Both are listed because contracts
+  # here reference FQNs from each.
+  coordinates:
+    - "com.google.cloud:google-cloud-kms"
+    - "com.google.api.grpc:proto-google-cloud-kms-v1"
+  # Verified with javap against the published google-cloud-kms-2.55.0.jar and
+  # its pinned proto-google-cloud-kms-v1-0.146.0.jar.
+  version_range: ">=2.0,<3.0"
+  description: "Google Cloud KMS contracts for client construction, remote encrypt/decrypt, asymmetric sign/decrypt, MAC, random-byte generation, and key-resource creation"
+
+contracts:
+  # =========================================================================
+  # Client construction (rule anchor: KeyManagementServiceClient.create)
+  # create#1 is overloaded (settings / stub) — canonical signature omitted.
+  # =========================================================================
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.create
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.KeyManagementServiceClient
+    return:
+      type: com.google.cloud.kms.v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.create
+    arity: 1
+    return:
+      type: com.google.cloud.kms.v1.KeyManagementServiceClient
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Symmetric encrypt/decrypt. Each has a request-object form at arity 1 and
+  # convenience (name, data) forms at arity 2; the arity-2 group is overloaded
+  # on the name type (ResourceName / CryptoKeyPathName / String), so canonical
+  # signatures are omitted there.
+  # =========================================================================
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.encrypt
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.EncryptRequest]
+    canonical_return_type: com.google.cloud.kms.v1.EncryptResponse
+    return:
+      type: com.google.cloud.kms.v1.EncryptResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.encrypt
+    arity: 2
+    return:
+      type: com.google.cloud.kms.v1.EncryptResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.decrypt
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.DecryptRequest]
+    canonical_return_type: com.google.cloud.kms.v1.DecryptResponse
+    return:
+      type: com.google.cloud.kms.v1.DecryptResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.decrypt
+    arity: 2
+    return:
+      type: com.google.cloud.kms.v1.DecryptResponse
+      confidence: high
+    role: operation
+  # rawEncrypt/rawDecrypt expose the raw AES modes and only take request objects.
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.rawEncrypt
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.RawEncryptRequest]
+    canonical_return_type: com.google.cloud.kms.v1.RawEncryptResponse
+    return:
+      type: com.google.cloud.kms.v1.RawEncryptResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.rawDecrypt
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.RawDecryptRequest]
+    canonical_return_type: com.google.cloud.kms.v1.RawDecryptResponse
+    return:
+      type: com.google.cloud.kms.v1.RawDecryptResponse
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Asymmetric operations and MAC
+  # =========================================================================
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.asymmetricSign
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.AsymmetricSignRequest]
+    canonical_return_type: com.google.cloud.kms.v1.AsymmetricSignResponse
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.asymmetricSign
+    arity: 2
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.asymmetricDecrypt
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.AsymmetricDecryptRequest]
+    canonical_return_type: com.google.cloud.kms.v1.AsymmetricDecryptResponse
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricDecryptResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.asymmetricDecrypt
+    arity: 2
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricDecryptResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.macSign
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.MacSignRequest]
+    canonical_return_type: com.google.cloud.kms.v1.MacSignResponse
+    return:
+      type: com.google.cloud.kms.v1.MacSignResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.macSign
+    arity: 2
+    return:
+      type: com.google.cloud.kms.v1.MacSignResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.macVerify
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.MacVerifyRequest]
+    canonical_return_type: com.google.cloud.kms.v1.MacVerifyResponse
+    return:
+      type: com.google.cloud.kms.v1.MacVerifyResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.macVerify
+    arity: 3
+    return:
+      type: com.google.cloud.kms.v1.MacVerifyResponse
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Random bytes and key-resource creation
+  # =========================================================================
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.generateRandomBytes
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.GenerateRandomBytesRequest]
+    canonical_return_type: com.google.cloud.kms.v1.GenerateRandomBytesResponse
+    return:
+      type: com.google.cloud.kms.v1.GenerateRandomBytesResponse
+      confidence: high
+    role: operation
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.generateRandomBytes
+    arity: 3
+    parameter_types:
+      [java.lang.String, int, com.google.cloud.kms.v1.ProtectionLevel]
+    canonical_return_type: com.google.cloud.kms.v1.GenerateRandomBytesResponse
+    return:
+      type: com.google.cloud.kms.v1.GenerateRandomBytesResponse
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: lengthBytes
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.createCryptoKey
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.CreateCryptoKeyRequest]
+    canonical_return_type: com.google.cloud.kms.v1.CryptoKey
+    return:
+      type: com.google.cloud.kms.v1.CryptoKey
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.createCryptoKey
+    arity: 3
+    return:
+      type: com.google.cloud.kms.v1.CryptoKey
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.createCryptoKeyVersion
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.CreateCryptoKeyVersionRequest]
+    canonical_return_type: com.google.cloud.kms.v1.CryptoKeyVersion
+    return:
+      type: com.google.cloud.kms.v1.CryptoKeyVersion
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.createCryptoKeyVersion
+    arity: 2
+    return:
+      type: com.google.cloud.kms.v1.CryptoKeyVersion
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.createKeyRing
+    arity: 1
+    parameter_types: [com.google.cloud.kms.v1.CreateKeyRingRequest]
+    canonical_return_type: com.google.cloud.kms.v1.KeyRing
+    return:
+      type: com.google.cloud.kms.v1.KeyRing
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.createKeyRing
+    arity: 3
+    return:
+      type: com.google.cloud.kms.v1.KeyRing
+      confidence: high
+    role: factory
+  # getPublicKey#1 mixes the request-object form with two convenience forms
+  # (CryptoKeyVersionName / String), all returning PublicKey.
+  - method: com.google.cloud.kms.v1.KeyManagementServiceClient.getPublicKey
+    arity: 1
+    return:
+      type: com.google.cloud.kms.v1.PublicKey
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # Request builders (rule anchors: *Request.newBuilder)
+  # newBuilder#1 takes a prototype request to copy.
+  # =========================================================================
+  - method: com.google.cloud.kms.v1.EncryptRequest.newBuilder
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.EncryptRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.EncryptRequest.Builder
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.DecryptRequest.newBuilder
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.DecryptRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.DecryptRequest.Builder
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.AsymmetricSignRequest.newBuilder
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.MacSignRequest.newBuilder
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.MacSignRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.MacSignRequest.Builder
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.CreateCryptoKeyRequest.newBuilder
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.CreateCryptoKeyRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.CreateCryptoKeyRequest.Builder
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.GenerateRandomBytesRequest.newBuilder
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.GenerateRandomBytesRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.GenerateRandomBytesRequest.Builder
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.EncryptRequest.Builder.setName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.google.cloud.kms.v1.EncryptRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.EncryptRequest.Builder
+      confidence: high
+    role: config
+  - method: com.google.cloud.kms.v1.EncryptRequest.Builder.setPlaintext
+    arity: 1
+    parameter_types: [com.google.protobuf.ByteString]
+    canonical_return_type: com.google.cloud.kms.v1.EncryptRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.EncryptRequest.Builder
+      confidence: high
+    role: config
+  - method: com.google.cloud.kms.v1.EncryptRequest.Builder.setAdditionalAuthenticatedData
+    arity: 1
+    parameter_types: [com.google.protobuf.ByteString]
+    canonical_return_type: com.google.cloud.kms.v1.EncryptRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.EncryptRequest.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: additionalAuthenticatedData
+        role: metadata-contributing
+        contributes: { property: associatedData, derivation: argument_value }
+  - method: com.google.cloud.kms.v1.EncryptRequest.Builder.build
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.EncryptRequest
+    return:
+      type: com.google.cloud.kms.v1.EncryptRequest
+      confidence: high
+    role: factory
+  - method: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder.setName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+      confidence: high
+    role: config
+  # setDigest#1 is overloaded (Digest / Digest.Builder).
+  - method: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder.setDigest
+    arity: 1
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+      confidence: high
+    role: config
+  - method: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder.setData
+    arity: 1
+    parameter_types: [com.google.protobuf.ByteString]
+    canonical_return_type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder
+      confidence: high
+    role: config
+  - method: com.google.cloud.kms.v1.AsymmetricSignRequest.Builder.build
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.AsymmetricSignRequest
+    return:
+      type: com.google.cloud.kms.v1.AsymmetricSignRequest
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Response and resource material
+  # =========================================================================
+  - method: com.google.cloud.kms.v1.EncryptResponse.getCiphertext
+    arity: 0
+    canonical_return_type: com.google.protobuf.ByteString
+    return:
+      type: com.google.protobuf.ByteString
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.DecryptResponse.getPlaintext
+    arity: 0
+    canonical_return_type: com.google.protobuf.ByteString
+    return:
+      type: com.google.protobuf.ByteString
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.AsymmetricSignResponse.getSignature
+    arity: 0
+    canonical_return_type: com.google.protobuf.ByteString
+    return:
+      type: com.google.protobuf.ByteString
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.AsymmetricDecryptResponse.getPlaintext
+    arity: 0
+    canonical_return_type: com.google.protobuf.ByteString
+    return:
+      type: com.google.protobuf.ByteString
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.MacSignResponse.getMac
+    arity: 0
+    canonical_return_type: com.google.protobuf.ByteString
+    return:
+      type: com.google.protobuf.ByteString
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.MacVerifyResponse.getSuccess
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.GenerateRandomBytesResponse.getData
+    arity: 0
+    canonical_return_type: com.google.protobuf.ByteString
+    return:
+      type: com.google.protobuf.ByteString
+      confidence: high
+    role: output
+  # The algorithm lives on CryptoKeyVersion and PublicKey, not on CryptoKey
+  # (which only carries the purpose and a version template).
+  - method: com.google.cloud.kms.v1.CryptoKeyVersion.getAlgorithm
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm
+    return:
+      type: com.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.CryptoKey.getPurpose
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
+    return:
+      type: com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.PublicKey.getPem
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.google.cloud.kms.v1.PublicKey.getAlgorithm
+    arity: 0
+    canonical_return_type: com.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm
+    return:
+      type: com.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm
+      confidence: high
+    role: output
+
+hierarchy:
+  com.google.cloud.kms.v1.KeyManagementServiceClient:
+    - java.lang.Object
+  com.google.cloud.kms.v1.EncryptRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.EncryptRequest.Builder:
+    - java.lang.Object
+  com.google.cloud.kms.v1.DecryptRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.DecryptRequest.Builder:
+    - java.lang.Object
+  com.google.cloud.kms.v1.RawEncryptRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.RawDecryptRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.AsymmetricSignRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.AsymmetricSignRequest.Builder:
+    - java.lang.Object
+  com.google.cloud.kms.v1.AsymmetricDecryptRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.MacSignRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.MacSignRequest.Builder:
+    - java.lang.Object
+  com.google.cloud.kms.v1.MacVerifyRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.GenerateRandomBytesRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.GenerateRandomBytesRequest.Builder:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CreateCryptoKeyRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CreateCryptoKeyRequest.Builder:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CreateCryptoKeyVersionRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CreateKeyRingRequest:
+    - java.lang.Object
+  com.google.cloud.kms.v1.EncryptResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.DecryptResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.RawEncryptResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.RawDecryptResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.AsymmetricSignResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.AsymmetricDecryptResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.MacSignResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.MacVerifyResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.GenerateRandomBytesResponse:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CryptoKey:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose:
+    - java.lang.Enum
+  com.google.cloud.kms.v1.CryptoKeyVersion:
+    - java.lang.Object
+  com.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm:
+    - java.lang.Enum
+  com.google.cloud.kms.v1.KeyRing:
+    - java.lang.Object
+  com.google.cloud.kms.v1.PublicKey:
+    - java.lang.Object
+  com.google.cloud.kms.v1.ProtectionLevel:
+    - java.lang.Enum
+  com.google.protobuf.ByteString:
+    - java.lang.Object
+  java.lang.Enum:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/jasypt.yaml
+++ b/internal/callgraph/contracts/java/jasypt.yaml
@@ -1,0 +1,836 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: jasypt
+  coordinates:
+    - "org.jasypt:jasypt"
+  # Verified against upstream source on the 1.9.4-SNAPSHOT tree (jasypt/jasypt);
+  # the API surface contracted here is unchanged since 1.9.x releases.
+  version_range: ">=1.9,<2.0"
+  description: "Jasypt contracts for the password-encryptor, text/binary encryptor, digester, and StandardPBE engine lifecycles"
+
+contracts:
+  # =========================================================================
+  # Password encryptors (org.jasypt.util.password)
+  # Contracted on the PasswordEncryptor interface plus each concrete facade's
+  # constructor: the constructor is what pins the algorithm (Basic = MD5,
+  # Strong = SHA-256/100k iterations), and the concrete classes are final.
+  # =========================================================================
+  - method: org.jasypt.util.password.BasicPasswordEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.password.BasicPasswordEncryptor
+    return:
+      type: org.jasypt.util.password.BasicPasswordEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.password.StrongPasswordEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.password.StrongPasswordEncryptor
+    return:
+      type: org.jasypt.util.password.StrongPasswordEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.password.ConfigurablePasswordEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.password.ConfigurablePasswordEncryptor
+    return:
+      type: org.jasypt.util.password.ConfigurablePasswordEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.password.PasswordEncryptor.encryptPassword
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.jasypt.util.password.PasswordEncryptor.checkPassword
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  # ConfigurablePasswordEncryptor's setters select the digest algorithm; jasypt
+  # setters are void throughout (no fluent API anywhere in the library).
+  - method: org.jasypt.util.password.ConfigurablePasswordEncryptor.setAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.util.password.ConfigurablePasswordEncryptor.setConfig
+    arity: 1
+    parameter_types: [org.jasypt.digest.config.DigesterConfig]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.password.ConfigurablePasswordEncryptor.setPlainDigest
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.password.ConfigurablePasswordEncryptor.setProvider
+    arity: 1
+    parameter_types: [java.security.Provider]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.password.ConfigurablePasswordEncryptor.setProviderName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+
+  # =========================================================================
+  # Text encryptors (org.jasypt.util.text) — encrypt/decrypt are String→String
+  # =========================================================================
+  - method: org.jasypt.util.text.BasicTextEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.text.BasicTextEncryptor
+    return:
+      type: org.jasypt.util.text.BasicTextEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.text.StrongTextEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.text.StrongTextEncryptor
+    return:
+      type: org.jasypt.util.text.StrongTextEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.text.AES256TextEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.text.AES256TextEncryptor
+    return:
+      type: org.jasypt.util.text.AES256TextEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.text.TextEncryptor.encrypt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.jasypt.util.text.TextEncryptor.decrypt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  # setPassword/setPasswordCharArray are declared on the concrete text
+  # encryptors, not on the TextEncryptor interface.
+  - method: org.jasypt.util.text.BasicTextEncryptor.setPassword
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.text.BasicTextEncryptor.setPasswordCharArray
+    arity: 1
+    parameter_types: ["char[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.text.StrongTextEncryptor.setPassword
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.text.StrongTextEncryptor.setPasswordCharArray
+    arity: 1
+    parameter_types: ["char[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.text.AES256TextEncryptor.setPassword
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.util.text.AES256TextEncryptor.setPasswordCharArray
+    arity: 1
+    parameter_types: ["char[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+
+  # =========================================================================
+  # Binary encryptors (org.jasypt.util.binary) — encrypt/decrypt are byte[]→byte[]
+  # so they are contracted on their own interface, distinct from the text ones.
+  # =========================================================================
+  - method: org.jasypt.util.binary.BasicBinaryEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.binary.BasicBinaryEncryptor
+    return:
+      type: org.jasypt.util.binary.BasicBinaryEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.binary.StrongBinaryEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.binary.StrongBinaryEncryptor
+    return:
+      type: org.jasypt.util.binary.StrongBinaryEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.binary.AES256BinaryEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.binary.AES256BinaryEncryptor
+    return:
+      type: org.jasypt.util.binary.AES256BinaryEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.binary.BinaryEncryptor.encrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.jasypt.util.binary.BinaryEncryptor.decrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Digester facade (org.jasypt.util.digest.Digester)
+  # =========================================================================
+  - method: org.jasypt.util.digest.Digester.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.util.digest.Digester
+    return:
+      type: org.jasypt.util.digest.Digester
+      confidence: high
+    role: factory
+  - method: org.jasypt.util.digest.Digester.<init>
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: org.jasypt.util.digest.Digester
+    return:
+      type: org.jasypt.util.digest.Digester
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  # Digester#2 is overloaded ((String,String) / (String,Provider)) — canonical
+  # signature omitted.
+  - method: org.jasypt.util.digest.Digester.<init>
+    arity: 2
+    return:
+      type: org.jasypt.util.digest.Digester
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.util.digest.Digester.setAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.util.digest.Digester.digest
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # StandardPBE engines (org.jasypt.encryption.pbe)
+  # The String and Byte engines share an identical arity-1 void setter surface
+  # but differ in the encrypt/decrypt return type, so each is contracted on its
+  # own class.
+  # =========================================================================
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.encryption.pbe.StandardPBEStringEncryptor
+    return:
+      type: org.jasypt.encryption.pbe.StandardPBEStringEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setPassword
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setPasswordCharArray
+    arity: 1
+    parameter_types: ["char[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setKeyObtentionIterations
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: keyObtentionIterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setSaltGenerator
+    arity: 1
+    parameter_types: [org.jasypt.salt.SaltGenerator]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setIvGenerator
+    arity: 1
+    parameter_types: [org.jasypt.iv.IvGenerator]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setConfig
+    arity: 1
+    parameter_types: [org.jasypt.encryption.pbe.config.PBEConfig]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setProvider
+    arity: 1
+    parameter_types: [java.security.Provider]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setProviderName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setStringOutputType
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.initialize
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.encrypt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.jasypt.encryption.pbe.StandardPBEStringEncryptor.decrypt
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.encryption.pbe.StandardPBEByteEncryptor
+    return:
+      type: org.jasypt.encryption.pbe.StandardPBEByteEncryptor
+      confidence: high
+    role: factory
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setPassword
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setPasswordCharArray
+    arity: 1
+    parameter_types: ["char[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setKeyObtentionIterations
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: keyObtentionIterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setSaltGenerator
+    arity: 1
+    parameter_types: [org.jasypt.salt.SaltGenerator]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setIvGenerator
+    arity: 1
+    parameter_types: [org.jasypt.iv.IvGenerator]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setConfig
+    arity: 1
+    parameter_types: [org.jasypt.encryption.pbe.config.PBEConfig]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.initialize
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.encrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.decrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Standard digesters (org.jasypt.digest)
+  # digest/matches differ in type between the String and Byte digester, so each
+  # is contracted on its own class.
+  # =========================================================================
+  - method: org.jasypt.digest.StandardStringDigester.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.digest.StandardStringDigester
+    return:
+      type: org.jasypt.digest.StandardStringDigester
+      confidence: high
+    role: factory
+  - method: org.jasypt.digest.StandardStringDigester.setAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.digest.StandardStringDigester.setIterations
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: iterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+  - method: org.jasypt.digest.StandardStringDigester.setSaltSizeBytes
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: saltSizeBytes
+        role: metadata-contributing
+        contributes: { property: saltLength, derivation: argument_value }
+  - method: org.jasypt.digest.StandardStringDigester.setSaltGenerator
+    arity: 1
+    parameter_types: [org.jasypt.salt.SaltGenerator]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.setConfig
+    arity: 1
+    parameter_types: [org.jasypt.digest.config.DigesterConfig]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.initialize
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.digest
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.jasypt.digest.StandardStringDigester.matches
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: org.jasypt.digest.StandardByteDigester.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.digest.StandardByteDigester
+    return:
+      type: org.jasypt.digest.StandardByteDigester
+      confidence: high
+    role: factory
+  - method: org.jasypt.digest.StandardByteDigester.setAlgorithm
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: algorithm
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: org.jasypt.digest.StandardByteDigester.setIterations
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: iterations
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+  - method: org.jasypt.digest.StandardByteDigester.setSaltSizeBytes
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: saltSizeBytes
+        role: metadata-contributing
+        contributes: { property: saltLength, derivation: argument_value }
+  - method: org.jasypt.digest.StandardByteDigester.setSaltGenerator
+    arity: 1
+    parameter_types: [org.jasypt.salt.SaltGenerator]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardByteDigester.initialize
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardByteDigester.digest
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.jasypt.digest.StandardByteDigester.matches
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Salt and IV generators (param objects of setSaltGenerator/setIvGenerator)
+  # =========================================================================
+  - method: org.jasypt.salt.RandomSaltGenerator.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.salt.RandomSaltGenerator
+    return:
+      type: org.jasypt.salt.RandomSaltGenerator
+      confidence: high
+    role: factory
+  - method: org.jasypt.salt.RandomSaltGenerator.<init>
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: org.jasypt.salt.RandomSaltGenerator
+    return:
+      type: org.jasypt.salt.RandomSaltGenerator
+      confidence: high
+    role: factory
+  - method: org.jasypt.salt.SaltGenerator.generateSalt
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: lengthBytes
+        role: metadata-contributing
+        contributes: { property: saltLength, derivation: argument_value }
+  - method: org.jasypt.iv.RandomIvGenerator.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.iv.RandomIvGenerator
+    return:
+      type: org.jasypt.iv.RandomIvGenerator
+      confidence: high
+    role: factory
+  - method: org.jasypt.iv.RandomIvGenerator.<init>
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: org.jasypt.iv.RandomIvGenerator
+    return:
+      type: org.jasypt.iv.RandomIvGenerator
+      confidence: high
+    role: factory
+  - method: org.jasypt.iv.NoIvGenerator.<init>
+    arity: 0
+    canonical_return_type: org.jasypt.iv.NoIvGenerator
+    return:
+      type: org.jasypt.iv.NoIvGenerator
+      confidence: high
+    role: factory
+  - method: org.jasypt.iv.IvGenerator.generateIv
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: lengthBytes
+        role: metadata-contributing
+        contributes: { property: ivLength, derivation: argument_value }
+
+hierarchy:
+  # Password encryptors
+  org.jasypt.util.password.PasswordEncryptor:
+    - java.lang.Object
+  org.jasypt.util.password.BasicPasswordEncryptor:
+    - org.jasypt.util.password.PasswordEncryptor
+  org.jasypt.util.password.StrongPasswordEncryptor:
+    - org.jasypt.util.password.PasswordEncryptor
+  org.jasypt.util.password.ConfigurablePasswordEncryptor:
+    - org.jasypt.util.password.PasswordEncryptor
+  # Text encryptors
+  org.jasypt.util.text.TextEncryptor:
+    - java.lang.Object
+  org.jasypt.util.text.BasicTextEncryptor:
+    - org.jasypt.util.text.TextEncryptor
+  org.jasypt.util.text.StrongTextEncryptor:
+    - org.jasypt.util.text.TextEncryptor
+  org.jasypt.util.text.AES256TextEncryptor:
+    - org.jasypt.util.text.TextEncryptor
+  # Binary encryptors
+  org.jasypt.util.binary.BinaryEncryptor:
+    - java.lang.Object
+  org.jasypt.util.binary.BasicBinaryEncryptor:
+    - org.jasypt.util.binary.BinaryEncryptor
+  org.jasypt.util.binary.StrongBinaryEncryptor:
+    - org.jasypt.util.binary.BinaryEncryptor
+  org.jasypt.util.binary.AES256BinaryEncryptor:
+    - org.jasypt.util.binary.BinaryEncryptor
+  # Digesters
+  org.jasypt.util.digest.Digester:
+    - java.lang.Object
+  org.jasypt.digest.StringDigester:
+    - java.lang.Object
+  org.jasypt.digest.ByteDigester:
+    - java.lang.Object
+  org.jasypt.digest.StandardStringDigester:
+    - org.jasypt.digest.StringDigester
+  org.jasypt.digest.StandardByteDigester:
+    - org.jasypt.digest.ByteDigester
+  # PBE engines
+  org.jasypt.encryption.StringEncryptor:
+    - java.lang.Object
+  org.jasypt.encryption.ByteEncryptor:
+    - java.lang.Object
+  org.jasypt.encryption.pbe.PasswordBased:
+    - java.lang.Object
+  org.jasypt.encryption.pbe.CleanablePasswordBased:
+    - org.jasypt.encryption.pbe.PasswordBased
+  org.jasypt.encryption.pbe.PBEStringEncryptor:
+    - org.jasypt.encryption.StringEncryptor
+    - org.jasypt.encryption.pbe.PasswordBased
+  org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor:
+    - org.jasypt.encryption.pbe.PBEStringEncryptor
+    - org.jasypt.encryption.pbe.CleanablePasswordBased
+  org.jasypt.encryption.pbe.StandardPBEStringEncryptor:
+    - org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor
+  org.jasypt.encryption.pbe.PBEByteEncryptor:
+    - org.jasypt.encryption.ByteEncryptor
+    - org.jasypt.encryption.pbe.PasswordBased
+  org.jasypt.encryption.pbe.PBEByteCleanablePasswordEncryptor:
+    - org.jasypt.encryption.pbe.PBEByteEncryptor
+    - org.jasypt.encryption.pbe.CleanablePasswordBased
+  org.jasypt.encryption.pbe.StandardPBEByteEncryptor:
+    - org.jasypt.encryption.pbe.PBEByteCleanablePasswordEncryptor
+  # Salt / IV generators
+  org.jasypt.salt.SaltGenerator:
+    - java.lang.Object
+  org.jasypt.salt.RandomSaltGenerator:
+    - org.jasypt.salt.SaltGenerator
+  org.jasypt.iv.IvGenerator:
+    - java.lang.Object
+  org.jasypt.iv.RandomIvGenerator:
+    - org.jasypt.iv.IvGenerator
+  org.jasypt.iv.NoIvGenerator:
+    - org.jasypt.iv.IvGenerator
+  # Config param types
+  org.jasypt.digest.config.DigesterConfig:
+    - java.lang.Object
+  org.jasypt.encryption.pbe.config.PBEConfig:
+    - java.lang.Object
+  java.security.Provider:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/jasypt.yaml
+++ b/internal/callgraph/contracts/java/jasypt.yaml
@@ -492,6 +492,22 @@ contracts:
       type: void
       confidence: high
     role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setProvider
+    arity: 1
+    parameter_types: [java.security.Provider]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setProviderName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
   - method: org.jasypt.encryption.pbe.StandardPBEByteEncryptor.initialize
     arity: 0
     canonical_return_type: void
@@ -585,6 +601,49 @@ contracts:
     role: config
   - method: org.jasypt.digest.StandardStringDigester.initialize
     arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  # String-digester-only configuration: output encoding, fixed affixes, and the
+  # salt/normalization compatibility switches. The Byte digester has none of
+  # these.
+  - method: org.jasypt.digest.StandardStringDigester.setStringOutputType
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.setPrefix
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.setSuffix
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.setUseLenientSaltSizeCheck
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: org.jasypt.digest.StandardStringDigester.setUnicodeNormalizationIgnored
+    arity: 1
+    parameter_types: [boolean]
     canonical_return_type: void
     return:
       type: void

--- a/internal/callgraph/contracts/java/jbcrypt.yaml
+++ b/internal/callgraph/contracts/java/jbcrypt.yaml
@@ -1,0 +1,91 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: jbcrypt
+  coordinates:
+    - "org.mindrot:jbcrypt"
+  # Verified against the published org.mindrot:jbcrypt:0.4 artifact (javap over
+  # the Maven Central jar): the shipped class is org/mindrot/jbcrypt/BCrypt.
+  # The jeremyh/jBCrypt GitHub tree is a repackaged redistribution declaring
+  # `package org.mindrot`, so its source FQN differs from the artifact's; the
+  # artifact (and the detection rules) use org.mindrot.jbcrypt.
+  version_range: ">=0.3,<1.0"
+  description: "jBCrypt password hashing contracts for bcrypt hash, verify, and salt generation"
+
+contracts:
+  - method: org.mindrot.jbcrypt.BCrypt.<init>
+    arity: 0
+    canonical_return_type: org.mindrot.jbcrypt.BCrypt
+    return:
+      type: org.mindrot.jbcrypt.BCrypt
+      confidence: high
+    role: factory
+  - method: org.mindrot.jbcrypt.BCrypt.hashpw
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.mindrot.jbcrypt.BCrypt.checkpw
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  # gensalt produces the salt (and encodes the cost factor) consumed by hashpw.
+  - method: org.mindrot.jbcrypt.BCrypt.gensalt
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: factory
+  - method: org.mindrot.jbcrypt.BCrypt.gensalt
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: log_rounds
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  - method: org.mindrot.jbcrypt.BCrypt.gensalt
+    arity: 2
+    parameter_types: [int, java.security.SecureRandom]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: log_rounds
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+  # Raw EksBlowfish core, public on the instance API.
+  - method: org.mindrot.jbcrypt.BCrypt.crypt_raw
+    arity: 4
+    parameter_types: ["byte[]", "byte[]", int, "int[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+hierarchy:
+  org.mindrot.jbcrypt.BCrypt:
+    - java.lang.Object
+  java.security.SecureRandom:
+    - java.util.Random
+  java.util.Random:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/jsch.yaml
+++ b/internal/callgraph/contracts/java/jsch.yaml
@@ -1,0 +1,723 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: jsch
+  coordinates:
+    - "com.jcraft:jsch"
+    - "com.github.mwiede:jsch"
+  # Verified against the maintained com.github.mwiede:jsch fork (2.28.x tree),
+  # which keeps the original com.jcraft.jsch package, so one contract set covers
+  # both coordinates.
+  version_range: ">=0.1.55"
+  description: "JSch contracts for SSH session setup, algorithm configuration, host-key handling, and key-pair generation and loading"
+
+contracts:
+  # =========================================================================
+  # com.jcraft.jsch.JSch — the entry point (rule anchor: JSch.<init>)
+  # =========================================================================
+  - method: com.jcraft.jsch.JSch.<init>
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.JSch
+    return:
+      type: com.jcraft.jsch.JSch
+      confidence: high
+    role: factory
+  # Session has no public constructor: getSession is the only producer, so it is
+  # the mandatory factory edge for every Session-receiver supporting call.
+  - method: com.jcraft.jsch.JSch.getSession
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.jcraft.jsch.Session
+    return:
+      type: com.jcraft.jsch.Session
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.JSch.getSession
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: com.jcraft.jsch.Session
+    return:
+      type: com.jcraft.jsch.Session
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.JSch.getSession
+    arity: 3
+    parameter_types: [java.lang.String, java.lang.String, int]
+    canonical_return_type: com.jcraft.jsch.Session
+    return:
+      type: com.jcraft.jsch.Session
+      confidence: high
+    role: factory
+  # addIdentity#1 takes a private-key path; #2 is overloaded
+  # ((String,String) / (String,byte[]) / (Identity,byte[])).
+  - method: com.jcraft.jsch.JSch.addIdentity
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.addIdentity
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.addIdentity
+    arity: 3
+    parameter_types: [java.lang.String, java.lang.String, "byte[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.addIdentity
+    arity: 4
+    parameter_types: [java.lang.String, "byte[]", "byte[]", "byte[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.removeIdentity
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.removeAllIdentity
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  # setKnownHosts#1 is overloaded (String filename / InputStream).
+  - method: com.jcraft.jsch.JSch.setKnownHosts
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.getHostKeyRepository
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.HostKeyRepository
+    return:
+      type: com.jcraft.jsch.HostKeyRepository
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.JSch.setHostKeyRepository
+    arity: 1
+    parameter_types: [com.jcraft.jsch.HostKeyRepository]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.setIdentityRepository
+    arity: 1
+    parameter_types: [com.jcraft.jsch.IdentityRepository]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.getIdentityRepository
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.IdentityRepository
+    return:
+      type: com.jcraft.jsch.IdentityRepository
+      confidence: high
+    role: output
+  # The static JSch.setConfig pair selects algorithms process-wide; the
+  # two-argument form carries the algorithm list in the value.
+  - method: com.jcraft.jsch.JSch.setConfig
+    arity: 1
+    parameter_types: [java.util.Hashtable]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.JSch.setConfig
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: key
+        role: operation-determining
+        contributes: { property: cryptoConfig, derivation: argument_value }
+      - index: 1
+        name: value
+        role: metadata-contributing
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.jcraft.jsch.JSch.getConfig
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # com.jcraft.jsch.Session — connection, algorithm config, negotiated results
+  # (rule anchor: Session.setConfig)
+  # =========================================================================
+  - method: com.jcraft.jsch.Session.connect
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: com.jcraft.jsch.Session.connect
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  # setConfig#1 is overloaded (Properties / Hashtable) — canonical omitted.
+  - method: com.jcraft.jsch.Session.setConfig
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Session.setConfig
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: key
+        role: operation-determining
+        contributes: { property: cryptoConfig, derivation: argument_value }
+      - index: 1
+        name: value
+        role: metadata-contributing
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.jcraft.jsch.Session.getConfig
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  # setPassword#1 is overloaded (String / byte[]).
+  - method: com.jcraft.jsch.Session.setPassword
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Session.setUserInfo
+    arity: 1
+    parameter_types: [com.jcraft.jsch.UserInfo]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Session.setHostKeyAlias
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Session.getHostKey
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.HostKey
+    return:
+      type: com.jcraft.jsch.HostKey
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.setHostKeyRepository
+    arity: 1
+    parameter_types: [com.jcraft.jsch.HostKeyRepository]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Session.getHostKeyRepository
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.HostKeyRepository
+    return:
+      type: com.jcraft.jsch.HostKeyRepository
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.setIdentityRepository
+    arity: 1
+    parameter_types: [com.jcraft.jsch.IdentityRepository]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Session.rekey
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: com.jcraft.jsch.Session.disconnect
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  # Negotiated-algorithm getters — the observable result of the KEX.
+  - method: com.jcraft.jsch.Session.getKexAlgorithm
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.getServerHostKeyAlgorithm
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.getCipherAlgorithmC2S
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.getCipherAlgorithmS2C
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.getMacAlgorithmC2S
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Session.getMacAlgorithmS2C
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # com.jcraft.jsch.KeyPair — generation, loading, export
+  # (rule anchors: KeyPair.genKeyPair, KeyPair.load)
+  # KeyPair has no public constructor and every subclass (KeyPairRSA/DSA/ECDSA/
+  # Ed25519/Ed448/PKCS8) is package-private, so external code can only ever
+  # hold the abstract com.jcraft.jsch.KeyPair type. The algorithm comes from
+  # the int type argument (DSA=1, RSA=2, ECDSA=3, ED25519=5, ED448=6), not from
+  # a return type.
+  # =========================================================================
+  - method: com.jcraft.jsch.KeyPair.genKeyPair
+    arity: 2
+    parameter_types: [com.jcraft.jsch.JSch, int]
+    canonical_return_type: com.jcraft.jsch.KeyPair
+    return:
+      type: com.jcraft.jsch.KeyPair
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+  - method: com.jcraft.jsch.KeyPair.genKeyPair
+    arity: 3
+    parameter_types: [com.jcraft.jsch.JSch, int, int]
+    canonical_return_type: com.jcraft.jsch.KeyPair
+    return:
+      type: com.jcraft.jsch.KeyPair
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+      - index: 2
+        name: key_size
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_value }
+  - method: com.jcraft.jsch.KeyPair.load
+    arity: 2
+    parameter_types: [com.jcraft.jsch.JSch, java.lang.String]
+    canonical_return_type: com.jcraft.jsch.KeyPair
+    return:
+      type: com.jcraft.jsch.KeyPair
+      confidence: high
+    role: factory
+  # load#3 is overloaded ((JSch,String,String) / (JSch,byte[],byte[])).
+  - method: com.jcraft.jsch.KeyPair.load
+    arity: 3
+    return:
+      type: com.jcraft.jsch.KeyPair
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.KeyPair.getPublicKeyBlob
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.getFingerPrint
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.getKeySize
+    arity: 0
+    canonical_return_type: int
+    return:
+      type: int
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.getKeyType
+    arity: 0
+    canonical_return_type: int
+    return:
+      type: int
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.getKeyTypeString
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.getSignature
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: com.jcraft.jsch.KeyPair.getSignature
+    arity: 2
+    parameter_types: ["byte[]", java.lang.String]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: alg
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.jcraft.jsch.KeyPair.getVerifier
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.Signature
+    return:
+      type: com.jcraft.jsch.Signature
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.KeyPair.getVerifier
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.jcraft.jsch.Signature
+    return:
+      type: com.jcraft.jsch.Signature
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: alg
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  # setPassphrase#1 and decrypt#1 are each overloaded (String / byte[]).
+  - method: com.jcraft.jsch.KeyPair.setPassphrase
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.KeyPair.isEncrypted
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.decrypt
+    arity: 1
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  # writePrivateKey/writePublicKey/writeOpenSSHv1PrivateKey are all overloaded
+  # per arity on (OutputStream / String name) — canonical signatures omitted.
+  - method: com.jcraft.jsch.KeyPair.writePrivateKey
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writePrivateKey
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writePublicKey
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writeSECSHPublicKey
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writeOpenSSHv1PrivateKey
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writeOpenSSHv1PrivateKey
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writeOpenSSHv1PrivateKey
+    arity: 3
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.writeOpenSSHv1PrivateKey
+    arity: 4
+    return:
+      type: void
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.KeyPair.dispose
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Host keys (com.jcraft.jsch.HostKey / HostKeyRepository)
+  # =========================================================================
+  - method: com.jcraft.jsch.HostKey.<init>
+    arity: 2
+    parameter_types: [java.lang.String, "byte[]"]
+    canonical_return_type: com.jcraft.jsch.HostKey
+    return:
+      type: com.jcraft.jsch.HostKey
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.HostKey.<init>
+    arity: 3
+    parameter_types: [java.lang.String, int, "byte[]"]
+    canonical_return_type: com.jcraft.jsch.HostKey
+    return:
+      type: com.jcraft.jsch.HostKey
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: type
+        role: operation-determining
+        contributes: { property: keyType, derivation: argument_value }
+  - method: com.jcraft.jsch.HostKey.<init>
+    arity: 4
+    parameter_types: [java.lang.String, int, "byte[]", java.lang.String]
+    canonical_return_type: com.jcraft.jsch.HostKey
+    return:
+      type: com.jcraft.jsch.HostKey
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.HostKey.<init>
+    arity: 5
+    parameter_types:
+      [java.lang.String, java.lang.String, int, "byte[]", java.lang.String]
+    canonical_return_type: com.jcraft.jsch.HostKey
+    return:
+      type: com.jcraft.jsch.HostKey
+      confidence: high
+    role: factory
+  - method: com.jcraft.jsch.HostKey.getType
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.HostKey.getKey
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  # getFingerPrint takes the JSch instance; there is no arity-0 form.
+  - method: com.jcraft.jsch.HostKey.getFingerPrint
+    arity: 1
+    parameter_types: [com.jcraft.jsch.JSch]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.HostKeyRepository.check
+    arity: 2
+    parameter_types: [java.lang.String, "byte[]"]
+    canonical_return_type: int
+    return:
+      type: int
+      confidence: high
+    role: operation
+  - method: com.jcraft.jsch.HostKeyRepository.add
+    arity: 2
+    parameter_types: [com.jcraft.jsch.HostKey, com.jcraft.jsch.UserInfo]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.HostKeyRepository.getHostKey
+    arity: 0
+    canonical_return_type: com.jcraft.jsch.HostKey[]
+    return:
+      type: com.jcraft.jsch.HostKey[]
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.HostKeyRepository.getHostKey
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: com.jcraft.jsch.HostKey[]
+    return:
+      type: com.jcraft.jsch.HostKey[]
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # Identities (com.jcraft.jsch.Identity / IdentityRepository)
+  # =========================================================================
+  - method: com.jcraft.jsch.Identity.getSignature
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: com.jcraft.jsch.Identity.getSignature
+    arity: 2
+    parameter_types: ["byte[]", java.lang.String]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: alg
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.jcraft.jsch.Identity.getPublicKeyBlob
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.Identity.setPassphrase
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+  - method: com.jcraft.jsch.Identity.getAlgName
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.IdentityRepository.getIdentities
+    arity: 0
+    canonical_return_type: java.util.Vector
+    return:
+      type: java.util.Vector
+      confidence: high
+    role: output
+  - method: com.jcraft.jsch.IdentityRepository.add
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+
+hierarchy:
+  com.jcraft.jsch.JSch:
+    - java.lang.Object
+  com.jcraft.jsch.Session:
+    - java.lang.Object
+  com.jcraft.jsch.KeyPair:
+    - java.lang.Object
+  com.jcraft.jsch.HostKey:
+    - java.lang.Object
+  com.jcraft.jsch.HostKey[]:
+    - java.lang.Object
+  com.jcraft.jsch.HostKeyRepository:
+    - java.lang.Object
+  com.jcraft.jsch.Identity:
+    - java.lang.Object
+  com.jcraft.jsch.IdentityRepository:
+    - java.lang.Object
+  com.jcraft.jsch.Signature:
+    - java.lang.Object
+  com.jcraft.jsch.UserInfo:
+    - java.lang.Object
+  java.util.Hashtable:
+    - java.lang.Object
+  java.util.Vector:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/kalium.yaml
+++ b/internal/callgraph/contracts/java/kalium.yaml
@@ -1,0 +1,668 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: kalium
+  coordinates:
+    - "org.abstractj.kalium:kalium"
+  # Verified against upstream source on the 0.8.1-SNAPSHOT tree (abstractj/kalium);
+  # the last published release is 0.8.0 and this surface is unchanged since.
+  version_range: ">=0.7,<1.0"
+  description: "Kalium contracts for the libsodium box, secretbox, sealed-box, AEAD, hash, password, and signing-key lifecycles"
+
+contracts:
+  # =========================================================================
+  # Box — Curve25519-XSalsa20-Poly1305 (org.abstractj.kalium.crypto.Box)
+  # The nonce is the FIRST argument of encrypt/decrypt in kalium.
+  # =========================================================================
+  # Box#2 is overloaded ((byte[],byte[]) / (PublicKey,PrivateKey)) — canonical
+  # signature omitted.
+  - method: org.abstractj.kalium.crypto.Box.<init>
+    arity: 2
+    return:
+      type: org.abstractj.kalium.crypto.Box
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.Box.<init>
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.crypto.Box
+    return:
+      type: org.abstractj.kalium.crypto.Box
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.Box.encrypt
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Box.encrypt
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Box.decrypt
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Box.decrypt
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # SecretBox — XSalsa20-Poly1305 (org.abstractj.kalium.crypto.SecretBox)
+  # =========================================================================
+  - method: org.abstractj.kalium.crypto.SecretBox.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.crypto.SecretBox
+    return:
+      type: org.abstractj.kalium.crypto.SecretBox
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: org.abstractj.kalium.crypto.SecretBox.<init>
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.crypto.SecretBox
+    return:
+      type: org.abstractj.kalium.crypto.SecretBox
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.SecretBox.encrypt
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.SecretBox.decrypt
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # SealedBox — crypto_box_seal, anonymous sender
+  # =========================================================================
+  - method: org.abstractj.kalium.crypto.SealedBox.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.crypto.SealedBox
+    return:
+      type: org.abstractj.kalium.crypto.SealedBox
+      confidence: high
+    role: factory
+  # SealedBox#2 is overloaded ((String,Encoder) / (byte[],byte[])).
+  - method: org.abstractj.kalium.crypto.SealedBox.<init>
+    arity: 2
+    return:
+      type: org.abstractj.kalium.crypto.SealedBox
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.SealedBox.<init>
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.crypto.SealedBox
+    return:
+      type: org.abstractj.kalium.crypto.SealedBox
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.SealedBox.encrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.SealedBox.decrypt
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Aead — ChaCha20-Poly1305 by default, AES-256-GCM after useAesGcm()
+  # useAesGcm is the fluent link that switches the algorithm for every later
+  # encrypt/decrypt on the same receiver, so algorithm attribution needs the
+  # chain, not the encrypt call alone.
+  # =========================================================================
+  - method: org.abstractj.kalium.crypto.Aead.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.crypto.Aead
+    return:
+      type: org.abstractj.kalium.crypto.Aead
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: org.abstractj.kalium.crypto.Aead.<init>
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.crypto.Aead
+    return:
+      type: org.abstractj.kalium.crypto.Aead
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.Aead.useAesGcm
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.crypto.Aead
+    return:
+      type: org.abstractj.kalium.crypto.Aead
+      confidence: high
+    role: config
+  - method: org.abstractj.kalium.crypto.Aead.encrypt
+    arity: 3
+    parameter_types: ["byte[]", "byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Aead.decrypt
+    arity: 3
+    parameter_types: ["byte[]", "byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Hash — SHA-256 / SHA-512 / BLAKE2b
+  # Each digest name has a byte[]-returning arity-1 form and a String-returning
+  # arity-2 (encoder) form.
+  # =========================================================================
+  - method: org.abstractj.kalium.crypto.Hash.<init>
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.crypto.Hash
+    return:
+      type: org.abstractj.kalium.crypto.Hash
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.Hash.sha256
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Hash.sha256
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Hash.sha512
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Hash.sha512
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Hash.blake2
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Hash.blake2
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Hash.blake2
+    arity: 4
+    parameter_types: ["byte[]", "byte[]", "byte[]", "byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+
+  # =========================================================================
+  # Password — scrypt (salsa208sha256)
+  # hash#4 is the modular-crypt-string form; hash#5/#6 derive a raw key.
+  # =========================================================================
+  - method: org.abstractj.kalium.crypto.Password.<init>
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.crypto.Password
+    return:
+      type: org.abstractj.kalium.crypto.Password
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.Password.deriveKey
+    arity: 5
+    parameter_types: [int, "byte[]", "byte[]", int, long]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: length
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+      - index: 3
+        name: opslimit
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 4
+        name: memlimit
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+  - method: org.abstractj.kalium.crypto.Password.hash
+    arity: 4
+    parameter_types: ["byte[]", org.abstractj.kalium.encoders.Encoder, int, long]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 2
+        name: opslimit
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 3
+        name: memlimit
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+  - method: org.abstractj.kalium.crypto.Password.hash
+    arity: 5
+    parameter_types:
+      ["byte[]", org.abstractj.kalium.encoders.Encoder, "byte[]", int, long]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 3
+        name: opslimit
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 4
+        name: memlimit
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+  - method: org.abstractj.kalium.crypto.Password.hash
+    arity: 6
+    parameter_types:
+      [int, "byte[]", org.abstractj.kalium.encoders.Encoder, "byte[]", int, long]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: length
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+      - index: 4
+        name: opslimit
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 5
+        name: memlimit
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+  - method: org.abstractj.kalium.crypto.Password.verify
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Random
+  # =========================================================================
+  - method: org.abstractj.kalium.crypto.Random.<init>
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.crypto.Random
+    return:
+      type: org.abstractj.kalium.crypto.Random
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.crypto.Random.randomBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.crypto.Random.randomBytes
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 0
+        name: n
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+
+  # =========================================================================
+  # Keys (org.abstractj.kalium.keys)
+  # =========================================================================
+  - method: org.abstractj.kalium.keys.KeyPair.<init>
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.keys.KeyPair
+    return:
+      type: org.abstractj.kalium.keys.KeyPair
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.KeyPair.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.keys.KeyPair
+    return:
+      type: org.abstractj.kalium.keys.KeyPair
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.KeyPair.<init>
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.keys.KeyPair
+    return:
+      type: org.abstractj.kalium.keys.KeyPair
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.KeyPair.getPublicKey
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.keys.PublicKey
+    return:
+      type: org.abstractj.kalium.keys.PublicKey
+      confidence: high
+    role: output
+  - method: org.abstractj.kalium.keys.KeyPair.getPrivateKey
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.keys.PrivateKey
+    return:
+      type: org.abstractj.kalium.keys.PrivateKey
+      confidence: high
+    role: output
+  # PublicKey/PrivateKey#1 are overloaded (byte[] / hex String) — canonical
+  # signatures omitted.
+  - method: org.abstractj.kalium.keys.PublicKey.<init>
+    arity: 1
+    return:
+      type: org.abstractj.kalium.keys.PublicKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.PrivateKey.<init>
+    arity: 1
+    return:
+      type: org.abstractj.kalium.keys.PrivateKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.PublicKey.toBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: org.abstractj.kalium.keys.PrivateKey.toBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  # Ed25519 signing keys
+  - method: org.abstractj.kalium.keys.SigningKey.<init>
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.keys.SigningKey
+    return:
+      type: org.abstractj.kalium.keys.SigningKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.SigningKey.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.keys.SigningKey
+    return:
+      type: org.abstractj.kalium.keys.SigningKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.SigningKey.<init>
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.keys.SigningKey
+    return:
+      type: org.abstractj.kalium.keys.SigningKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.SigningKey.getVerifyKey
+    arity: 0
+    canonical_return_type: org.abstractj.kalium.keys.VerifyKey
+    return:
+      type: org.abstractj.kalium.keys.VerifyKey
+      confidence: high
+    role: output
+  - method: org.abstractj.kalium.keys.SigningKey.sign
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.SigningKey.sign
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.SigningKey.toBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: org.abstractj.kalium.keys.VerifyKey.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.keys.VerifyKey
+    return:
+      type: org.abstractj.kalium.keys.VerifyKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.VerifyKey.<init>
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.keys.VerifyKey
+    return:
+      type: org.abstractj.kalium.keys.VerifyKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.VerifyKey.verify
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.VerifyKey.verify
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.VerifyKey.toBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  # HMAC-SHA512/256 authentication keys
+  - method: org.abstractj.kalium.keys.AuthenticationKey.<init>
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: org.abstractj.kalium.keys.AuthenticationKey
+    return:
+      type: org.abstractj.kalium.keys.AuthenticationKey
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: org.abstractj.kalium.keys.AuthenticationKey.<init>
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: org.abstractj.kalium.keys.AuthenticationKey
+    return:
+      type: org.abstractj.kalium.keys.AuthenticationKey
+      confidence: high
+    role: factory
+  - method: org.abstractj.kalium.keys.AuthenticationKey.sign
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.AuthenticationKey.sign
+    arity: 2
+    parameter_types: [java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.AuthenticationKey.verify
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.AuthenticationKey.verify
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, org.abstractj.kalium.encoders.Encoder]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: org.abstractj.kalium.keys.AuthenticationKey.toBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+
+hierarchy:
+  # Every kalium crypto class is a flat java.lang.Object subclass; the keys
+  # package has a small Key interface that only PublicKey/PrivateKey/
+  # AuthenticationKey implement (SigningKey and VerifyKey deliberately do not).
+  org.abstractj.kalium.crypto.Box:
+    - java.lang.Object
+  org.abstractj.kalium.crypto.SecretBox:
+    - java.lang.Object
+  org.abstractj.kalium.crypto.SealedBox:
+    - java.lang.Object
+  org.abstractj.kalium.crypto.Aead:
+    - java.lang.Object
+  org.abstractj.kalium.crypto.Hash:
+    - java.lang.Object
+  org.abstractj.kalium.crypto.Password:
+    - java.lang.Object
+  org.abstractj.kalium.crypto.Random:
+    - java.lang.Object
+  org.abstractj.kalium.keys.Key:
+    - java.lang.Object
+  org.abstractj.kalium.keys.KeyPair:
+    - java.lang.Object
+  org.abstractj.kalium.keys.PublicKey:
+    - org.abstractj.kalium.keys.Key
+  org.abstractj.kalium.keys.PrivateKey:
+    - org.abstractj.kalium.keys.Key
+  org.abstractj.kalium.keys.AuthenticationKey:
+    - org.abstractj.kalium.keys.Key
+  org.abstractj.kalium.keys.SigningKey:
+    - java.lang.Object
+  org.abstractj.kalium.keys.VerifyKey:
+    - java.lang.Object
+  org.abstractj.kalium.encoders.Encoder:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/lambdaworks-scrypt.yaml
+++ b/internal/callgraph/contracts/java/lambdaworks-scrypt.yaml
@@ -1,0 +1,130 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: lambdaworks-scrypt
+  coordinates:
+    - "com.lambdaworks:scrypt"
+  # Verified against upstream source at release 1.4.0 (wg/scrypt).
+  version_range: ">=1.4,<2.0"
+  description: "Lambdaworks scrypt contracts for the scrypt KDF and the SCryptUtil hash/check password facade"
+
+contracts:
+  # --- KDF core (com.lambdaworks.crypto.SCrypt) ---
+  # scrypt dispatches to the native (scryptN) or pure-Java (scryptJ) impl; all
+  # three share the same signature, so each is contracted separately.
+  - method: com.lambdaworks.crypto.SCrypt.scrypt
+    arity: 6
+    parameter_types: ["byte[]", "byte[]", int, int, int, int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 2
+        name: N
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+      - index: 3
+        name: r
+        role: metadata-contributing
+        contributes: { property: blockSize, derivation: argument_value }
+      - index: 4
+        name: p
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+      - index: 5
+        name: dkLen
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: com.lambdaworks.crypto.SCrypt.scryptN
+    arity: 6
+    parameter_types: ["byte[]", "byte[]", int, int, int, int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 2
+        name: N
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+      - index: 3
+        name: r
+        role: metadata-contributing
+        contributes: { property: blockSize, derivation: argument_value }
+      - index: 4
+        name: p
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+      - index: 5
+        name: dkLen
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+  - method: com.lambdaworks.crypto.SCrypt.scryptJ
+    arity: 6
+    parameter_types: ["byte[]", "byte[]", int, int, int, int]
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: operation
+    parameters:
+      - index: 2
+        name: N
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+      - index: 3
+        name: r
+        role: metadata-contributing
+        contributes: { property: blockSize, derivation: argument_value }
+      - index: 4
+        name: p
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+      - index: 5
+        name: dkLen
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+
+  # --- Password facade (com.lambdaworks.crypto.SCryptUtil) ---
+  # scrypt derives a modular-crypt-format hash string (16-byte salt, 32-byte
+  # derived key are fixed by the facade); check verifies against it.
+  - method: com.lambdaworks.crypto.SCryptUtil.scrypt
+    arity: 4
+    parameter_types: [java.lang.String, int, int, int]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: N
+        role: metadata-contributing
+        contributes: { property: cost, derivation: argument_value }
+      - index: 2
+        name: r
+        role: metadata-contributing
+        contributes: { property: blockSize, derivation: argument_value }
+      - index: 3
+        name: p
+        role: metadata-contributing
+        contributes: { property: parallelism, derivation: argument_value }
+  - method: com.lambdaworks.crypto.SCryptUtil.check
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+hierarchy:
+  com.lambdaworks.crypto.SCrypt:
+    - java.lang.Object
+  com.lambdaworks.crypto.SCryptUtil:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/lazysodium.yaml
+++ b/internal/callgraph/contracts/java/lazysodium.yaml
@@ -1,0 +1,1063 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: lazysodium
+  coordinates:
+    - "com.goterl:lazysodium-java"
+  # Verified against upstream source at release 5.2.0 (terl/lazysodium-java).
+  version_range: ">=5.0,<6.0"
+  description: "Lazysodium-java contracts for the libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles"
+
+contracts:
+  # =========================================================================
+  # Sodium handles and lazy facade construction
+  # LazySodiumJava implements every *.Lazy / *.Native interface pair, so the
+  # interface-authored operations below resolve on a LazySodiumJava receiver
+  # through the hierarchy edges at the bottom of this file.
+  # =========================================================================
+  - method: com.goterl.lazysodium.SodiumJava.<init>
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.SodiumJava
+    return:
+      type: com.goterl.lazysodium.SodiumJava
+      confidence: high
+    role: factory
+  # SodiumJava#1 is overloaded (LibraryLoader.Mode / String absolutePath).
+  - method: com.goterl.lazysodium.SodiumJava.<init>
+    arity: 1
+    return:
+      type: com.goterl.lazysodium.SodiumJava
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.LazySodiumJava.<init>
+    arity: 1
+    parameter_types: [com.goterl.lazysodium.SodiumJava]
+    canonical_return_type: com.goterl.lazysodium.LazySodiumJava
+    return:
+      type: com.goterl.lazysodium.LazySodiumJava
+      confidence: high
+    role: factory
+  # LazySodiumJava#2 is overloaded ((SodiumJava,Charset) / (SodiumJava,MessageEncoder)).
+  - method: com.goterl.lazysodium.LazySodiumJava.<init>
+    arity: 2
+    return:
+      type: com.goterl.lazysodium.LazySodiumJava
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.LazySodiumJava.<init>
+    arity: 3
+    parameter_types:
+      [
+        com.goterl.lazysodium.SodiumJava,
+        java.nio.charset.Charset,
+        com.goterl.lazysodium.interfaces.MessageEncoder,
+      ]
+    canonical_return_type: com.goterl.lazysodium.LazySodiumJava
+    return:
+      type: com.goterl.lazysodium.LazySodiumJava
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Key material (com.goterl.lazysodium.utils)
+  # =========================================================================
+  # Key#1 is overloaded (byte[] / hex String / plain String / base64 String).
+  - method: com.goterl.lazysodium.utils.Key.fromBytes
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_bit_length }
+  - method: com.goterl.lazysodium.utils.Key.fromHexString
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.utils.Key.fromPlainString
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.utils.Key.fromPlainString
+    arity: 2
+    parameter_types: [java.lang.String, java.nio.charset.Charset]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.utils.Key.fromBase64String
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.utils.Key.fromBase64String
+    arity: 2
+    parameter_types: [java.lang.String, com.goterl.lazysodium.utils.Base64Facade]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.utils.Key.generate
+    arity: 2
+    parameter_types: [com.goterl.lazysodium.LazySodium, int]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+    parameters:
+      - index: 1
+        name: size
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_value }
+  - method: com.goterl.lazysodium.utils.Key.getAsBytes
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: com.goterl.lazysodium.utils.Key.getAsHexString
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.goterl.lazysodium.utils.KeyPair.<init>
+    arity: 2
+    parameter_types:
+      [com.goterl.lazysodium.utils.Key, com.goterl.lazysodium.utils.Key]
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.utils.KeyPair.getPublicKey
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: output
+  - method: com.goterl.lazysodium.utils.KeyPair.getSecretKey
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # SecretBox — XSalsa20-Poly1305 (interfaces.SecretBox)
+  # =========================================================================
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxKeygen
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxEasy
+    arity: 3
+    parameter_types:
+      [java.lang.String, "byte[]", com.goterl.lazysodium.utils.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxOpenEasy
+    arity: 3
+    parameter_types:
+      [java.lang.String, "byte[]", com.goterl.lazysodium.utils.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxDetached
+    arity: 3
+    parameter_types:
+      [java.lang.String, "byte[]", com.goterl.lazysodium.utils.Key]
+    canonical_return_type: com.goterl.lazysodium.utils.DetachedEncrypt
+    return:
+      type: com.goterl.lazysodium.utils.DetachedEncrypt
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxOpenDetached
+    arity: 3
+    parameter_types:
+      [
+        com.goterl.lazysodium.utils.DetachedEncrypt,
+        "byte[]",
+        com.goterl.lazysodium.utils.Key,
+      ]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  # Native buffer-based forms; arity separates them from every Lazy method.
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Native.cryptoSecretBoxKeygen
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Native.cryptoSecretBoxEasy
+    arity: 5
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Native.cryptoSecretBoxOpenEasy
+    arity: 5
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Native.cryptoSecretBoxDetached
+    arity: 6
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.SecretBox.Native.cryptoSecretBoxOpenDetached
+    arity: 6
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Box — Curve25519-XSalsa20-Poly1305 (interfaces.Box)
+  # =========================================================================
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxKeypair
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxSeedKeypair
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxEasy
+    arity: 3
+    parameter_types:
+      [java.lang.String, "byte[]", com.goterl.lazysodium.utils.KeyPair]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxOpenEasy
+    arity: 3
+    parameter_types:
+      [java.lang.String, "byte[]", com.goterl.lazysodium.utils.KeyPair]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  # cryptoBoxBeforeNm has a 1-arg KeyPair form and a 2-arg raw-key form.
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxBeforeNm
+    arity: 1
+    parameter_types: [com.goterl.lazysodium.utils.KeyPair]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxBeforeNm
+    arity: 2
+    parameter_types: ["byte[]", "byte[]"]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxEasyAfterNm
+    arity: 3
+    parameter_types: [java.lang.String, "byte[]", java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxOpenEasyAfterNm
+    arity: 3
+    parameter_types: [java.lang.String, "byte[]", java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxDetachedAfterNm
+    arity: 3
+    parameter_types: [java.lang.String, "byte[]", java.lang.String]
+    canonical_return_type: com.goterl.lazysodium.utils.DetachedEncrypt
+    return:
+      type: com.goterl.lazysodium.utils.DetachedEncrypt
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxOpenDetachedAfterNm
+    arity: 3
+    parameter_types:
+      [com.goterl.lazysodium.utils.DetachedEncrypt, "byte[]", java.lang.String]
+    canonical_return_type: com.goterl.lazysodium.utils.DetachedDecrypt
+    return:
+      type: com.goterl.lazysodium.utils.DetachedDecrypt
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxSealEasy
+    arity: 2
+    parameter_types: [java.lang.String, com.goterl.lazysodium.utils.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxSealOpenEasy
+    arity: 2
+    parameter_types: [java.lang.String, com.goterl.lazysodium.utils.KeyPair]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  # Native forms
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxKeypair
+    arity: 2
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxSeedKeypair
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxEasy
+    arity: 6
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxOpenEasy
+    arity: 6
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxDetached
+    arity: 7
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxOpenDetached
+    arity: 7
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxSeal
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Box.Native.cryptoBoxSealOpen
+    arity: 5
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # GenericHash — BLAKE2b (interfaces.GenericHash)
+  # NOTE: cryptoGenericHashKeygen is the one name where the Lazy and Native
+  # forms share arity 1 with different params and returns (Lazy(int) -> Key vs
+  # Native(byte[]) -> void). They are distinct contract keys because the
+  # declaring interface differs; a LazySodiumJava receiver implements both, so
+  # call-site parameter provenance is what selects the right one.
+  # =========================================================================
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHashKeygen
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHashKeygen
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: size
+        role: metadata-contributing
+        contributes: { property: keySize, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHash
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHash
+    arity: 2
+    parameter_types: [java.lang.String, com.goterl.lazysodium.utils.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHashInit
+    arity: 3
+    parameter_types: ["byte[]", com.goterl.lazysodium.utils.Key, int]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHashUpdate
+    arity: 2
+    parameter_types: ["byte[]", java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHashFinal
+    arity: 2
+    parameter_types: ["byte[]", int]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHashKeygen
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHash
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHash
+    arity: 6
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHashInit
+    arity: 2
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHashInit
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHashUpdate
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHashFinal
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # PwHash — Argon2 (interfaces.PwHash)
+  # =========================================================================
+  - method: com.goterl.lazysodium.interfaces.PwHash.Lazy.cryptoPwHash
+    arity: 6
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: cryptoPwHashLen
+        role: metadata-contributing
+        contributes: { property: outputLength, derivation: argument_value }
+      - index: 3
+        name: opsLimit
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 4
+        name: memLimit
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.PwHash.Lazy.cryptoPwHashStr
+    arity: 3
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 1
+        name: opsLimit
+        role: metadata-contributing
+        contributes: { property: iterations, derivation: argument_value }
+      - index: 2
+        name: memLimit
+        role: metadata-contributing
+        contributes: { property: memoryLimit, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.PwHash.Lazy.cryptoPwHashStrRemoveNulls
+    arity: 3
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.PwHash.Lazy.cryptoPwHashStrVerify
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.PwHash.Native.cryptoPwHash
+    arity: 8
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.PwHash.Native.cryptoPwHashStr
+    arity: 5
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.PwHash.Native.cryptoPwHashStrVerify
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.PwHash.Native.cryptoPwHashStrNeedsRehash
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Sign — Ed25519 (interfaces.Sign)
+  # =========================================================================
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignKeypair
+    arity: 0
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignSeedKeypair
+    arity: 1
+    parameter_types: ["byte[]"]
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignSecretKeyPair
+    arity: 1
+    parameter_types: [com.goterl.lazysodium.utils.Key]
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  # cryptoSign#2 is overloaded ((String,String) / (String,Key)) with the same
+  # String return — canonical signature omitted.
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSign
+    arity: 2
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignOpen
+    arity: 2
+    parameter_types: [java.lang.String, com.goterl.lazysodium.utils.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignDetached
+    arity: 2
+    parameter_types: [java.lang.String, com.goterl.lazysodium.utils.Key]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignVerifyDetached
+    arity: 3
+    parameter_types:
+      [java.lang.String, java.lang.String, com.goterl.lazysodium.utils.Key]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Lazy.convertKeyPairEd25519ToCurve25519
+    arity: 1
+    parameter_types: [com.goterl.lazysodium.utils.KeyPair]
+    canonical_return_type: com.goterl.lazysodium.utils.KeyPair
+    return:
+      type: com.goterl.lazysodium.utils.KeyPair
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignKeypair
+    arity: 2
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignSeedKeypair
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSign
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignOpen
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignDetached
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignVerifyDetached
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignInit
+    arity: 1
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignUpdate
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignFinalCreate
+    arity: 4
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.Sign.Native.cryptoSignFinalVerify
+    arity: 3
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # AEAD (interfaces.AEAD)
+  # The Lazy forms take the algorithm as a trailing AEAD.Method enum argument,
+  # so the contract cannot pin an algorithm; the Native names encode the
+  # algorithm family directly and are the precise attribution points.
+  # =========================================================================
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.keygen
+    arity: 1
+    parameter_types: [com.goterl.lazysodium.interfaces.AEAD.Method]
+    canonical_return_type: com.goterl.lazysodium.utils.Key
+    return:
+      type: com.goterl.lazysodium.utils.Key
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.encrypt
+    arity: 5
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 4
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.encrypt
+    arity: 6
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 5
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.decrypt
+    arity: 5
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 4
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.decrypt
+    arity: 6
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: operation
+    parameters:
+      - index: 5
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.encryptDetached
+    arity: 6
+    canonical_return_type: com.goterl.lazysodium.utils.DetachedEncrypt
+    return:
+      type: com.goterl.lazysodium.utils.DetachedEncrypt
+      confidence: high
+    role: operation
+    parameters:
+      - index: 5
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  - method: com.goterl.lazysodium.interfaces.AEAD.Lazy.decryptDetached
+    arity: 6
+    canonical_return_type: com.goterl.lazysodium.utils.DetachedDecrypt
+    return:
+      type: com.goterl.lazysodium.utils.DetachedDecrypt
+      confidence: high
+    role: operation
+    parameters:
+      - index: 5
+        name: method
+        role: operation-determining
+        contributes: { property: algorithm, derivation: argument_value }
+  # Native, algorithm-bearing entry points: ChaCha20-Poly1305 (original and
+  # IETF), XChaCha20-Poly1305 IETF, and AES-256-GCM.
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305Keygen
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305Encrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305Decrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305EncryptDetached
+    arity: 10
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305DecryptDetached
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305IetfKeygen
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305IetfEncrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305IetfDecrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305IetfEncryptDetached
+    arity: 10
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadChaCha20Poly1305IetfDecryptDetached
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadXChaCha20Poly1305IetfKeygen
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadXChaCha20Poly1305IetfEncrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadXChaCha20Poly1305IetfDecrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadXChaCha20Poly1305IetfEncryptDetached
+    arity: 10
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadXChaCha20Poly1305IetfDecryptDetached
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMKeygen
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: factory
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMEncrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMDecrypt
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMEncryptDetached
+    arity: 10
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMDecryptDetached
+    arity: 9
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  - method: com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMIsAvailable
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: config
+
+hierarchy:
+  # LazySodium implements every Lazy/Native interface pair; LazySodiumJava adds
+  # the Java-only Scrypt and StreamJava pairs.
+  com.goterl.lazysodium.LazySodium:
+    - com.goterl.lazysodium.interfaces.AEAD.Lazy
+    - com.goterl.lazysodium.interfaces.AEAD.Native
+    - com.goterl.lazysodium.interfaces.Box.Lazy
+    - com.goterl.lazysodium.interfaces.Box.Native
+    - com.goterl.lazysodium.interfaces.GenericHash.Lazy
+    - com.goterl.lazysodium.interfaces.GenericHash.Native
+    - com.goterl.lazysodium.interfaces.PwHash.Lazy
+    - com.goterl.lazysodium.interfaces.PwHash.Native
+    - com.goterl.lazysodium.interfaces.SecretBox.Lazy
+    - com.goterl.lazysodium.interfaces.SecretBox.Native
+    - com.goterl.lazysodium.interfaces.Sign.Lazy
+    - com.goterl.lazysodium.interfaces.Sign.Native
+  com.goterl.lazysodium.LazySodiumJava:
+    - com.goterl.lazysodium.LazySodium
+  com.goterl.lazysodium.Sodium:
+    - java.lang.Object
+  com.goterl.lazysodium.SodiumJava:
+    - com.goterl.lazysodium.Sodium
+  com.goterl.lazysodium.interfaces.AEAD.Lazy:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.AEAD.Native:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.AEAD.Method:
+    - java.lang.Enum
+  com.goterl.lazysodium.interfaces.Box.Lazy:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.Box.Native:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.GenericHash.Lazy:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.GenericHash.Native:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.PwHash.Lazy:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.PwHash.Native:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.SecretBox.Lazy:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.SecretBox.Native:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.Sign.Lazy:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.Sign.Native:
+    - java.lang.Object
+  com.goterl.lazysodium.interfaces.MessageEncoder:
+    - java.lang.Object
+  com.goterl.lazysodium.utils.Key:
+    - java.lang.Object
+  com.goterl.lazysodium.utils.KeyPair:
+    - java.lang.Object
+  com.goterl.lazysodium.utils.Base64Facade:
+    - java.lang.Object
+  com.goterl.lazysodium.utils.DetachedEncrypt:
+    - java.lang.Object
+  com.goterl.lazysodium.utils.DetachedDecrypt:
+    - java.lang.Object
+  java.lang.Enum:
+    - java.lang.Object
+  java.nio.charset.Charset:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/lazysodium.yaml
+++ b/internal/callgraph/contracts/java/lazysodium.yaml
@@ -5,6 +5,11 @@ library:
   name: lazysodium
   coordinates:
     - "com.goterl:lazysodium-java"
+  # Scope note: this KB covers the JVM artifact only. The Android artifact
+  # (com.goterl:lazysodium-android) exposes the same interfaces through
+  # LazySodiumAndroid/SodiumAndroid, which are NOT declared in the hierarchy
+  # below, so Android consumers resolve nothing from here. Adding them is a
+  # separate KB decision, not an omission of this one.
   # Verified against upstream source at release 5.2.0 (terl/lazysodium-java).
   version_range: ">=5.0,<6.0"
   description: "Lazysodium-java contracts for the libsodium AEAD, box, secretbox, generic-hash, password-hash, and signing lifecycles"

--- a/internal/callgraph/contracts/java/okhttp-tls.yaml
+++ b/internal/callgraph/contracts/java/okhttp-tls.yaml
@@ -1,0 +1,758 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: okhttp-tls
+  coordinates:
+    - "com.squareup.okhttp3:okhttp"
+    - "com.squareup.okhttp3:okhttp-tls"
+  # Verified against upstream Kotlin sources and the binary-compatibility API
+  # dumps on the okhttp 5.x line (repo declares 5.5.0-SNAPSHOT; latest release
+  # 5.4.0). The JVM-visible surface is contracted: Kotlin `val` accessors carry
+  # @get:JvmName so Java sees x() rather than getX(), and varargs occupy a
+  # single parameter slot. okhttp3.tls.* ships in the separate okhttp-tls
+  # artifact; both coordinates are listed above.
+  version_range: ">=5.0,<6.0"
+  description: "OkHttp TLS contracts for certificate pinning, connection-spec cipher/TLS-version selection, handshake inspection, and the okhttp-tls certificate helpers"
+
+contracts:
+  # =========================================================================
+  # Certificate pinning (okhttp3.CertificatePinner)
+  # rule anchor: CertificatePinner.Builder.add
+  # =========================================================================
+  - method: okhttp3.CertificatePinner.Builder.<init>
+    arity: 0
+    canonical_return_type: okhttp3.CertificatePinner.Builder
+    return:
+      type: okhttp3.CertificatePinner.Builder
+      confidence: high
+    role: factory
+  # add(pattern, vararg pins) — the varargs pin array is one slot, so the
+  # Java-visible arity is 2 regardless of how many pins a call site passes.
+  - method: okhttp3.CertificatePinner.Builder.add
+    arity: 2
+    parameter_types: [java.lang.String, "java.lang.String[]"]
+    canonical_return_type: okhttp3.CertificatePinner.Builder
+    return:
+      type: okhttp3.CertificatePinner.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 1
+        name: pins
+        role: metadata-contributing
+        contributes: { property: digest, derivation: argument_value }
+  - method: okhttp3.CertificatePinner.Builder.build
+    arity: 0
+    canonical_return_type: okhttp3.CertificatePinner
+    return:
+      type: okhttp3.CertificatePinner
+      confidence: high
+    role: factory
+  # check#2 is overloaded ((String,List) / (String,Certificate[]) deprecated),
+  # both void — canonical signature omitted.
+  - method: okhttp3.CertificatePinner.check
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: okhttp3.CertificatePinner.pin
+    arity: 1
+    parameter_types: [java.security.cert.Certificate]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.CertificatePinner.sha256Hash
+    arity: 1
+    parameter_types: [java.security.cert.X509Certificate]
+    canonical_return_type: okio.ByteString
+    return:
+      type: okio.ByteString
+      confidence: high
+    role: operation
+  - method: okhttp3.CertificatePinner.sha1Hash
+    arity: 1
+    parameter_types: [java.security.cert.X509Certificate]
+    canonical_return_type: okio.ByteString
+    return:
+      type: okio.ByteString
+      confidence: high
+    role: operation
+  - method: okhttp3.CertificatePinner.Pin.<init>
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: okhttp3.CertificatePinner.Pin
+    return:
+      type: okhttp3.CertificatePinner.Pin
+      confidence: high
+    role: factory
+  - method: okhttp3.CertificatePinner.Pin.getHashAlgorithm
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.CertificatePinner.Pin.getHash
+    arity: 0
+    canonical_return_type: okio.ByteString
+    return:
+      type: okio.ByteString
+      confidence: high
+    role: output
+  - method: okhttp3.CertificatePinner.Pin.matchesCertificate
+    arity: 1
+    parameter_types: [java.security.cert.X509Certificate]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Connection specs (okhttp3.ConnectionSpec)
+  # rule anchors: ConnectionSpec, ConnectionSpec.Builder.cipherSuites
+  # NOTE: Builder has no no-arg constructor — the only public form takes a base
+  # ConnectionSpec (typically the MODERN_TLS/COMPATIBLE_TLS constant).
+  # =========================================================================
+  - method: okhttp3.ConnectionSpec.Builder.<init>
+    arity: 1
+    parameter_types: [okhttp3.ConnectionSpec]
+    canonical_return_type: okhttp3.ConnectionSpec.Builder
+    return:
+      type: okhttp3.ConnectionSpec.Builder
+      confidence: high
+    role: factory
+  # cipherSuites and tlsVersions each have two vararg overloads at arity 1
+  # (typed CipherSuite[]/TlsVersion[] and String[]); the typed forms delegate to
+  # the String forms internally. Canonical signatures are omitted because arity
+  # alone cannot select the overload.
+  - method: okhttp3.ConnectionSpec.Builder.cipherSuites
+    arity: 1
+    return:
+      type: okhttp3.ConnectionSpec.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: cipherSuites
+        role: operation-determining
+        contributes: { property: cipher, derivation: argument_value }
+  - method: okhttp3.ConnectionSpec.Builder.tlsVersions
+    arity: 1
+    return:
+      type: okhttp3.ConnectionSpec.Builder
+      confidence: high
+    role: config
+    parameters:
+      - index: 0
+        name: tlsVersions
+        role: operation-determining
+        contributes: { property: protocolVersion, derivation: argument_value }
+  - method: okhttp3.ConnectionSpec.Builder.allEnabledCipherSuites
+    arity: 0
+    canonical_return_type: okhttp3.ConnectionSpec.Builder
+    return:
+      type: okhttp3.ConnectionSpec.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.ConnectionSpec.Builder.allEnabledTlsVersions
+    arity: 0
+    canonical_return_type: okhttp3.ConnectionSpec.Builder
+    return:
+      type: okhttp3.ConnectionSpec.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.ConnectionSpec.Builder.supportsTlsExtensions
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: okhttp3.ConnectionSpec.Builder
+    return:
+      type: okhttp3.ConnectionSpec.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.ConnectionSpec.Builder.build
+    arity: 0
+    canonical_return_type: okhttp3.ConnectionSpec
+    return:
+      type: okhttp3.ConnectionSpec
+      confidence: high
+    role: factory
+  # Kotlin @get:JvmName accessors: Java calls cipherSuites()/tlsVersions(), not
+  # getCipherSuites()/getTlsVersions().
+  - method: okhttp3.ConnectionSpec.cipherSuites
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+  - method: okhttp3.ConnectionSpec.tlsVersions
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+  - method: okhttp3.ConnectionSpec.isTls
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+  - method: okhttp3.ConnectionSpec.supportsTlsExtensions
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+  - method: okhttp3.ConnectionSpec.isCompatible
+    arity: 1
+    parameter_types: [javax.net.ssl.SSLSocket]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # TLS versions and cipher suites (okhttp3.TlsVersion / okhttp3.CipherSuite)
+  # rule anchors: TlsVersion, TlsVersion.SSL_3_0
+  # TlsVersion.forJavaName throws on an unknown name; CipherSuite.forJavaName
+  # interns a fresh instance instead, so an arbitrary suite string is accepted.
+  # =========================================================================
+  - method: okhttp3.TlsVersion.forJavaName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.TlsVersion
+    return:
+      type: okhttp3.TlsVersion
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: javaName
+        role: operation-determining
+        contributes: { property: protocolVersion, derivation: argument_value }
+  - method: okhttp3.TlsVersion.javaName
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.CipherSuite.forJavaName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.CipherSuite
+    return:
+      type: okhttp3.CipherSuite
+      confidence: high
+    role: factory
+    parameters:
+      - index: 0
+        name: javaName
+        role: operation-determining
+        contributes: { property: cipher, derivation: argument_value }
+  - method: okhttp3.CipherSuite.javaName
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # Client TLS configuration (okhttp3.OkHttpClient.Builder) — TLS surface only;
+  # interceptors, timeouts, caching, and routing are deliberately not contracted.
+  # =========================================================================
+  - method: okhttp3.OkHttpClient.<init>
+    arity: 0
+    canonical_return_type: okhttp3.OkHttpClient
+    return:
+      type: okhttp3.OkHttpClient
+      confidence: high
+    role: factory
+  - method: okhttp3.OkHttpClient.Builder.<init>
+    arity: 0
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: factory
+  - method: okhttp3.OkHttpClient.newBuilder
+    arity: 0
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: factory
+  # The arity-1 sslSocketFactory is deprecated at ERROR level in Kotlin but is
+  # not name-mangled, so it stays callable (and reachable) from Java.
+  - method: okhttp3.OkHttpClient.Builder.sslSocketFactory
+    arity: 1
+    parameter_types: [javax.net.ssl.SSLSocketFactory]
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.OkHttpClient.Builder.sslSocketFactory
+    arity: 2
+    parameter_types:
+      [javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager]
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.OkHttpClient.Builder.hostnameVerifier
+    arity: 1
+    parameter_types: [javax.net.ssl.HostnameVerifier]
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.OkHttpClient.Builder.certificatePinner
+    arity: 1
+    parameter_types: [okhttp3.CertificatePinner]
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.OkHttpClient.Builder.connectionSpecs
+    arity: 1
+    parameter_types: [java.util.List]
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.OkHttpClient.Builder.protocols
+    arity: 1
+    parameter_types: [java.util.List]
+    canonical_return_type: okhttp3.OkHttpClient.Builder
+    return:
+      type: okhttp3.OkHttpClient.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.OkHttpClient.Builder.build
+    arity: 0
+    canonical_return_type: okhttp3.OkHttpClient
+    return:
+      type: okhttp3.OkHttpClient
+      confidence: high
+    role: factory
+  - method: okhttp3.OkHttpClient.sslSocketFactory
+    arity: 0
+    canonical_return_type: javax.net.ssl.SSLSocketFactory
+    return:
+      type: javax.net.ssl.SSLSocketFactory
+      confidence: high
+    role: output
+  - method: okhttp3.OkHttpClient.x509TrustManager
+    arity: 0
+    canonical_return_type: javax.net.ssl.X509TrustManager
+    return:
+      type: javax.net.ssl.X509TrustManager
+      confidence: high
+    role: output
+  - method: okhttp3.OkHttpClient.certificatePinner
+    arity: 0
+    canonical_return_type: okhttp3.CertificatePinner
+    return:
+      type: okhttp3.CertificatePinner
+      confidence: high
+    role: output
+  - method: okhttp3.OkHttpClient.connectionSpecs
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # Handshake inspection (okhttp3.Handshake) — the negotiated result
+  # =========================================================================
+  # get#1 takes an SSLSession; get#4 builds a Handshake from its parts.
+  - method: okhttp3.Handshake.get
+    arity: 1
+    parameter_types: [javax.net.ssl.SSLSession]
+    canonical_return_type: okhttp3.Handshake
+    return:
+      type: okhttp3.Handshake
+      confidence: high
+    role: factory
+  - method: okhttp3.Handshake.get
+    arity: 4
+    parameter_types:
+      [okhttp3.TlsVersion, okhttp3.CipherSuite, java.util.List, java.util.List]
+    canonical_return_type: okhttp3.Handshake
+    return:
+      type: okhttp3.Handshake
+      confidence: high
+    role: factory
+  - method: okhttp3.Handshake.tlsVersion
+    arity: 0
+    canonical_return_type: okhttp3.TlsVersion
+    return:
+      type: okhttp3.TlsVersion
+      confidence: high
+    role: output
+  - method: okhttp3.Handshake.cipherSuite
+    arity: 0
+    canonical_return_type: okhttp3.CipherSuite
+    return:
+      type: okhttp3.CipherSuite
+      confidence: high
+    role: output
+  - method: okhttp3.Handshake.peerCertificates
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+  - method: okhttp3.Handshake.localCertificates
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+
+  # =========================================================================
+  # okhttp-tls artifact (okhttp3.tls) — certificate and key generation
+  # =========================================================================
+  - method: okhttp3.tls.HeldCertificate.<init>
+    arity: 2
+    parameter_types: [java.security.KeyPair, java.security.cert.X509Certificate]
+    canonical_return_type: okhttp3.tls.HeldCertificate
+    return:
+      type: okhttp3.tls.HeldCertificate
+      confidence: high
+    role: factory
+  - method: okhttp3.tls.HeldCertificate.decode
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.tls.HeldCertificate
+    return:
+      type: okhttp3.tls.HeldCertificate
+      confidence: high
+    role: factory
+  - method: okhttp3.tls.HeldCertificate.certificate
+    arity: 0
+    canonical_return_type: java.security.cert.X509Certificate
+    return:
+      type: java.security.cert.X509Certificate
+      confidence: high
+    role: output
+  - method: okhttp3.tls.HeldCertificate.keyPair
+    arity: 0
+    canonical_return_type: java.security.KeyPair
+    return:
+      type: java.security.KeyPair
+      confidence: high
+    role: output
+  - method: okhttp3.tls.HeldCertificate.certificatePem
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.tls.HeldCertificate.privateKeyPkcs8Pem
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.tls.HeldCertificate.privateKeyPkcs1Pem
+    arity: 0
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.tls.HeldCertificate.Builder.<init>
+    arity: 0
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: factory
+  # The builder defaults to EC/256 (its init block calls ecdsa256()).
+  - method: okhttp3.tls.HeldCertificate.Builder.ecdsa256
+    arity: 0
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.rsa2048
+    arity: 0
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.keyPair
+    arity: 1
+    parameter_types: [java.security.KeyPair]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.keyPair
+    arity: 2
+    parameter_types: [java.security.PublicKey, java.security.PrivateKey]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.commonName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.organizationalUnit
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.duration
+    arity: 2
+    parameter_types: [long, java.util.concurrent.TimeUnit]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.validityInterval
+    arity: 2
+    parameter_types: [long, long]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.addSubjectAlternativeName
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.signedBy
+    arity: 1
+    parameter_types: [okhttp3.tls.HeldCertificate]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HeldCertificate.Builder.certificateAuthority
+    arity: 1
+    parameter_types: [int]
+    canonical_return_type: okhttp3.tls.HeldCertificate.Builder
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  # serialNumber#1 is overloaded (long / BigInteger); the long form delegates.
+  - method: okhttp3.tls.HeldCertificate.Builder.serialNumber
+    arity: 1
+    return:
+      type: okhttp3.tls.HeldCertificate.Builder
+      confidence: high
+    role: config
+  # build() is the terminal: it generates the key pair (EC or RSA at the
+  # configured size) and self- or CA-signs with SHA256withECDSA/SHA256withRSA.
+  - method: okhttp3.tls.HeldCertificate.Builder.build
+    arity: 0
+    canonical_return_type: okhttp3.tls.HeldCertificate
+    return:
+      type: okhttp3.tls.HeldCertificate
+      confidence: high
+    role: operation
+  - method: okhttp3.tls.HandshakeCertificates.Builder.<init>
+    arity: 0
+    canonical_return_type: okhttp3.tls.HandshakeCertificates.Builder
+    return:
+      type: okhttp3.tls.HandshakeCertificates.Builder
+      confidence: high
+    role: factory
+  - method: okhttp3.tls.HandshakeCertificates.Builder.heldCertificate
+    arity: 2
+    parameter_types:
+      [okhttp3.tls.HeldCertificate, "java.security.cert.X509Certificate[]"]
+    canonical_return_type: okhttp3.tls.HandshakeCertificates.Builder
+    return:
+      type: okhttp3.tls.HandshakeCertificates.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HandshakeCertificates.Builder.addTrustedCertificate
+    arity: 1
+    parameter_types: [java.security.cert.X509Certificate]
+    canonical_return_type: okhttp3.tls.HandshakeCertificates.Builder
+    return:
+      type: okhttp3.tls.HandshakeCertificates.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HandshakeCertificates.Builder.addPlatformTrustedCertificates
+    arity: 0
+    canonical_return_type: okhttp3.tls.HandshakeCertificates.Builder
+    return:
+      type: okhttp3.tls.HandshakeCertificates.Builder
+      confidence: high
+    role: config
+  # addInsecureHost disables server authentication for a hostname.
+  - method: okhttp3.tls.HandshakeCertificates.Builder.addInsecureHost
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: okhttp3.tls.HandshakeCertificates.Builder
+    return:
+      type: okhttp3.tls.HandshakeCertificates.Builder
+      confidence: high
+    role: config
+  - method: okhttp3.tls.HandshakeCertificates.Builder.build
+    arity: 0
+    canonical_return_type: okhttp3.tls.HandshakeCertificates
+    return:
+      type: okhttp3.tls.HandshakeCertificates
+      confidence: high
+    role: factory
+  - method: okhttp3.tls.HandshakeCertificates.keyManager
+    arity: 0
+    canonical_return_type: javax.net.ssl.X509KeyManager
+    return:
+      type: javax.net.ssl.X509KeyManager
+      confidence: high
+    role: output
+  - method: okhttp3.tls.HandshakeCertificates.trustManager
+    arity: 0
+    canonical_return_type: javax.net.ssl.X509TrustManager
+    return:
+      type: javax.net.ssl.X509TrustManager
+      confidence: high
+    role: output
+  # sslContext()/sslSocketFactory() initialize the SSLContext with the key and
+  # trust managers and a fresh SecureRandom.
+  - method: okhttp3.tls.HandshakeCertificates.sslContext
+    arity: 0
+    canonical_return_type: javax.net.ssl.SSLContext
+    return:
+      type: javax.net.ssl.SSLContext
+      confidence: high
+    role: operation
+  - method: okhttp3.tls.HandshakeCertificates.sslSocketFactory
+    arity: 0
+    canonical_return_type: javax.net.ssl.SSLSocketFactory
+    return:
+      type: javax.net.ssl.SSLSocketFactory
+      confidence: high
+    role: operation
+  - method: okhttp3.tls.Certificates.certificatePem
+    arity: 1
+    parameter_types: [java.security.cert.X509Certificate]
+    canonical_return_type: java.lang.String
+    return:
+      type: java.lang.String
+      confidence: high
+    role: output
+  - method: okhttp3.tls.Certificates.decodeCertificatePem
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: java.security.cert.X509Certificate
+    return:
+      type: java.security.cert.X509Certificate
+      confidence: high
+    role: factory
+
+hierarchy:
+  # Every okhttp TLS type is a flat java.lang.Object subclass except the
+  # TlsVersion enum; nested Builders are static, so there is no outer receiver.
+  okhttp3.CertificatePinner:
+    - java.lang.Object
+  okhttp3.CertificatePinner.Builder:
+    - java.lang.Object
+  okhttp3.CertificatePinner.Pin:
+    - java.lang.Object
+  okhttp3.ConnectionSpec:
+    - java.lang.Object
+  okhttp3.ConnectionSpec.Builder:
+    - java.lang.Object
+  okhttp3.TlsVersion:
+    - java.lang.Enum
+  okhttp3.CipherSuite:
+    - java.lang.Object
+  okhttp3.Handshake:
+    - java.lang.Object
+  okhttp3.OkHttpClient:
+    - java.lang.Object
+  okhttp3.OkHttpClient.Builder:
+    - java.lang.Object
+  okhttp3.tls.HeldCertificate:
+    - java.lang.Object
+  okhttp3.tls.HeldCertificate.Builder:
+    - java.lang.Object
+  okhttp3.tls.HandshakeCertificates:
+    - java.lang.Object
+  okhttp3.tls.HandshakeCertificates.Builder:
+    - java.lang.Object
+  okhttp3.tls.Certificates:
+    - java.lang.Object
+  okio.ByteString:
+    - java.lang.Object
+  # JCA / JSSE types referenced as returns
+  javax.net.ssl.SSLContext:
+    - java.lang.Object
+  javax.net.ssl.SSLSocketFactory:
+    - java.lang.Object
+  javax.net.ssl.SSLSocket:
+    - java.lang.Object
+  javax.net.ssl.SSLSession:
+    - java.lang.Object
+  javax.net.ssl.X509TrustManager:
+    - java.lang.Object
+  javax.net.ssl.X509KeyManager:
+    - java.lang.Object
+  javax.net.ssl.HostnameVerifier:
+    - java.lang.Object
+  java.security.cert.X509Certificate:
+    - java.security.cert.Certificate
+  java.security.cert.Certificate:
+    - java.lang.Object
+  java.security.KeyPair:
+    - java.lang.Object
+  java.security.PublicKey:
+    - java.security.Key
+  java.security.PrivateKey:
+    - java.security.Key
+  java.security.Key:
+    - java.lang.Object
+  java.util.List:
+    - java.lang.Object
+  java.util.concurrent.TimeUnit:
+    - java.lang.Enum
+  java.lang.Enum:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/sshj.yaml
+++ b/internal/callgraph/contracts/java/sshj.yaml
@@ -1,0 +1,524 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: sshj
+  coordinates:
+    - "com.hierynomus:sshj"
+  # Verified against upstream source at release 0.40.0 (hierynomus/sshj).
+  version_range: ">=0.32,<1.0"
+  description: "sshj contracts for SSH client setup, algorithm configuration, host-key verification, and key-provider loading"
+
+contracts:
+  # =========================================================================
+  # net.schmizz.sshj.SSHClient — the entry point (rule anchor: SSHClient.<init>)
+  # =========================================================================
+  - method: net.schmizz.sshj.SSHClient.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.SSHClient
+    return:
+      type: net.schmizz.sshj.SSHClient
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.SSHClient.<init>
+    arity: 1
+    parameter_types: [net.schmizz.sshj.Config]
+    canonical_return_type: net.schmizz.sshj.SSHClient
+    return:
+      type: net.schmizz.sshj.SSHClient
+      confidence: high
+    role: factory
+  # connect is inherited from SocketClient and overloaded per arity on
+  # (String hostname / InetAddress) — resolved through the hierarchy edge below.
+  - method: net.schmizz.sshj.SocketClient.connect
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SocketClient.connect
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SocketClient.connect
+    arity: 4
+    return:
+      type: void
+      confidence: high
+    role: operation
+  # Host-key policy. addHostKeyVerifier#1 is overloaded (HostKeyVerifier /
+  # String fingerprint).
+  - method: net.schmizz.sshj.SSHClient.addHostKeyVerifier
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.SSHClient.addAlgorithmsVerifier
+    arity: 1
+    parameter_types: [net.schmizz.sshj.transport.verification.AlgorithmsVerifier]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.SSHClient.loadKnownHosts
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.SSHClient.loadKnownHosts
+    arity: 1
+    parameter_types: [java.io.File]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  # Authentication. authPassword#2 and authPublickey#2 are each overloaded on
+  # the credential type — canonical signatures omitted.
+  - method: net.schmizz.sshj.SSHClient.authPassword
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SSHClient.authPassword
+    arity: 3
+    parameter_types:
+      [
+        java.lang.String,
+        net.schmizz.sshj.userauth.password.PasswordFinder,
+        net.schmizz.sshj.userauth.password.PasswordUpdateProvider,
+      ]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SSHClient.authPublickey
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SSHClient.authPublickey
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SSHClient.auth
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SSHClient.authGssApiWithMic
+    arity: 4
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  # Key loading. loadKeys#1 is overloaded (KeyPair / String location) and
+  # loadKeys#2 on the passphrase form — all return KeyProvider.
+  - method: net.schmizz.sshj.SSHClient.loadKeys
+    arity: 1
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.KeyProvider
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.SSHClient.loadKeys
+    arity: 2
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.KeyProvider
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.SSHClient.loadKeys
+    arity: 3
+    parameter_types:
+      [
+        java.lang.String,
+        java.lang.String,
+        net.schmizz.sshj.userauth.password.PasswordFinder,
+      ]
+    canonical_return_type: net.schmizz.sshj.userauth.keyprovider.KeyProvider
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.KeyProvider
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.SSHClient.getTransport
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.transport.Transport
+    return:
+      type: net.schmizz.sshj.transport.Transport
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.SSHClient.rekey
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+  - method: net.schmizz.sshj.SSHClient.isAuthenticated
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.SSHClient.disconnect
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: operation
+
+  # =========================================================================
+  # Algorithm configuration (net.schmizz.sshj.Config / ConfigImpl / DefaultConfig)
+  # Authored on the Config interface; ConfigImpl adds varargs siblings at the
+  # same arity 1 (array vs List), so those entries omit canonical signatures.
+  # NOTE: sshj has no setSignatureFactories — signature/host-key algorithms are
+  # selected through setKeyAlgorithms.
+  # =========================================================================
+  - method: net.schmizz.sshj.DefaultConfig.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.DefaultConfig
+    return:
+      type: net.schmizz.sshj.DefaultConfig
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.AndroidConfig.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.AndroidConfig
+    return:
+      type: net.schmizz.sshj.AndroidConfig
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.DefaultSecurityProviderConfig.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.DefaultSecurityProviderConfig
+    return:
+      type: net.schmizz.sshj.DefaultSecurityProviderConfig
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.Config.setCipherFactories
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setMACFactories
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setKeyExchangeFactories
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setKeyAlgorithms
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setCompressionFactories
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setFileKeyProviderFactories
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setRandomFactory
+    arity: 1
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.setVerifyHostKeyCertificates
+    arity: 1
+    parameter_types: [boolean]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.Config.getCipherFactories
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.Config.getKeyAlgorithms
+    arity: 0
+    canonical_return_type: java.util.List
+    return:
+      type: java.util.List
+      confidence: high
+    role: output
+  # ConfigImpl reorders the key algorithms to prefer ssh-rsa (SHA-1 signatures).
+  - method: net.schmizz.sshj.ConfigImpl.prioritizeSshRsaKeyAlgorithm
+    arity: 0
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+
+  # =========================================================================
+  # Key providers (net.schmizz.sshj.userauth.keyprovider)
+  # =========================================================================
+  - method: net.schmizz.sshj.userauth.keyprovider.KeyProvider.getPrivate
+    arity: 0
+    canonical_return_type: java.security.PrivateKey
+    return:
+      type: java.security.PrivateKey
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.userauth.keyprovider.KeyProvider.getPublic
+    arity: 0
+    canonical_return_type: java.security.PublicKey
+    return:
+      type: java.security.PublicKey
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.userauth.keyprovider.KeyProvider.getType
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.common.KeyType
+    return:
+      type: net.schmizz.sshj.common.KeyType
+      confidence: high
+    role: output
+  # FileKeyProvider.init is heavily overloaded per arity (File/Reader/String
+  # sources, with or without a PasswordFinder) — canonical signatures omitted.
+  - method: net.schmizz.sshj.userauth.keyprovider.FileKeyProvider.init
+    arity: 1
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.userauth.keyprovider.FileKeyProvider.init
+    arity: 2
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.userauth.keyprovider.FileKeyProvider.init
+    arity: 3
+    return:
+      type: void
+      confidence: high
+    role: config
+  - method: net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper.<init>
+    arity: 1
+    parameter_types: [java.security.KeyPair]
+    canonical_return_type: net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper.<init>
+    arity: 2
+    parameter_types: [java.security.PublicKey, java.security.PrivateKey]
+    canonical_return_type: net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper
+    return:
+      type: net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Host-key verification (net.schmizz.sshj.transport.verification)
+  # =========================================================================
+  - method: net.schmizz.sshj.transport.verification.HostKeyVerifier.verify
+    arity: 3
+    parameter_types: [java.lang.String, int, java.security.PublicKey]
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: operation
+  # PromiscuousVerifier accepts any host key — a deliberate verification bypass.
+  - method: net.schmizz.sshj.transport.verification.PromiscuousVerifier.<init>
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.transport.verification.PromiscuousVerifier
+    return:
+      type: net.schmizz.sshj.transport.verification.PromiscuousVerifier
+      confidence: high
+    role: factory
+  # FingerprintVerifier has no public constructor; getInstance is the producer.
+  - method: net.schmizz.sshj.transport.verification.FingerprintVerifier.getInstance
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: net.schmizz.sshj.transport.verification.HostKeyVerifier
+    return:
+      type: net.schmizz.sshj.transport.verification.HostKeyVerifier
+      confidence: high
+    role: factory
+  # OpenSSHKnownHosts#1 and #2 are overloaded on (File / Reader).
+  - method: net.schmizz.sshj.transport.verification.OpenSSHKnownHosts.<init>
+    arity: 1
+    return:
+      type: net.schmizz.sshj.transport.verification.OpenSSHKnownHosts
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.transport.verification.OpenSSHKnownHosts.<init>
+    arity: 2
+    return:
+      type: net.schmizz.sshj.transport.verification.OpenSSHKnownHosts
+      confidence: high
+    role: factory
+  - method: net.schmizz.sshj.transport.verification.ConsoleKnownHostsVerifier.<init>
+    arity: 2
+    parameter_types: [java.io.File, java.io.Console]
+    canonical_return_type: net.schmizz.sshj.transport.verification.ConsoleKnownHostsVerifier
+    return:
+      type: net.schmizz.sshj.transport.verification.ConsoleKnownHostsVerifier
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Transport — negotiated results. sshj has no Transport.getServerKey; the
+  # remote key is observable through HostKeyVerifier.verify and the negotiated
+  # host-key algorithm.
+  # =========================================================================
+  - method: net.schmizz.sshj.transport.Transport.getSessionID
+    arity: 0
+    canonical_return_type: byte[]
+    return:
+      type: byte[]
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.transport.Transport.getHostKeyAlgorithm
+    arity: 0
+    canonical_return_type: net.schmizz.sshj.common.KeyAlgorithm
+    return:
+      type: net.schmizz.sshj.common.KeyAlgorithm
+      confidence: high
+    role: output
+  - method: net.schmizz.sshj.transport.Transport.addHostKeyVerifier
+    arity: 1
+    parameter_types: [net.schmizz.sshj.transport.verification.HostKeyVerifier]
+    canonical_return_type: void
+    return:
+      type: void
+      confidence: high
+    role: config
+
+hierarchy:
+  net.schmizz.sshj.SocketClient:
+    - java.lang.Object
+  net.schmizz.sshj.SSHClient:
+    - net.schmizz.sshj.SocketClient
+  net.schmizz.sshj.Config:
+    - java.lang.Object
+  net.schmizz.sshj.ConfigImpl:
+    - net.schmizz.sshj.Config
+  net.schmizz.sshj.DefaultConfig:
+    - net.schmizz.sshj.ConfigImpl
+  net.schmizz.sshj.AndroidConfig:
+    - net.schmizz.sshj.DefaultConfig
+  net.schmizz.sshj.DefaultSecurityProviderConfig:
+    - net.schmizz.sshj.DefaultConfig
+  # Key providers: OpenSSHKeyFile extends PKCS8KeyFile, not BaseFileKeyProvider
+  # directly.
+  net.schmizz.sshj.userauth.keyprovider.KeyProvider:
+    - java.lang.Object
+  net.schmizz.sshj.userauth.keyprovider.FileKeyProvider:
+    - net.schmizz.sshj.userauth.keyprovider.KeyProvider
+  net.schmizz.sshj.userauth.keyprovider.BaseFileKeyProvider:
+    - net.schmizz.sshj.userauth.keyprovider.FileKeyProvider
+  net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile:
+    - net.schmizz.sshj.userauth.keyprovider.BaseFileKeyProvider
+  net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile:
+    - net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile
+  net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile:
+    - net.schmizz.sshj.userauth.keyprovider.BaseFileKeyProvider
+  net.schmizz.sshj.userauth.keyprovider.KeyPairWrapper:
+    - net.schmizz.sshj.userauth.keyprovider.KeyProvider
+  net.schmizz.sshj.userauth.password.PasswordFinder:
+    - java.lang.Object
+  net.schmizz.sshj.userauth.password.PasswordUpdateProvider:
+    - java.lang.Object
+  # Host-key verification
+  net.schmizz.sshj.transport.verification.HostKeyVerifier:
+    - java.lang.Object
+  net.schmizz.sshj.transport.verification.PromiscuousVerifier:
+    - net.schmizz.sshj.transport.verification.HostKeyVerifier
+  net.schmizz.sshj.transport.verification.FingerprintVerifier:
+    - net.schmizz.sshj.transport.verification.HostKeyVerifier
+  net.schmizz.sshj.transport.verification.OpenSSHKnownHosts:
+    - net.schmizz.sshj.transport.verification.HostKeyVerifier
+  net.schmizz.sshj.transport.verification.ConsoleKnownHostsVerifier:
+    - net.schmizz.sshj.transport.verification.OpenSSHKnownHosts
+  net.schmizz.sshj.transport.verification.AlgorithmsVerifier:
+    - java.lang.Object
+  net.schmizz.sshj.transport.Transport:
+    - java.lang.Object
+  net.schmizz.sshj.common.KeyType:
+    - java.lang.Enum
+  net.schmizz.sshj.common.KeyAlgorithm:
+    - java.lang.Object
+  java.security.PrivateKey:
+    - java.security.Key
+  java.security.PublicKey:
+    - java.security.Key
+  java.security.Key:
+    - java.lang.Object
+  java.security.KeyPair:
+    - java.lang.Object
+  java.io.File:
+    - java.lang.Object
+  java.io.Console:
+    - java.lang.Object
+  java.util.List:
+    - java.lang.Object
+  java.lang.Enum:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/vault-java-driver.yaml
+++ b/internal/callgraph/contracts/java/vault-java-driver.yaml
@@ -1,0 +1,349 @@
+schema_version: "2"
+ecosystem: java
+
+library:
+  name: vault-java-driver
+  coordinates:
+    - "com.bettercloud:vault-java-driver"
+  # Verified with javap against the published com.bettercloud:vault-java-driver
+  # 5.1.0 jar. (The project later moved to io.github.jopenlibs:vault-java-driver;
+  # that coordinate has its own package and is a separate KB if ever needed.)
+  version_range: ">=5.0,<6.0"
+  description: "vault-java-driver contracts for Vault client construction, TLS/token configuration, and the secrets-engine accessors that reach remote crypto operations"
+
+contracts:
+  # =========================================================================
+  # Client construction (rule anchors: new Vault(...), new VaultConfig())
+  # =========================================================================
+  - method: com.bettercloud.vault.Vault.<init>
+    arity: 1
+    parameter_types: [com.bettercloud.vault.VaultConfig]
+    canonical_return_type: com.bettercloud.vault.Vault
+    return:
+      type: com.bettercloud.vault.Vault
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.<init>
+    arity: 2
+    parameter_types: [com.bettercloud.vault.VaultConfig, java.lang.Integer]
+    canonical_return_type: com.bettercloud.vault.Vault
+    return:
+      type: com.bettercloud.vault.Vault
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.<init>
+    arity: 3
+    parameter_types:
+      [com.bettercloud.vault.VaultConfig, java.lang.Boolean, java.lang.Integer]
+    canonical_return_type: com.bettercloud.vault.Vault
+    return:
+      type: com.bettercloud.vault.Vault
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.withRetries
+    arity: 2
+    parameter_types: [int, int]
+    canonical_return_type: com.bettercloud.vault.Vault
+    return:
+      type: com.bettercloud.vault.Vault
+      confidence: high
+    role: config
+
+  # =========================================================================
+  # Client configuration (com.bettercloud.vault.VaultConfig) — fluent, returns
+  # itself. address/token/sslConfig carry the trust and credential material.
+  # =========================================================================
+  - method: com.bettercloud.vault.VaultConfig.<init>
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.VaultConfig.address
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.token
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.sslConfig
+    arity: 1
+    parameter_types: [com.bettercloud.vault.SslConfig]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.nameSpace
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.engineVersion
+    arity: 1
+    parameter_types: [java.lang.Integer]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.build
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # TLS trust configuration (com.bettercloud.vault.SslConfig) — fluent.
+  # verify(false) disables server-certificate verification.
+  # =========================================================================
+  - method: com.bettercloud.vault.SslConfig.<init>
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.SslConfig.verify
+    arity: 1
+    parameter_types: [java.lang.Boolean]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  # The PEM and keystore loaders are distinct method names per source kind
+  # (File / classpath resource / UTF-8 contents), not overloads, so every entry
+  # can declare a canonical signature.
+  - method: com.bettercloud.vault.SslConfig.pemFile
+    arity: 1
+    parameter_types: [java.io.File]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.pemResource
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.pemUTF8
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.clientPemFile
+    arity: 1
+    parameter_types: [java.io.File]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.clientKeyPemFile
+    arity: 1
+    parameter_types: [java.io.File]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.keyStoreFile
+    arity: 2
+    parameter_types: [java.io.File, java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.clientPemResource
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.clientPemUTF8
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.clientKeyPemResource
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.clientKeyPemUTF8
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.keyStore
+    arity: 2
+    parameter_types: [java.security.KeyStore, java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.keyStoreResource
+    arity: 2
+    parameter_types: [java.lang.String, java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.trustStore
+    arity: 1
+    parameter_types: [java.security.KeyStore]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.trustStoreFile
+    arity: 1
+    parameter_types: [java.io.File]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.SslConfig.trustStoreResource
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: config
+  # getSslContext exposes the initialized JSSE context built from the above.
+  - method: com.bettercloud.vault.SslConfig.getSslContext
+    arity: 0
+    canonical_return_type: javax.net.ssl.SSLContext
+    return:
+      type: javax.net.ssl.SSLContext
+      confidence: high
+    role: output
+  - method: com.bettercloud.vault.SslConfig.isVerify
+    arity: 0
+    canonical_return_type: boolean
+    return:
+      type: boolean
+      confidence: high
+    role: output
+  - method: com.bettercloud.vault.SslConfig.build
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.SslConfig
+    return:
+      type: com.bettercloud.vault.SslConfig
+      confidence: high
+    role: factory
+
+  # =========================================================================
+  # Secrets-engine accessors — the factory edges from a Vault client to the
+  # engines that perform remote crypto (KV secret storage, PKI issuance, token
+  # auth). The driver has no Transit-engine API of its own, so remote
+  # encrypt/decrypt is reached through Logical.write against a transit path.
+  # =========================================================================
+  - method: com.bettercloud.vault.Vault.logical
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.api.Logical
+    return:
+      type: com.bettercloud.vault.api.Logical
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.auth
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.api.Auth
+    return:
+      type: com.bettercloud.vault.api.Auth
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.pki
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.api.pki.Pki
+    return:
+      type: com.bettercloud.vault.api.pki.Pki
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.pki
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.api.pki.Pki
+    return:
+      type: com.bettercloud.vault.api.pki.Pki
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.seal
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.api.Seal
+    return:
+      type: com.bettercloud.vault.api.Seal
+      confidence: high
+    role: factory
+  - method: com.bettercloud.vault.Vault.mounts
+    arity: 0
+    canonical_return_type: com.bettercloud.vault.api.mounts.Mounts
+    return:
+      type: com.bettercloud.vault.api.mounts.Mounts
+      confidence: high
+    role: factory
+
+hierarchy:
+  com.bettercloud.vault.Vault:
+    - java.lang.Object
+  com.bettercloud.vault.VaultConfig:
+    - java.lang.Object
+  com.bettercloud.vault.SslConfig:
+    - java.lang.Object
+  com.bettercloud.vault.api.Logical:
+    - java.lang.Object
+  com.bettercloud.vault.api.Auth:
+    - java.lang.Object
+  com.bettercloud.vault.api.Seal:
+    - java.lang.Object
+  com.bettercloud.vault.api.pki.Pki:
+    - java.lang.Object
+  com.bettercloud.vault.api.mounts.Mounts:
+    - java.lang.Object
+  javax.net.ssl.SSLContext:
+    - java.lang.Object
+  java.security.KeyStore:
+    - java.lang.Object
+  java.io.File:
+    - java.lang.Object
+  java.lang.Object: []

--- a/internal/callgraph/contracts/java/vault-java-driver.yaml
+++ b/internal/callgraph/contracts/java/vault-java-driver.yaml
@@ -100,6 +100,38 @@ contracts:
       type: com.bettercloud.vault.VaultConfig
       confidence: high
     role: config
+  - method: com.bettercloud.vault.VaultConfig.openTimeout
+    arity: 1
+    parameter_types: [java.lang.Integer]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.readTimeout
+    arity: 1
+    parameter_types: [java.lang.Integer]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.environmentLoader
+    arity: 1
+    parameter_types: [com.bettercloud.vault.EnvironmentLoader]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
+  - method: com.bettercloud.vault.VaultConfig.secretsEnginePathMap
+    arity: 1
+    parameter_types: [java.util.Map]
+    canonical_return_type: com.bettercloud.vault.VaultConfig
+    return:
+      type: com.bettercloud.vault.VaultConfig
+      confidence: high
+    role: config
   - method: com.bettercloud.vault.VaultConfig.build
     arity: 0
     canonical_return_type: com.bettercloud.vault.VaultConfig
@@ -323,6 +355,60 @@ contracts:
       confidence: high
     role: factory
 
+  # Logical is where the remote crypto actually happens: write against a transit
+  # path performs encrypt/decrypt/sign server-side, and read retrieves key
+  # material. Contracting only the Vault.logical factory edge would leave the
+  # chain broken at exactly the operation.
+  - method: com.bettercloud.vault.api.Logical.write
+    arity: 2
+    parameter_types: [java.lang.String, java.util.Map]
+    canonical_return_type: com.bettercloud.vault.response.LogicalResponse
+    return:
+      type: com.bettercloud.vault.response.LogicalResponse
+      confidence: high
+    role: operation
+  - method: com.bettercloud.vault.api.Logical.read
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.response.LogicalResponse
+    return:
+      type: com.bettercloud.vault.response.LogicalResponse
+      confidence: high
+    role: operation
+  - method: com.bettercloud.vault.api.Logical.read
+    arity: 3
+    parameter_types: [java.lang.String, java.lang.Boolean, java.lang.Integer]
+    canonical_return_type: com.bettercloud.vault.response.LogicalResponse
+    return:
+      type: com.bettercloud.vault.response.LogicalResponse
+      confidence: high
+    role: operation
+  - method: com.bettercloud.vault.api.Logical.list
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.response.LogicalResponse
+    return:
+      type: com.bettercloud.vault.response.LogicalResponse
+      confidence: high
+    role: output
+  # delete#2 and unDelete/destroy take a version array.
+  - method: com.bettercloud.vault.api.Logical.delete
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.response.LogicalResponse
+    return:
+      type: com.bettercloud.vault.response.LogicalResponse
+      confidence: high
+    role: operation
+  - method: com.bettercloud.vault.api.Logical.withNameSpace
+    arity: 1
+    parameter_types: [java.lang.String]
+    canonical_return_type: com.bettercloud.vault.api.Logical
+    return:
+      type: com.bettercloud.vault.api.Logical
+      confidence: high
+    role: config
+
 hierarchy:
   com.bettercloud.vault.Vault:
     - java.lang.Object
@@ -339,6 +425,12 @@ hierarchy:
   com.bettercloud.vault.api.pki.Pki:
     - java.lang.Object
   com.bettercloud.vault.api.mounts.Mounts:
+    - java.lang.Object
+  com.bettercloud.vault.response.LogicalResponse:
+    - java.lang.Object
+  com.bettercloud.vault.EnvironmentLoader:
+    - java.lang.Object
+  java.util.Map:
     - java.lang.Object
   javax.net.ssl.SSLContext:
     - java.lang.Object

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -949,6 +949,14 @@ func TestLoadEmbeddedJava_PasswordHasherLifecycle(t *testing.T) {
 		{"org.jasypt.digest.StandardByteDigester.digest", 1, "byte[]", "operation", "jasypt"},
 		{"org.jasypt.util.digest.Digester.digest", 1, "byte[]", "operation", "jasypt"},
 		{"org.jasypt.salt.RandomSaltGenerator.<init>", 0, "org.jasypt.salt.RandomSaltGenerator", "factory", "jasypt"},
+		// Asymmetries found by validating against real code: the provider
+		// setters existed only on the String PBE encryptor, and the
+		// String-digester-only configuration was uncontracted.
+		{"org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setProvider", 1, "void", "config", "jasypt"},
+		{"org.jasypt.encryption.pbe.StandardPBEByteEncryptor.setProviderName", 1, "void", "config", "jasypt"},
+		{"org.jasypt.digest.StandardStringDigester.setStringOutputType", 1, "void", "config", "jasypt"},
+		{"org.jasypt.digest.StandardStringDigester.setPrefix", 1, "void", "config", "jasypt"},
+		{"org.jasypt.digest.StandardStringDigester.setUseLenientSaltSizeCheck", 1, "void", "config", "jasypt"},
 	}
 
 	for _, tt := range tests {

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -2,6 +2,7 @@ package contracts_test
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
@@ -1010,6 +1011,130 @@ func TestLoadEmbeddedJava_PasswordHasherLifecycle(t *testing.T) {
 	for child, wantParent := range hierarchyWants {
 		if parents := kb.Hierarchy[child]; len(parents) == 0 || parents[0] != wantParent {
 			t.Fatalf("%s hierarchy = %v, want first parent %s", child, kb.Hierarchy[child], wantParent)
+		}
+	}
+}
+
+// TestLoadEmbeddedJava_NaClBindingLifecycle verifies the Java libsodium/NaCl
+// binding contracts (scanoss/crypto-finder#205): lazysodium-java's rule-anchored
+// AEAD/Box/GenericHash/PwHash/SecretBox/Sign interface pairs plus key material,
+// and kalium's Box/SecretBox/SealedBox/Aead/Hash/Password/key surfaces. It pins
+// the Lazy-vs-Native split (high-level object returns vs boolean buffer forms),
+// the algorithm-bearing native AEAD entry points, and the work-factor and key
+// parameter roles.
+func TestLoadEmbeddedJava_NaClBindingLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+		lib    string
+	}{
+		// lazysodium: facade construction and key material.
+		{"com.goterl.lazysodium.LazySodiumJava.<init>", 1, "com.goterl.lazysodium.LazySodiumJava", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.SodiumJava.<init>", 0, "com.goterl.lazysodium.SodiumJava", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.utils.Key.fromBytes", 1, "com.goterl.lazysodium.utils.Key", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.utils.Key.generate", 2, "com.goterl.lazysodium.utils.Key", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.utils.KeyPair.getSecretKey", 0, "com.goterl.lazysodium.utils.Key", "output", "lazysodium"},
+		// lazysodium Lazy forms return high-level objects.
+		{"com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxKeygen", 0, "com.goterl.lazysodium.utils.Key", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxEasy", 3, "java.lang.String", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.SecretBox.Lazy.cryptoSecretBoxDetached", 3, "com.goterl.lazysodium.utils.DetachedEncrypt", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxKeypair", 0, "com.goterl.lazysodium.utils.KeyPair", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxEasy", 3, "java.lang.String", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.Box.Lazy.cryptoBoxSealEasy", 2, "java.lang.String", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHash", 2, "java.lang.String", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.PwHash.Lazy.cryptoPwHashStr", 3, "java.lang.String", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.PwHash.Lazy.cryptoPwHashStrVerify", 2, "boolean", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignKeypair", 0, "com.goterl.lazysodium.utils.KeyPair", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignDetached", 2, "java.lang.String", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.Sign.Lazy.cryptoSignVerifyDetached", 3, "boolean", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.AEAD.Lazy.keygen", 1, "com.goterl.lazysodium.utils.Key", "factory", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.AEAD.Lazy.encrypt", 5, "java.lang.String", "operation", "lazysodium"},
+		// lazysodium Native forms are buffer-based and boolean/void-returning;
+		// the AEAD names carry the algorithm family.
+		{"com.goterl.lazysodium.interfaces.SecretBox.Native.cryptoSecretBoxEasy", 5, "boolean", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadXChaCha20Poly1305IetfEncrypt", 9, "boolean", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMEncrypt", 9, "boolean", "operation", "lazysodium"},
+		{"com.goterl.lazysodium.interfaces.AEAD.Native.cryptoAeadAES256GCMKeygen", 1, "void", "factory", "lazysodium"},
+		// kalium: rule anchors are the Box/Hash/SecretBox constructors.
+		{"org.abstractj.kalium.crypto.Box.<init>", 2, "org.abstractj.kalium.crypto.Box", "factory", "kalium"},
+		{"org.abstractj.kalium.crypto.SecretBox.<init>", 1, "org.abstractj.kalium.crypto.SecretBox", "factory", "kalium"},
+		{"org.abstractj.kalium.crypto.Hash.<init>", 0, "org.abstractj.kalium.crypto.Hash", "factory", "kalium"},
+		{"org.abstractj.kalium.crypto.Box.encrypt", 2, "byte[]", "operation", "kalium"},
+		{"org.abstractj.kalium.crypto.SecretBox.decrypt", 2, "byte[]", "operation", "kalium"},
+		{"org.abstractj.kalium.crypto.SealedBox.encrypt", 1, "byte[]", "operation", "kalium"},
+		{"org.abstractj.kalium.crypto.Aead.useAesGcm", 0, "org.abstractj.kalium.crypto.Aead", "config", "kalium"},
+		{"org.abstractj.kalium.crypto.Aead.encrypt", 3, "byte[]", "operation", "kalium"},
+		// kalium Hash splits byte[] (arity 1) from String (arity 2 with encoder).
+		{"org.abstractj.kalium.crypto.Hash.sha256", 1, "byte[]", "operation", "kalium"},
+		{"org.abstractj.kalium.crypto.Hash.sha256", 2, "java.lang.String", "operation", "kalium"},
+		{"org.abstractj.kalium.crypto.Password.hash", 4, "java.lang.String", "operation", "kalium"},
+		{"org.abstractj.kalium.crypto.Password.verify", 2, "boolean", "operation", "kalium"},
+		{"org.abstractj.kalium.keys.SigningKey.sign", 1, "byte[]", "operation", "kalium"},
+		{"org.abstractj.kalium.keys.VerifyKey.verify", 2, "boolean", "operation", "kalium"},
+		{"org.abstractj.kalium.keys.KeyPair.getPrivateKey", 0, "org.abstractj.kalium.keys.PrivateKey", "output", "kalium"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != tt.lib {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from %q", tt.method, tt.arity, got[0], tt.want, tt.role, tt.lib)
+			}
+		})
+	}
+
+	// cryptoGenericHashKeygen is the one lazysodium name where the Lazy and
+	// Native forms share arity 1: Lazy(int) -> Key vs Native(byte[]) -> void.
+	// They must stay distinct contracts keyed by the declaring interface.
+	lazyKeygen := kb.ContractsFor("com.goterl.lazysodium.interfaces.GenericHash.Lazy.cryptoGenericHashKeygen", 1)
+	nativeKeygen := kb.ContractsFor("com.goterl.lazysodium.interfaces.GenericHash.Native.cryptoGenericHashKeygen", 1)
+	if len(lazyKeygen) != 1 || lazyKeygen[0].Return.Type != "com.goterl.lazysodium.utils.Key" {
+		t.Fatalf("GenericHash.Lazy.cryptoGenericHashKeygen#1 = %#v, want Key", lazyKeygen)
+	}
+	if len(nativeKeygen) != 1 || nativeKeygen[0].Return.Type != "void" {
+		t.Fatalf("GenericHash.Native.cryptoGenericHashKeygen#1 = %#v, want void", nativeKeygen)
+	}
+
+	// The AEAD.Lazy methods take the algorithm as a trailing enum argument, so
+	// that parameter must be operation-determining rather than metadata.
+	aeadEncrypt := kb.ContractsFor("com.goterl.lazysodium.interfaces.AEAD.Lazy.encrypt", 5)
+	if len(aeadEncrypt) != 1 || len(aeadEncrypt[0].Parameters) != 1 {
+		t.Fatalf("AEAD.Lazy.encrypt#5 parameters = %#v, want the trailing method parameter", aeadEncrypt)
+	}
+	p := aeadEncrypt[0].Parameters[0]
+	if p.Index == nil || *p.Index != 4 || p.Role != "operation-determining" ||
+		p.Contributes == nil || p.Contributes.Property != "algorithm" {
+		t.Fatalf("AEAD.Lazy.encrypt#5 parameters[0] = %#v, want index=4 operation-determining algorithm", p)
+	}
+
+	// LazySodiumJava must resolve to LazySodium, which declares the Lazy/Native
+	// interfaces the operations are authored on.
+	if parents := kb.Hierarchy["com.goterl.lazysodium.LazySodiumJava"]; len(parents) != 1 || parents[0] != "com.goterl.lazysodium.LazySodium" {
+		t.Fatalf("LazySodiumJava hierarchy = %v, want [LazySodium]", parents)
+	}
+	lazySodiumParents := kb.Hierarchy["com.goterl.lazysodium.LazySodium"]
+	for _, want := range []string{
+		"com.goterl.lazysodium.interfaces.AEAD.Lazy",
+		"com.goterl.lazysodium.interfaces.Box.Lazy",
+		"com.goterl.lazysodium.interfaces.GenericHash.Lazy",
+		"com.goterl.lazysodium.interfaces.PwHash.Lazy",
+		"com.goterl.lazysodium.interfaces.SecretBox.Lazy",
+		"com.goterl.lazysodium.interfaces.Sign.Lazy",
+	} {
+		if !slices.Contains(lazySodiumParents, want) {
+			t.Fatalf("LazySodium hierarchy = %v, missing %s", lazySodiumParents, want)
 		}
 	}
 }

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -1138,3 +1138,133 @@ func TestLoadEmbeddedJava_NaClBindingLifecycle(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadEmbeddedJava_SSHClientLifecycle verifies the Java SSH facade
+// contracts (scanoss/crypto-finder#201): jsch's JSch/Session/KeyPair/HostKey
+// surfaces and sshj's SSHClient/Config/KeyProvider/HostKeyVerifier surfaces. It
+// pins the rule anchors, the mandatory producer edges (jsch Session and KeyPair
+// have no public constructors), the algorithm-selection config calls, and the
+// key-provider and verifier hierarchies.
+func TestLoadEmbeddedJava_SSHClientLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+		lib    string
+	}{
+		// jsch rule anchors: JSch.<init>, KeyPair.genKeyPair, KeyPair.load, Session.setConfig.
+		{"com.jcraft.jsch.JSch.<init>", 0, "com.jcraft.jsch.JSch", "factory", "jsch"},
+		{"com.jcraft.jsch.KeyPair.genKeyPair", 2, "com.jcraft.jsch.KeyPair", "factory", "jsch"},
+		{"com.jcraft.jsch.KeyPair.genKeyPair", 3, "com.jcraft.jsch.KeyPair", "factory", "jsch"},
+		{"com.jcraft.jsch.KeyPair.load", 2, "com.jcraft.jsch.KeyPair", "factory", "jsch"},
+		{"com.jcraft.jsch.KeyPair.load", 3, "com.jcraft.jsch.KeyPair", "factory", "jsch"},
+		{"com.jcraft.jsch.Session.setConfig", 2, "void", "config", "jsch"},
+		// jsch: getSession is the only Session producer.
+		{"com.jcraft.jsch.JSch.getSession", 3, "com.jcraft.jsch.Session", "factory", "jsch"},
+		{"com.jcraft.jsch.JSch.setConfig", 2, "void", "config", "jsch"},
+		{"com.jcraft.jsch.JSch.setKnownHosts", 1, "void", "config", "jsch"},
+		{"com.jcraft.jsch.Session.connect", 0, "void", "operation", "jsch"},
+		{"com.jcraft.jsch.Session.getKexAlgorithm", 0, "java.lang.String", "output", "jsch"},
+		{"com.jcraft.jsch.Session.getHostKey", 0, "com.jcraft.jsch.HostKey", "output", "jsch"},
+		{"com.jcraft.jsch.KeyPair.getSignature", 1, "byte[]", "operation", "jsch"},
+		{"com.jcraft.jsch.KeyPair.getFingerPrint", 0, "java.lang.String", "output", "jsch"},
+		{"com.jcraft.jsch.KeyPair.writePrivateKey", 1, "void", "output", "jsch"},
+		{"com.jcraft.jsch.HostKeyRepository.check", 2, "int", "operation", "jsch"},
+		// HostKey.getFingerPrint only exists at arity 1 (it takes the JSch instance).
+		{"com.jcraft.jsch.HostKey.getFingerPrint", 1, "java.lang.String", "output", "jsch"},
+		// sshj rule anchor plus the connect/auth/key-loading lifecycle.
+		{"net.schmizz.sshj.SSHClient.<init>", 0, "net.schmizz.sshj.SSHClient", "factory", "sshj"},
+		{"net.schmizz.sshj.SSHClient.<init>", 1, "net.schmizz.sshj.SSHClient", "factory", "sshj"},
+		{"net.schmizz.sshj.SocketClient.connect", 2, "void", "operation", "sshj"},
+		{"net.schmizz.sshj.SSHClient.addHostKeyVerifier", 1, "void", "config", "sshj"},
+		{"net.schmizz.sshj.SSHClient.authPassword", 2, "void", "operation", "sshj"},
+		{"net.schmizz.sshj.SSHClient.authPublickey", 2, "void", "operation", "sshj"},
+		{"net.schmizz.sshj.SSHClient.loadKeys", 2, "net.schmizz.sshj.userauth.keyprovider.KeyProvider", "factory", "sshj"},
+		{"net.schmizz.sshj.SSHClient.getTransport", 0, "net.schmizz.sshj.transport.Transport", "output", "sshj"},
+		// sshj algorithm selection lives on Config; there is no
+		// setSignatureFactories — setKeyAlgorithms is the signature selector.
+		{"net.schmizz.sshj.DefaultConfig.<init>", 0, "net.schmizz.sshj.DefaultConfig", "factory", "sshj"},
+		{"net.schmizz.sshj.Config.setCipherFactories", 1, "void", "config", "sshj"},
+		{"net.schmizz.sshj.Config.setKeyExchangeFactories", 1, "void", "config", "sshj"},
+		{"net.schmizz.sshj.Config.setKeyAlgorithms", 1, "void", "config", "sshj"},
+		{"net.schmizz.sshj.ConfigImpl.prioritizeSshRsaKeyAlgorithm", 0, "void", "config", "sshj"},
+		// sshj key providers and verifiers.
+		{"net.schmizz.sshj.userauth.keyprovider.KeyProvider.getPrivate", 0, "java.security.PrivateKey", "output", "sshj"},
+		{"net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile.<init>", 0, "net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile", "factory", "sshj"},
+		{"net.schmizz.sshj.userauth.keyprovider.FileKeyProvider.init", 2, "void", "config", "sshj"},
+		{"net.schmizz.sshj.transport.verification.HostKeyVerifier.verify", 3, "boolean", "operation", "sshj"},
+		{"net.schmizz.sshj.transport.verification.PromiscuousVerifier.<init>", 0, "net.schmizz.sshj.transport.verification.PromiscuousVerifier", "factory", "sshj"},
+		{"net.schmizz.sshj.transport.verification.FingerprintVerifier.getInstance", 1, "net.schmizz.sshj.transport.verification.HostKeyVerifier", "factory", "sshj"},
+		{"net.schmizz.sshj.transport.Transport.getSessionID", 0, "byte[]", "output", "sshj"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != tt.lib {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from %q", tt.method, tt.arity, got[0], tt.want, tt.role, tt.lib)
+			}
+		})
+	}
+
+	// jsch KeyPair subclasses are all package-private, so the algorithm can only
+	// come from the int type argument of genKeyPair — it must be
+	// operation-determining, with the key size as metadata.
+	genKeyPair := kb.ContractsFor("com.jcraft.jsch.KeyPair.genKeyPair", 3)
+	if len(genKeyPair) != 1 || len(genKeyPair[0].Parameters) != 2 {
+		t.Fatalf("KeyPair.genKeyPair#3 parameters = %#v, want type and key_size roles", genKeyPair)
+	}
+	byIndex := map[int]contracts.ParameterContract{}
+	for _, p := range genKeyPair[0].Parameters {
+		if p.Index != nil {
+			byIndex[*p.Index] = p
+		}
+	}
+	if p, ok := byIndex[1]; !ok || p.Role != "operation-determining" || p.Contributes == nil || p.Contributes.Property != "keyType" {
+		t.Fatalf("KeyPair.genKeyPair#3 parameters[1] = %#v, want operation-determining keyType", byIndex[1])
+	}
+	if p, ok := byIndex[2]; !ok || p.Role != "metadata-contributing" || p.Contributes == nil || p.Contributes.Property != "keySize" {
+		t.Fatalf("KeyPair.genKeyPair#3 parameters[2] = %#v, want metadata-contributing keySize", byIndex[2])
+	}
+
+	// Both libraries' setConfig-style algorithm selection must expose the config
+	// key as operation-determining and the value as the algorithm list.
+	for _, method := range []string{"com.jcraft.jsch.JSch.setConfig", "com.jcraft.jsch.Session.setConfig"} {
+		got := kb.ContractsFor(method, 2)
+		if len(got) != 1 || len(got[0].Parameters) != 2 {
+			t.Fatalf("%s#2 parameters = %#v, want key and value roles", method, got)
+		}
+		if got[0].Parameters[0].Role != "operation-determining" || got[0].Parameters[1].Contributes == nil ||
+			got[0].Parameters[1].Contributes.Property != "algorithm" {
+			t.Fatalf("%s#2 parameters = %#v, want operation-determining key + algorithm value", method, got[0].Parameters)
+		}
+	}
+
+	// Provider and verifier hierarchies: OpenSSHKeyFile extends PKCS8KeyFile
+	// (not BaseFileKeyProvider directly), and SSHClient inherits connect from
+	// SocketClient.
+	hierarchyWants := map[string]string{
+		"net.schmizz.sshj.SSHClient":                                        "net.schmizz.sshj.SocketClient",
+		"net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile":              "net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile",
+		"net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile":                "net.schmizz.sshj.userauth.keyprovider.BaseFileKeyProvider",
+		"net.schmizz.sshj.transport.verification.PromiscuousVerifier":       "net.schmizz.sshj.transport.verification.HostKeyVerifier",
+		"net.schmizz.sshj.transport.verification.ConsoleKnownHostsVerifier": "net.schmizz.sshj.transport.verification.OpenSSHKnownHosts",
+		"net.schmizz.sshj.DefaultConfig":                                    "net.schmizz.sshj.ConfigImpl",
+	}
+	for child, wantParent := range hierarchyWants {
+		if parents := kb.Hierarchy[child]; len(parents) == 0 || parents[0] != wantParent {
+			t.Fatalf("%s hierarchy = %v, want first parent %s", child, kb.Hierarchy[child], wantParent)
+		}
+	}
+}

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -1384,3 +1384,161 @@ func TestLoadEmbeddedJava_OkHttpTLSLifecycle(t *testing.T) {
 		t.Fatalf("CipherSuite hierarchy = %v, want [java.lang.Object]", parents)
 	}
 }
+
+// TestLoadEmbeddedJava_CloudKmsAndVaultLifecycle verifies the Java KMS/HSM SDK
+// facade contracts (scanoss/crypto-finder#206): AWS KMS across BOTH SDK
+// generations, GCP KMS, Azure Key Vault Keys, and the HashiCorp vault-java-driver.
+// It pins the rule anchors, the remote crypto operations and their response
+// material, the algorithm-selecting parameters, and the coordinate-hygiene fact
+// that the two AWS generations live in disjoint packages under one KB.
+func TestLoadEmbeddedJava_CloudKmsAndVaultLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+		lib    string
+	}{
+		// AWS SDK v2 (software.amazon.awssdk) — rule anchors KmsClient.create /
+		// builder and the *Request.builder factories.
+		{"software.amazon.awssdk.services.kms.KmsClient.create", 0, "software.amazon.awssdk.services.kms.KmsClient", "factory", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.KmsClient.builder", 0, "software.amazon.awssdk.services.kms.KmsClientBuilder", "factory", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.KmsClient.encrypt", 1, "software.amazon.awssdk.services.kms.model.EncryptResponse", "operation", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.KmsClient.decrypt", 1, "software.amazon.awssdk.services.kms.model.DecryptResponse", "operation", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.KmsClient.sign", 1, "software.amazon.awssdk.services.kms.model.SignResponse", "operation", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.KmsClient.generateDataKey", 1, "software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse", "factory", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.KmsClient.generateRandom", 0, "software.amazon.awssdk.services.kms.model.GenerateRandomResponse", "operation", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.model.EncryptRequest.builder", 0, "software.amazon.awssdk.services.kms.model.EncryptRequest.Builder", "factory", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.model.SignRequest.builder", 0, "software.amazon.awssdk.services.kms.model.SignRequest.Builder", "factory", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.model.EncryptResponse.ciphertextBlob", 0, "software.amazon.awssdk.core.SdkBytes", "output", "aws-kms"},
+		// v2's data-key plaintext accessor is plaintext(), not plaintextKey().
+		{"software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse.plaintext", 0, "software.amazon.awssdk.core.SdkBytes", "output", "aws-kms"},
+		// AWS SDK v1 (com.amazonaws) — disjoint package, same KB.
+		{"com.amazonaws.services.kms.AWSKMSClientBuilder.standard", 0, "com.amazonaws.services.kms.AWSKMSClientBuilder", "factory", "aws-kms"},
+		{"com.amazonaws.services.kms.AWSKMSClientBuilder.defaultClient", 0, "com.amazonaws.services.kms.AWSKMS", "factory", "aws-kms"},
+		{"com.amazonaws.services.kms.AWSKMS.encrypt", 1, "com.amazonaws.services.kms.model.EncryptResult", "operation", "aws-kms"},
+		{"com.amazonaws.services.kms.model.EncryptRequest.<init>", 0, "com.amazonaws.services.kms.model.EncryptRequest", "factory", "aws-kms"},
+		{"com.amazonaws.services.kms.model.EncryptRequest.withPlaintext", 1, "com.amazonaws.services.kms.model.EncryptRequest", "config", "aws-kms"},
+		// v1 returns java.nio.ByteBuffer where v2 returns SdkBytes.
+		{"com.amazonaws.services.kms.model.EncryptResult.getCiphertextBlob", 0, "java.nio.ByteBuffer", "output", "aws-kms"},
+		// GCP KMS — rule anchors KeyManagementServiceClient.create and *Request.newBuilder.
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.create", 0, "com.google.cloud.kms.v1.KeyManagementServiceClient", "factory", "gcp-kms"},
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.encrypt", 1, "com.google.cloud.kms.v1.EncryptResponse", "operation", "gcp-kms"},
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.encrypt", 2, "com.google.cloud.kms.v1.EncryptResponse", "operation", "gcp-kms"},
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.asymmetricSign", 1, "com.google.cloud.kms.v1.AsymmetricSignResponse", "operation", "gcp-kms"},
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.macSign", 1, "com.google.cloud.kms.v1.MacSignResponse", "operation", "gcp-kms"},
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.generateRandomBytes", 3, "com.google.cloud.kms.v1.GenerateRandomBytesResponse", "operation", "gcp-kms"},
+		{"com.google.cloud.kms.v1.KeyManagementServiceClient.createCryptoKey", 1, "com.google.cloud.kms.v1.CryptoKey", "factory", "gcp-kms"},
+		{"com.google.cloud.kms.v1.EncryptRequest.newBuilder", 0, "com.google.cloud.kms.v1.EncryptRequest.Builder", "factory", "gcp-kms"},
+		{"com.google.cloud.kms.v1.AsymmetricSignRequest.newBuilder", 0, "com.google.cloud.kms.v1.AsymmetricSignRequest.Builder", "factory", "gcp-kms"},
+		{"com.google.cloud.kms.v1.EncryptResponse.getCiphertext", 0, "com.google.protobuf.ByteString", "output", "gcp-kms"},
+		// The algorithm is on CryptoKeyVersion/PublicKey, not on CryptoKey.
+		{"com.google.cloud.kms.v1.CryptoKeyVersion.getAlgorithm", 0, "com.google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionAlgorithm", "output", "gcp-kms"},
+		{"com.google.cloud.kms.v1.PublicKey.getPem", 0, "java.lang.String", "output", "gcp-kms"},
+		// Azure Key Vault — rule anchors new CryptographyClientBuilder() / new KeyClientBuilder().
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.<init>", 0, "com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder", "factory", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder.buildClient", 0, "com.azure.security.keyvault.keys.cryptography.CryptographyClient", "factory", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClient.encrypt", 2, "com.azure.security.keyvault.keys.cryptography.models.EncryptResult", "operation", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClient.sign", 2, "com.azure.security.keyvault.keys.cryptography.models.SignResult", "operation", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClient.verify", 3, "com.azure.security.keyvault.keys.cryptography.models.VerifyResult", "operation", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClient.wrapKey", 2, "com.azure.security.keyvault.keys.cryptography.models.WrapResult", "operation", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.KeyClientBuilder.<init>", 0, "com.azure.security.keyvault.keys.KeyClientBuilder", "factory", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.KeyClient.createRsaKey", 1, "com.azure.security.keyvault.keys.models.KeyVaultKey", "factory", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.KeyClient.backupKey", 1, "byte[]", "output", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.models.EncryptResult.getCipherText", 0, "byte[]", "output", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm.fromString", 1, "com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm", "factory", "azure-keyvault-keys-java"},
+		// vault-java-driver — rule anchors new Vault(...) / new VaultConfig().
+		{"com.bettercloud.vault.Vault.<init>", 1, "com.bettercloud.vault.Vault", "factory", "vault-java-driver"},
+		{"com.bettercloud.vault.VaultConfig.<init>", 0, "com.bettercloud.vault.VaultConfig", "factory", "vault-java-driver"},
+		{"com.bettercloud.vault.VaultConfig.token", 1, "com.bettercloud.vault.VaultConfig", "config", "vault-java-driver"},
+		{"com.bettercloud.vault.VaultConfig.sslConfig", 1, "com.bettercloud.vault.VaultConfig", "config", "vault-java-driver"},
+		{"com.bettercloud.vault.SslConfig.verify", 1, "com.bettercloud.vault.SslConfig", "config", "vault-java-driver"},
+		{"com.bettercloud.vault.SslConfig.getSslContext", 0, "javax.net.ssl.SSLContext", "output", "vault-java-driver"},
+		{"com.bettercloud.vault.Vault.logical", 0, "com.bettercloud.vault.api.Logical", "factory", "vault-java-driver"},
+		{"com.bettercloud.vault.Vault.pki", 0, "com.bettercloud.vault.api.pki.Pki", "factory", "vault-java-driver"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != tt.lib {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from %q", tt.method, tt.arity, got[0], tt.want, tt.role, tt.lib)
+			}
+		})
+	}
+
+	// Coordinate hygiene: the two AWS SDK generations live in disjoint packages
+	// (software.amazon.awssdk vs com.amazonaws) but are served by one KB, so
+	// both namespaces must report the same source library. The table above
+	// already asserts the operations; this pins the pairing explicitly so a
+	// future split into two KBs cannot pass silently.
+	v2Encrypt := kb.ContractsFor("software.amazon.awssdk.services.kms.KmsClient.encrypt", 1)
+	v1Encrypt := kb.ContractsFor("com.amazonaws.services.kms.AWSKMS.encrypt", 1)
+	if len(v2Encrypt) != 1 || len(v1Encrypt) != 1 {
+		t.Fatalf("AWS encrypt contracts: v2=%d v1=%d, want 1 each", len(v2Encrypt), len(v1Encrypt))
+	}
+	if v2Encrypt[0].SourceLibrary != v1Encrypt[0].SourceLibrary {
+		t.Fatalf("AWS v2 library %q != v1 library %q, want one KB covering both SDK generations",
+			v2Encrypt[0].SourceLibrary, v1Encrypt[0].SourceLibrary)
+	}
+	// The two generations must not be conflated: their response types differ
+	// (SdkBytes vs java.nio.ByteBuffer for the same logical material).
+	if v2Encrypt[0].Return.Type == v1Encrypt[0].Return.Type {
+		t.Fatalf("AWS v2 and v1 encrypt both return %q, want the generation-specific response types", v2Encrypt[0].Return.Type)
+	}
+
+	// Algorithm-selecting arguments must be operation-determining across all
+	// three cloud SDKs, so a consumer can attribute the remote algorithm.
+	selectors := []struct {
+		method string
+		arity  int
+		index  int
+	}{
+		{"software.amazon.awssdk.services.kms.model.EncryptRequest.Builder.encryptionAlgorithm", 1, 0},
+		{"software.amazon.awssdk.services.kms.model.SignRequest.Builder.signingAlgorithm", 1, 0},
+		{"com.amazonaws.services.kms.model.EncryptRequest.withEncryptionAlgorithm", 1, 0},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyClient.sign", 2, 0},
+		{"com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm.fromString", 1, 0},
+	}
+	for _, s := range selectors {
+		got := kb.ContractsFor(s.method, s.arity)
+		if len(got) != 1 || len(got[0].Parameters) == 0 {
+			t.Fatalf("%s#%d parameters = %#v, want an algorithm selector role", s.method, s.arity, got)
+		}
+		var found bool
+		for _, p := range got[0].Parameters {
+			if p.Index == nil || *p.Index != s.index {
+				continue
+			}
+			found = true
+			if p.Role != "operation-determining" || p.Contributes == nil || p.Contributes.Property != "algorithm" {
+				t.Fatalf("%s#%d parameters[%d] = %#v, want operation-determining algorithm", s.method, s.arity, s.index, p)
+			}
+		}
+		if !found {
+			t.Fatalf("%s#%d has no parameter role at index %d", s.method, s.arity, s.index)
+		}
+	}
+
+	// Azure's algorithm selectors are ExpandableStringEnum, not java.lang.Enum,
+	// so fromString accepts names beyond the declared constants.
+	for _, typ := range []string{
+		"com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm",
+		"com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm",
+		"com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm",
+	} {
+		if parents := kb.Hierarchy[typ]; len(parents) != 1 || parents[0] != "com.azure.core.util.ExpandableStringEnum" {
+			t.Fatalf("%s hierarchy = %v, want [ExpandableStringEnum]", typ, kb.Hierarchy[typ])
+		}
+	}
+}

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -885,3 +885,131 @@ func TestLoadEmbeddedJava_HutoolEddsaPgpainlessLifecycle(t *testing.T) {
 		t.Fatalf("AES.<init>#1 parameters[0] = %#v, want index=0 keySize/argument_bit_length", p)
 	}
 }
+
+// TestLoadEmbeddedJava_PasswordHasherLifecycle verifies the Java password/KDF
+// facade contracts (scanoss/crypto-finder#202): jbcrypt, favre-bcrypt,
+// lambdaworks-scrypt, argon2-jvm, and jasypt. It pins the rule-anchor methods,
+// the hash/verify entry points and their return types, the lifecycle roles, and
+// the cost/iteration parameter roles that carry the KDF work factors.
+func TestLoadEmbeddedJava_PasswordHasherLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+		lib    string
+	}{
+		// jbcrypt — the FQN is the one shipped in the org.mindrot:jbcrypt jar.
+		{"org.mindrot.jbcrypt.BCrypt.hashpw", 2, "java.lang.String", "operation", "jbcrypt"},
+		{"org.mindrot.jbcrypt.BCrypt.checkpw", 2, "boolean", "operation", "jbcrypt"},
+		{"org.mindrot.jbcrypt.BCrypt.gensalt", 0, "java.lang.String", "factory", "jbcrypt"},
+		{"org.mindrot.jbcrypt.BCrypt.gensalt", 1, "java.lang.String", "factory", "jbcrypt"},
+		// favre-bcrypt — fluent hasher/verifyer; verify returns Result, not boolean.
+		{"at.favre.lib.crypto.bcrypt.BCrypt.withDefaults", 0, "at.favre.lib.crypto.bcrypt.BCrypt.Hasher", "factory", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.with", 1, "at.favre.lib.crypto.bcrypt.BCrypt.Hasher", "factory", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.verifyer", 0, "at.favre.lib.crypto.bcrypt.BCrypt.Verifyer", "factory", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hashToString", 2, "java.lang.String", "operation", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hashToChar", 2, "char[]", "operation", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hash", 2, "byte[]", "operation", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.Verifyer.verify", 2, "at.favre.lib.crypto.bcrypt.BCrypt.Result", "operation", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.Verifyer.verifyStrict", 2, "at.favre.lib.crypto.bcrypt.BCrypt.Result", "operation", "favre-bcrypt"},
+		{"at.favre.lib.crypto.bcrypt.LongPasswordStrategies.hashSha512", 1, "at.favre.lib.crypto.bcrypt.LongPasswordStrategy", "factory", "favre-bcrypt"},
+		// lambdaworks-scrypt — KDF core plus the MCF password facade.
+		{"com.lambdaworks.crypto.SCrypt.scrypt", 6, "byte[]", "operation", "lambdaworks-scrypt"},
+		{"com.lambdaworks.crypto.SCrypt.scryptJ", 6, "byte[]", "operation", "lambdaworks-scrypt"},
+		{"com.lambdaworks.crypto.SCryptUtil.scrypt", 4, "java.lang.String", "operation", "lambdaworks-scrypt"},
+		{"com.lambdaworks.crypto.SCryptUtil.check", 2, "boolean", "operation", "lambdaworks-scrypt"},
+		// argon2-jvm — create vs createAdvanced differ only by declared return.
+		{"de.mkammerer.argon2.Argon2Factory.create", 0, "de.mkammerer.argon2.Argon2", "factory", "argon2-jvm"},
+		{"de.mkammerer.argon2.Argon2Factory.create", 1, "de.mkammerer.argon2.Argon2", "factory", "argon2-jvm"},
+		{"de.mkammerer.argon2.Argon2Factory.createAdvanced", 0, "de.mkammerer.argon2.Argon2Advanced", "factory", "argon2-jvm"},
+		{"de.mkammerer.argon2.Argon2.hash", 4, "java.lang.String", "operation", "argon2-jvm"},
+		{"de.mkammerer.argon2.Argon2.verify", 2, "boolean", "operation", "argon2-jvm"},
+		{"de.mkammerer.argon2.Argon2Advanced.rawHash", 5, "byte[]", "operation", "argon2-jvm"},
+		{"de.mkammerer.argon2.Argon2Advanced.generateSalt", 0, "byte[]", "factory", "argon2-jvm"},
+		// jasypt — util facades, PBE engines, and standard digesters.
+		{"org.jasypt.util.password.StrongPasswordEncryptor.<init>", 0, "org.jasypt.util.password.StrongPasswordEncryptor", "factory", "jasypt"},
+		{"org.jasypt.util.password.PasswordEncryptor.encryptPassword", 1, "java.lang.String", "operation", "jasypt"},
+		{"org.jasypt.util.password.PasswordEncryptor.checkPassword", 2, "boolean", "operation", "jasypt"},
+		{"org.jasypt.util.text.BasicTextEncryptor.<init>", 0, "org.jasypt.util.text.BasicTextEncryptor", "factory", "jasypt"},
+		{"org.jasypt.util.text.TextEncryptor.encrypt", 1, "java.lang.String", "operation", "jasypt"},
+		{"org.jasypt.util.binary.BinaryEncryptor.encrypt", 1, "byte[]", "operation", "jasypt"},
+		{"org.jasypt.encryption.pbe.StandardPBEStringEncryptor.<init>", 0, "org.jasypt.encryption.pbe.StandardPBEStringEncryptor", "factory", "jasypt"},
+		{"org.jasypt.encryption.pbe.StandardPBEStringEncryptor.encrypt", 1, "java.lang.String", "operation", "jasypt"},
+		{"org.jasypt.encryption.pbe.StandardPBEByteEncryptor.encrypt", 1, "byte[]", "operation", "jasypt"},
+		{"org.jasypt.digest.StandardStringDigester.digest", 1, "java.lang.String", "operation", "jasypt"},
+		{"org.jasypt.digest.StandardByteDigester.digest", 1, "byte[]", "operation", "jasypt"},
+		{"org.jasypt.util.digest.Digester.digest", 1, "byte[]", "operation", "jasypt"},
+		{"org.jasypt.salt.RandomSaltGenerator.<init>", 0, "org.jasypt.salt.RandomSaltGenerator", "factory", "jasypt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != tt.lib {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from %q", tt.method, tt.arity, got[0], tt.want, tt.role, tt.lib)
+			}
+		})
+	}
+
+	// Work-factor parameter roles: bcrypt cost, scrypt N/r/p, and the jasypt PBE
+	// key-obtention iteration count must all reach the consumer.
+	workFactors := []struct {
+		method     string
+		arity      int
+		index      int
+		property   string
+		derivation string
+	}{
+		{"org.mindrot.jbcrypt.BCrypt.gensalt", 1, 0, "cost", "argument_value"},
+		{"at.favre.lib.crypto.bcrypt.BCrypt.Hasher.hashToString", 2, 0, "cost", "argument_value"},
+		{"com.lambdaworks.crypto.SCryptUtil.scrypt", 4, 1, "cost", "argument_value"},
+		{"de.mkammerer.argon2.Argon2.hash", 4, 0, "iterations", "argument_value"},
+		{"org.jasypt.encryption.pbe.StandardPBEStringEncryptor.setKeyObtentionIterations", 1, 0, "iterations", "argument_value"},
+		{"org.jasypt.digest.StandardStringDigester.setIterations", 1, 0, "iterations", "argument_value"},
+	}
+	for _, wf := range workFactors {
+		got := kb.ContractsFor(wf.method, wf.arity)
+		if len(got) != 1 || len(got[0].Parameters) == 0 {
+			t.Fatalf("%s#%d parameters = %#v, want at least one parameter role", wf.method, wf.arity, got)
+		}
+		var found bool
+		for _, p := range got[0].Parameters {
+			if p.Index == nil || *p.Index != wf.index {
+				continue
+			}
+			found = true
+			if p.Role != "metadata-contributing" || p.Contributes == nil ||
+				p.Contributes.Property != wf.property || p.Contributes.Derivation != wf.derivation {
+				t.Fatalf("%s#%d parameters[%d] = %#v, want %s/%s", wf.method, wf.arity, wf.index, p, wf.property, wf.derivation)
+			}
+		}
+		if !found {
+			t.Fatalf("%s#%d has no parameter role at index %d", wf.method, wf.arity, wf.index)
+		}
+	}
+
+	// Concrete facades must resolve to the interfaces the operations are
+	// authored on, and Argon2Advanced must extend Argon2.
+	hierarchyWants := map[string]string{
+		"org.jasypt.util.password.StrongPasswordEncryptor": "org.jasypt.util.password.PasswordEncryptor",
+		"org.jasypt.util.text.BasicTextEncryptor":          "org.jasypt.util.text.TextEncryptor",
+		"org.jasypt.util.binary.BasicBinaryEncryptor":      "org.jasypt.util.binary.BinaryEncryptor",
+		"de.mkammerer.argon2.Argon2Advanced":               "de.mkammerer.argon2.Argon2",
+	}
+	for child, wantParent := range hierarchyWants {
+		if parents := kb.Hierarchy[child]; len(parents) == 0 || parents[0] != wantParent {
+			t.Fatalf("%s hierarchy = %v, want first parent %s", child, kb.Hierarchy[child], wantParent)
+		}
+	}
+}

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -1268,3 +1268,119 @@ func TestLoadEmbeddedJava_SSHClientLifecycle(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadEmbeddedJava_OkHttpTLSLifecycle verifies the OkHttp TLS contracts
+// (scanoss/crypto-finder#204): certificate pinning, connection-spec cipher and
+// TLS-version selection, handshake inspection, the TLS-only slice of
+// OkHttpClient.Builder, and the okhttp-tls certificate helpers. It also pins the
+// Kotlin-specific shapes that a naive KB would get wrong: @get:JvmName
+// accessors are x() not getX(), varargs occupy one parameter slot, and
+// ConnectionSpec.Builder has no no-arg constructor.
+func TestLoadEmbeddedJava_OkHttpTLSLifecycle(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("java")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(java): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   string
+		role   string
+	}{
+		// Rule anchors: CertificatePinner.Builder.add, ConnectionSpec,
+		// ConnectionSpec.Builder.cipherSuites, TlsVersion.
+		{"okhttp3.CertificatePinner.Builder.add", 2, "okhttp3.CertificatePinner.Builder", "config"},
+		{"okhttp3.CertificatePinner.Builder.build", 0, "okhttp3.CertificatePinner", "factory"},
+		{"okhttp3.CertificatePinner.pin", 1, "java.lang.String", "output"},
+		{"okhttp3.CertificatePinner.sha256Hash", 1, "okio.ByteString", "operation"},
+		{"okhttp3.ConnectionSpec.Builder.cipherSuites", 1, "okhttp3.ConnectionSpec.Builder", "config"},
+		{"okhttp3.ConnectionSpec.Builder.tlsVersions", 1, "okhttp3.ConnectionSpec.Builder", "config"},
+		{"okhttp3.ConnectionSpec.Builder.build", 0, "okhttp3.ConnectionSpec", "factory"},
+		{"okhttp3.ConnectionSpec.isCompatible", 1, "boolean", "operation"},
+		{"okhttp3.TlsVersion.forJavaName", 1, "okhttp3.TlsVersion", "factory"},
+		{"okhttp3.CipherSuite.forJavaName", 1, "okhttp3.CipherSuite", "factory"},
+		// Client TLS configuration.
+		{"okhttp3.OkHttpClient.Builder.sslSocketFactory", 2, "okhttp3.OkHttpClient.Builder", "config"},
+		{"okhttp3.OkHttpClient.Builder.hostnameVerifier", 1, "okhttp3.OkHttpClient.Builder", "config"},
+		{"okhttp3.OkHttpClient.Builder.certificatePinner", 1, "okhttp3.OkHttpClient.Builder", "config"},
+		{"okhttp3.OkHttpClient.Builder.connectionSpecs", 1, "okhttp3.OkHttpClient.Builder", "config"},
+		{"okhttp3.OkHttpClient.Builder.build", 0, "okhttp3.OkHttpClient", "factory"},
+		{"okhttp3.OkHttpClient.x509TrustManager", 0, "javax.net.ssl.X509TrustManager", "output"},
+		// Handshake results.
+		{"okhttp3.Handshake.get", 1, "okhttp3.Handshake", "factory"},
+		{"okhttp3.Handshake.tlsVersion", 0, "okhttp3.TlsVersion", "output"},
+		{"okhttp3.Handshake.cipherSuite", 0, "okhttp3.CipherSuite", "output"},
+		// okhttp-tls certificate generation.
+		{"okhttp3.tls.HeldCertificate.Builder.ecdsa256", 0, "okhttp3.tls.HeldCertificate.Builder", "config"},
+		{"okhttp3.tls.HeldCertificate.Builder.rsa2048", 0, "okhttp3.tls.HeldCertificate.Builder", "config"},
+		{"okhttp3.tls.HeldCertificate.Builder.signedBy", 1, "okhttp3.tls.HeldCertificate.Builder", "config"},
+		{"okhttp3.tls.HeldCertificate.Builder.build", 0, "okhttp3.tls.HeldCertificate", "operation"},
+		{"okhttp3.tls.HeldCertificate.privateKeyPkcs8Pem", 0, "java.lang.String", "output"},
+		{"okhttp3.tls.HandshakeCertificates.Builder.addInsecureHost", 1, "okhttp3.tls.HandshakeCertificates.Builder", "config"},
+		{"okhttp3.tls.HandshakeCertificates.sslContext", 0, "javax.net.ssl.SSLContext", "operation"},
+		{"okhttp3.tls.Certificates.decodeCertificatePem", 1, "java.security.cert.X509Certificate", "factory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].Return.Type != tt.want || got[0].Role != tt.role || got[0].SourceLibrary != "okhttp-tls" {
+				t.Fatalf("%s#%d = %#v, want return %q with role %q from okhttp-tls", tt.method, tt.arity, got[0], tt.want, tt.role)
+			}
+		})
+	}
+
+	// Kotlin @get:JvmName means the Java-visible accessors are cipherSuites()
+	// and tlsVersions(), never getCipherSuites()/getTlsVersions().
+	for _, method := range []string{"okhttp3.ConnectionSpec.cipherSuites", "okhttp3.ConnectionSpec.tlsVersions"} {
+		if got := kb.ContractsFor(method, 0); len(got) != 1 || got[0].Return.Type != "java.util.List" {
+			t.Fatalf("%s#0 = %#v, want java.util.List", method, got)
+		}
+	}
+	for _, absent := range []string{"okhttp3.ConnectionSpec.getCipherSuites", "okhttp3.ConnectionSpec.getTlsVersions"} {
+		if got := kb.ContractsFor(absent, 0); len(got) != 0 {
+			t.Fatalf("%s#0 = %#v, want no contract (Kotlin @get:JvmName renames it)", absent, got)
+		}
+	}
+
+	// ConnectionSpec.Builder is only constructible from a base spec — a no-arg
+	// form does not exist and must not be contracted.
+	if got := kb.ContractsFor("okhttp3.ConnectionSpec.Builder.<init>", 1); len(got) != 1 {
+		t.Fatalf("ConnectionSpec.Builder.<init>#1 contracts = %d, want 1", len(got))
+	}
+	if got := kb.ContractsFor("okhttp3.ConnectionSpec.Builder.<init>", 0); len(got) != 0 {
+		t.Fatalf("ConnectionSpec.Builder.<init>#0 = %#v, want no contract (no no-arg ctor exists)", got)
+	}
+
+	// Cipher-suite and TLS-version selection is operation-determining: it picks
+	// the algorithms rather than describing them.
+	selectors := map[string]string{
+		"okhttp3.ConnectionSpec.Builder.cipherSuites": "cipher",
+		"okhttp3.ConnectionSpec.Builder.tlsVersions":  "protocolVersion",
+	}
+	for method, property := range selectors {
+		got := kb.ContractsFor(method, 1)
+		if len(got) != 1 || len(got[0].Parameters) != 1 {
+			t.Fatalf("%s#1 parameters = %#v, want one selector parameter", method, got)
+		}
+		p := got[0].Parameters[0]
+		if p.Role != "operation-determining" || p.Contributes == nil || p.Contributes.Property != property {
+			t.Fatalf("%s#1 parameters[0] = %#v, want operation-determining %s", method, p, property)
+		}
+	}
+
+	// TlsVersion is an enum; CipherSuite deliberately is not (it interns
+	// instances through forJavaName).
+	if parents := kb.Hierarchy["okhttp3.TlsVersion"]; len(parents) != 1 || parents[0] != "java.lang.Enum" {
+		t.Fatalf("TlsVersion hierarchy = %v, want [java.lang.Enum]", parents)
+	}
+	if parents := kb.Hierarchy["okhttp3.CipherSuite"]; len(parents) != 1 || parents[0] != "java.lang.Object" {
+		t.Fatalf("CipherSuite hierarchy = %v, want [java.lang.Object]", parents)
+	}
+}

--- a/internal/callgraph/contracts/java_libraries_test.go
+++ b/internal/callgraph/contracts/java_libraries_test.go
@@ -1463,6 +1463,20 @@ func TestLoadEmbeddedJava_CloudKmsAndVaultLifecycle(t *testing.T) {
 		{"com.bettercloud.vault.SslConfig.getSslContext", 0, "javax.net.ssl.SSLContext", "output", "vault-java-driver"},
 		{"com.bettercloud.vault.Vault.logical", 0, "com.bettercloud.vault.api.Logical", "factory", "vault-java-driver"},
 		{"com.bettercloud.vault.Vault.pki", 0, "com.bettercloud.vault.api.pki.Pki", "factory", "vault-java-driver"},
+		// Gaps found by validating against real third-party code: the AWS v2
+		// DecryptRequest builder, the AWS v1 bean setters that AWS's own samples
+		// prefer, the Azure async clients used by 8 of 21 Azure samples, and the
+		// Vault Logical methods where the remote crypto actually happens.
+		{"software.amazon.awssdk.services.kms.model.DecryptRequest.Builder.ciphertextBlob", 1, "software.amazon.awssdk.services.kms.model.DecryptRequest.Builder", "config", "aws-kms"},
+		{"software.amazon.awssdk.services.kms.model.DecryptRequest.Builder.build", 0, "software.amazon.awssdk.services.kms.model.DecryptRequest", "factory", "aws-kms"},
+		{"com.amazonaws.services.kms.model.EncryptRequest.setKeyId", 1, "void", "config", "aws-kms"},
+		{"com.amazonaws.services.kms.model.GenerateDataKeyRequest.setKeySpec", 1, "void", "config", "aws-kms"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.encrypt", 2, "reactor.core.publisher.Mono", "operation", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient.sign", 2, "reactor.core.publisher.Mono", "operation", "azure-keyvault-keys-java"},
+		{"com.azure.security.keyvault.keys.KeyAsyncClient.createRsaKey", 1, "reactor.core.publisher.Mono", "factory", "azure-keyvault-keys-java"},
+		{"com.bettercloud.vault.api.Logical.write", 2, "com.bettercloud.vault.response.LogicalResponse", "operation", "vault-java-driver"},
+		{"com.bettercloud.vault.api.Logical.read", 1, "com.bettercloud.vault.response.LogicalResponse", "operation", "vault-java-driver"},
+		{"com.bettercloud.vault.VaultConfig.openTimeout", 1, "com.bettercloud.vault.VaultConfig", "config", "vault-java-driver"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #202
Closes #205
Closes #201
Closes #204
Closes #206

Resolves the five `ready-for-agent` Java `contract-gap` issues, **one commit per issue** on this branch. Every signature was verified against a real artifact — upstream source at a pinned release, or `javap` over the published jar — never from memory or docs.

| Commit | Issue | New KBs |
|---|---|---|
| `5066157` | #202 password hashers | `jbcrypt`, `favre-bcrypt`, `lambdaworks-scrypt`, `argon2-jvm`, `jasypt` |
| `b979fc2` | #205 NaCl bindings | `lazysodium`, `kalium` |
| `f2a6ea7` | #201 SSH | `jsch`, `sshj` |
| `7a60051` | #204 okhttp TLS | `okhttp-tls` |
| `0bd0459` | #206 cloud KMS + Vault | `aws-kms`, `gcp-kms`, `azure-keyvault-keys-java`, `vault-java-driver` |

All rule anchors from `crypto_rules` are covered. Each KB's `version_range` states its verification anchor in a header comment.

## Findings that changed what got authored

These are the cases where reading the real artifact contradicted the obvious assumption. Each one would have produced dead or wrong contracts otherwise.

1. **jbcrypt's FQN differs between GitHub and Maven.** The `jeremyh/jBCrypt` tree declares `package org.mindrot` (it is a repackaged redistribution, per its own README), but the artifact consumers depend on ships the class at `org/mindrot/jbcrypt/BCrypt.class` — confirmed with `javap` over the Maven Central jar, and matching what the rules pattern on. The KB uses `org.mindrot.jbcrypt.BCrypt`.
2. **Three sshj APIs do not exist.** `setSignatureFactories`, `Transport.getServerKey`, and `SSHClient.verifyHostKey` have zero occurrences in the source. Signature algorithms are selected via `setKeyAlgorithms`; the remote key is observable through `HostKeyVerifier.verify`. Likewise jsch's `HostKey.getFingerPrint` exists only at arity 1 (it takes the `JSch` instance).
3. **favre-bcrypt verification returns an object, not a boolean.** All `verify`/`verifyStrict` overloads return `BCrypt.Result`; the boolean lives in `Result.verified`.
4. **OkHttp's Kotlin shapes.** `@get:JvmName` makes the Java accessors `cipherSuites()`/`tlsVersions()`, not `getCipherSuites()`/`getTlsVersions()`; varargs occupy one parameter slot; and `ConnectionSpec.Builder` has **no** no-arg constructor. The test asserts the `getX()` forms are absent so a future regression can't reintroduce them.
5. **AWS ships two live SDK generations.** Disjoint packages, disjoint response material (`SdkBytes` vs `java.nio.ByteBuffer`). Both are in one KB; contracting only v2 would miss real call sites since v1 is still widely pinned.
6. **GCP splits client and protos across artifacts.** `google-cloud-kms` carries only the client; every request/response/resource type lives in `proto-google-cloud-kms-v1`. Both coordinates are declared.
7. **Package-private implementations force interface-level authoring.** jsch's `KeyPair` subclasses, argon2-jvm's `Argon2i`/`d`/`id`, and lazysodium's concrete facade are unnameable at a call site, so contracts sit on the public interface/base and the algorithm comes from an argument (tagged `operation-determining`) rather than a return type.
8. **Two algorithm choices are not derivable from the call itself.** lazysodium's `AEAD.Lazy.encrypt` takes the algorithm as a trailing `AEAD.Method` enum, and kalium's `Aead.useAesGcm()` is a fluent link that switches the algorithm for every later `encrypt`/`decrypt` on the same receiver. Both are documented in the YAML instead of guessed; the precise attribution points are lazysodium's `AEAD.Native.cryptoAead<Family>*` names.

## Deliberate exclusions

- **Covariant bridge methods** that `javap` reports with differing return types at the same arity — AWS `overrideConfiguration` and `clone`, protobuf `build`, Azure trait setters — are omitted rather than resolved to a guessed return.
- **`com.lambdaworks.crypto.PBKDF.pbkdf2`** has two arity-5 overloads with genuinely **different declared returns** (`byte[]` vs `void`). A single method+arity contract cannot express that, so it is excluded and recorded as `needs-follow-up`.
- **Non-crypto HTTP surface** per #204: interceptors, timeouts, cache, dispatcher, cookies, DNS, proxy routing.
- **Non-crypto SSH surface**: channels, SFTP, port forwarding, X11.

Full per-library API audits with `contracted` / `covered-existing` / `skipped-*` / `needs-follow-up` dispositions are in each commit message and YAML header comments.

## Work factors and material reaching consumers

Parameter roles use existing property-name precedent (e.g. `property: "cost"` from `golang.org/x/crypto/bcrypt.GenerateFromPassword`): bcrypt `cost`, scrypt `cost`/`blockSize`/`parallelism`/`outputLength`, Argon2 and PBE `iterations`, libsodium `opslimit`/`memlimit`, `saltLength`, and key sizes by bit length.

## Test-support change

`char[]` was added to the hierarchy-reachability test's opaque-root set — a JVM primitive array in the same category as the already-exempt `byte[]`, appearing on password APIs that keep the secret out of an immutable `String` (`BCrypt.Hasher.hashToChar`). No production code changed.

## Testing

Five focused test functions, ~180 assertions total (return type + lifecycle role + source library per contract, plus parameter-role and hierarchy-resolution assertions):
`TestLoadEmbeddedJava_PasswordHasherLifecycle`, `_NaClBindingLifecycle`, `_SSHClientLifecycle`, `_OkHttpTLSLifecycle`, `_CloudKmsAndVaultLifecycle`.

`go build ./...`, `go test ./internal/callgraph/...` and `./internal/scan/...` green. The full suite's only failures are the pre-existing Docker-dependent Postgres testcontainers in `internal/engine`, identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Java API coverage for AWS and Google Cloud KMS, Azure Key Vault, Vault, OkHttp TLS, JSch, sshj, Lazysodium, Kalium, Argon2, bcrypt, Jasypt, and scrypt.
  * Added support for tracking cryptographic operations, authentication workflows, TLS configuration, SSH lifecycles, key management, and password-derived key operations.

* **Tests**
  * Added comprehensive validation for library contracts, return types, hierarchies, overloads, metadata, and lifecycle behavior.

* **Documentation**
  * Updated the unreleased changelog with the new Java contract coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->