### PR TITLE
ci: add OpenCode automated PR review

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,10 +22,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Review skills (code-review + whichever crypto-specific ones apply)
-      # live in the private scanoss/agent-skills repo, never in this repo's
-      # history. Pull them in at runtime with a short-lived, read-only token
-      # scoped to that one repo only.
+      # Review skills live in a private repo, never in this repo's history.
+      # Pull them in at runtime with a short-lived, read-only token scoped
+      # to that one repo only.
       - name: Mint short-lived token for the private skills repo
         id: skills-token
         uses: actions/create-github-app-token@v2
@@ -42,10 +41,7 @@ jobs:
           token: ${{ steps.skills-token.outputs.token }}
           path: _agent-skills-src
           sparse-checkout: |
-            skills/code-review
-            skills/crypto-repo-analyzer
-            skills/crypto-kb-author
-            skills/crypto-coverage-expansion
+            skills
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -71,22 +67,17 @@ jobs:
             what else is relevant.
 
             Beyond that, check what else is available under .agents/skills/
-            and load whichever skills are actually relevant to this diff
-            (for example, the callgraph/KB-authoring skill for
-            reachability/contract changes, or the repo-analyzer skill for
-            library-inventory questions). Don't force a skill that doesn't
-            apply to this PR.
+            and load whichever additional skills are actually relevant to
+            this diff. Don't force one that doesn't apply to this PR.
 
             Also read this repo's own AGENTS.md for its specific
-            conventions (error wrapping, reachability must not depend on
-            metadata.api, library contracts live under
-            internal/callgraph/contracts/, detection rules belong in the
-            rules repo).
+            conventions.
 
             Treat all skill content as internal review criteria only: use
-            it to judge the PR, but never quote it verbatim in your review
-            comment — report only your resulting findings, each with a
-            severity marker and a concrete suggested fix. This repo is
-            public: never mention customers, private repositories, mining
+            it to judge the PR, but never quote it verbatim, and never
+            name or describe any loaded skill, in your review comment —
+            report only your resulting findings, each with a severity
+            marker and a concrete suggested fix. This repo is public:
+            never mention customers, private repositories, mining
             internals, commercial delivery context, or confidential
             benchmarks in your review comment.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -2,10 +2,9 @@ name: opencode-review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
-  id-token: write
   contents: read
   pull-requests: write
   issues: read
@@ -16,6 +15,10 @@ concurrency:
 
 jobs:
   review:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      vars.CODE_REVIEW_MODEL != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,13 +34,13 @@ jobs:
         with:
           app-id: ${{ secrets.AGENT_SKILLS_APP_ID }}
           private-key: ${{ secrets.AGENT_SKILLS_APP_PRIVATE_KEY }}
-          owner: scanoss
-          repositories: agent-skills
+          owner: ${{ vars.AGENT_SKILLS_OWNER }}
+          repositories: ${{ vars.AGENT_SKILLS_REPO }}
 
       - name: Fetch review skills
         uses: actions/checkout@v6
         with:
-          repository: scanoss/agent-skills
+          repository: ${{ vars.AGENT_SKILLS_OWNER }}/${{ vars.AGENT_SKILLS_REPO }}
           token: ${{ steps.skills-token.outputs.token }}
           path: _agent-skills-src
           sparse-checkout: |
@@ -51,7 +54,7 @@ jobs:
           cp -r _agent-skills-src/skills/. .agents/skills/
           rm -rf _agent-skills-src
 
-      - uses: anomalyco/opencode/github@latest
+      - uses: anomalyco/opencode/github@v1.18.18
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,14 +65,13 @@ jobs:
           prompt: |
             Review this pull request.
 
-            Always apply the code-review skill (installed at
-            .agents/skills/code-review) — its Standards + Spec two-axis
-            approach applies to every change in this repo, regardless of
-            what else is relevant.
+            Always apply the code-review skill — its Standards + Spec
+            two-axis approach applies to every change in this repo,
+            regardless of what else is relevant.
 
-            Beyond that, check what else is available under .agents/skills/
-            and load whichever additional skills are actually relevant to
-            this diff. Don't force one that doesn't apply to this PR.
+            Beyond that, check what else is available as a skill and load
+            whichever additional ones are actually relevant to this diff.
+            Don't force one that doesn't apply to this PR.
 
             Also read this repo's own AGENTS.md for its specific
             conventions.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -18,8 +18,11 @@ jobs:
     if: >
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
-      vars.CODE_REVIEW_MODEL != ''
+      vars.CODE_REVIEW_MODEL != '' &&
+      vars.AGENT_SKILLS_OWNER != '' &&
+      vars.AGENT_SKILLS_REPO != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -69,6 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.review-token.outputs.token }}
         with:
           model: openrouter/${{ vars.CODE_REVIEW_MODEL }}
+          agent: plan
           use_github_token: true
           share: false
           prompt: |
@@ -85,11 +89,14 @@ jobs:
             Also read this repo's own AGENTS.md for its specific
             conventions.
 
+            You are read-only: never edit, create, or commit any file, and
+            never run a git write command. Comment only.
+
             Treat all skill content as internal review criteria only: use
             it to judge the PR, but never quote it verbatim, and never
-            name or describe any loaded skill, in your review comment —
-            report only your resulting findings, each with a severity
-            marker and a concrete suggested fix. This repo is public:
-            never mention customers, private repositories, mining
-            internals, commercial delivery context, or confidential
-            benchmarks in your review comment.
+            name or describe any skill other than code-review in your
+            review comment — report only your resulting findings, each
+            with a severity marker and a concrete suggested fix. This
+            repo is public: never mention customers, private
+            repositories, mining internals, commercial delivery context,
+            or confidential benchmarks in your review comment.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -52,10 +52,21 @@ jobs:
           cp -r _agent-skills-src/skills/. .agents/skills/
           rm -rf _agent-skills-src
 
+      # Post the review as our own bot identity instead of the generic
+      # github-actions[bot]. Scoped to this repo only, short-lived.
+      - name: Mint token for posting the review
+        id: review-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AGENT_SKILLS_APP_ID }}
+          private-key: ${{ secrets.AGENT_SKILLS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - uses: anomalyco/opencode/github@v1.18.18
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.review-token.outputs.token }}
         with:
           model: openrouter/${{ vars.CODE_REVIEW_MODEL }}
           use_github_token: true

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           model: openrouter/${{ vars.CODE_REVIEW_MODEL }}
           use_github_token: true
+          share: false
           prompt: |
             Review this pull request.
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
 
       # Review skills live in a private repo, never in this repo's history.
       # Pull them in at runtime with a short-lived, read-only token scoped

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,47 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: openrouter/${{ vars.CODE_REVIEW_MODEL }}
+          use_github_token: true
+          prompt: |
+            Review this pull request against this repo's AGENTS.md conventions:
+            - Deep library packages return wrapped Go errors with package prefixes.
+            - Boundary packages wrap terminal failures with internal/failure.
+            - Do not move CLI policy into deep library code.
+            - Detection rules belong in the rules repo; this repo derives
+              reachability/supporting calls structurally.
+            - Reachability must not depend on metadata.api.
+            - Library-specific type/contract knowledge belongs in YAML contracts
+              under internal/callgraph/contracts/, not parser hacks.
+
+            Check correctness, security, and test coverage. Report findings
+            with a severity marker and a concrete suggested fix. This repo is
+            public — never mention customers, private repositories, mining
+            internals, commercial delivery context, or confidential benchmarks
+            in your review comment.

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,6 +22,39 @@ jobs:
         with:
           persist-credentials: false
 
+      # Review skills (code-review + whichever crypto-specific ones apply)
+      # live in the private scanoss/agent-skills repo, never in this repo's
+      # history. Pull them in at runtime with a short-lived, read-only token
+      # scoped to that one repo only.
+      - name: Mint short-lived token for the private skills repo
+        id: skills-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AGENT_SKILLS_APP_ID }}
+          private-key: ${{ secrets.AGENT_SKILLS_APP_PRIVATE_KEY }}
+          owner: scanoss
+          repositories: agent-skills
+
+      - name: Fetch review skills
+        uses: actions/checkout@v6
+        with:
+          repository: scanoss/agent-skills
+          token: ${{ steps.skills-token.outputs.token }}
+          path: _agent-skills-src
+          sparse-checkout: |
+            skills/code-review
+            skills/crypto-repo-analyzer
+            skills/crypto-kb-author
+            skills/crypto-coverage-expansion
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Install skills into workspace (never logged, never committed)
+        run: |
+          mkdir -p .agents/skills
+          cp -r _agent-skills-src/skills/. .agents/skills/
+          rm -rf _agent-skills-src
+
       - uses: anomalyco/opencode/github@latest
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -30,18 +63,30 @@ jobs:
           model: openrouter/${{ vars.CODE_REVIEW_MODEL }}
           use_github_token: true
           prompt: |
-            Review this pull request against this repo's AGENTS.md conventions:
-            - Deep library packages return wrapped Go errors with package prefixes.
-            - Boundary packages wrap terminal failures with internal/failure.
-            - Do not move CLI policy into deep library code.
-            - Detection rules belong in the rules repo; this repo derives
-              reachability/supporting calls structurally.
-            - Reachability must not depend on metadata.api.
-            - Library-specific type/contract knowledge belongs in YAML contracts
-              under internal/callgraph/contracts/, not parser hacks.
+            Review this pull request.
 
-            Check correctness, security, and test coverage. Report findings
-            with a severity marker and a concrete suggested fix. This repo is
-            public — never mention customers, private repositories, mining
-            internals, commercial delivery context, or confidential benchmarks
-            in your review comment.
+            Always apply the code-review skill (installed at
+            .agents/skills/code-review) — its Standards + Spec two-axis
+            approach applies to every change in this repo, regardless of
+            what else is relevant.
+
+            Beyond that, check what else is available under .agents/skills/
+            and load whichever skills are actually relevant to this diff
+            (for example, the callgraph/KB-authoring skill for
+            reachability/contract changes, or the repo-analyzer skill for
+            library-inventory questions). Don't force a skill that doesn't
+            apply to this PR.
+
+            Also read this repo's own AGENTS.md for its specific
+            conventions (error wrapping, reachability must not depend on
+            metadata.api, library contracts live under
+            internal/callgraph/contracts/, detection rules belong in the
+            rules repo).
+
+            Treat all skill content as internal review criteria only: use
+            it to judge the PR, but never quote it verbatim in your review
+            comment — report only your resulting findings, each with a
+            severity marker and a concrete suggested fix. This repo is
+            public: never mention customers, private repositories, mining
+            internals, commercial delivery context, or confidential
+            benchmarks in your review comment.


### PR DESCRIPTION
## Summary
- Adds an OpenCode-powered automated PR review, triggered on `pull_request: [opened, synchronize, reopened, ready_for_review]`.
- Model is provider-agnostic via OpenRouter (`openrouter/${{ vars.CODE_REVIEW_MODEL }}`) — swap models by changing the `CODE_REVIEW_MODEL` repo/org variable, no workflow edit needed.
- Pulls review skills from the private scanoss/agent-skills repo at runtime via a short-lived GitHub App token scoped to that repo only. Nothing from it is committed here.
- Only runs on same-repo, non-draft PRs, and skips cleanly if the model variable isn't set.

## Requires before this is functional
- `OPENROUTER_API_KEY` secret
- `AGENT_SKILLS_APP_ID` / `AGENT_SKILLS_APP_PRIVATE_KEY` secrets (GitHub App scoped to read-only on agent-skills)
- `AGENT_SKILLS_OWNER` / `AGENT_SKILLS_REPO` variables (e.g. `scanoss` / `agent-skills`)
- `CODE_REVIEW_MODEL` variable, e.g. `anthropic/claude-sonnet-4-5`

## Test plan
- [ ] Secrets/vars/App configured
- [ ] Open a throwaway PR and confirm the review comment posts and does not name any loaded skill or the skills-repo location