### PR TITLE
docs(changelog): cut 0.19.0 release section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-14
+
 ### Changed
 - Replaced the generated DOCX/PDF Crypto Finder guide with a standalone interactive SCANOSS-branded HTML guide at `docs/user-guide/user-guide.html`.
 - Dependency-scanning container images now use digest-pinned base/tool images, exact package versions, and checksum-verified installer inputs; CI rejects unpinned tooling.


### PR DESCRIPTION
## What
Dates the accumulated `[Unreleased]` changelog entries as `## [0.19.0] - 2026-08-14`, leaving a fresh empty `[Unreleased]`. Only the version header and date are added — no entry content changes.

## Why
Prepares the changelog so the `v0.19.0` tag (minor bump from `v0.18.0`) ships a dated section. This release carries the Java callgraph fixes (annotation visibility, receiver/object-identity resolution, try-with-resources/anonymous-class call-chain restoration, cast lifecycle) and the OkHttp TLS + java-jwt + cloud-KMS contracts that downstream mining consumes.

## Follow-ups (not in this PR)
- Run `version-bump.yml` (minor) to cut `v0.19.0` after merge.
- Bump crypto-mining-service `go.mod` from `v0.17.0` to the new tag, rebuild the image, and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional analysis schemas and public contracts.
  - Expanded Java and Python call-graph analysis.
  - Improved detection of reachable findings and resource-bound variables.

- **Bug Fixes**
  - Improved cancellation, signal handling, parsing, call resolution, reachability, casting, and object lifecycle tracking.
  - Fixed handling of anonymous classes and fluent varargs chains.
  - Improved dependency-scan verification and safer export-file writing.

- **Documentation**
  - Added the 0.19.0 release notes dated August 14, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->