### PR TITLE
feat(graphfrag): restrict chain enumeration to requested entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `StitchOptions.ChainEntrySignatures` restricts call-chain enumeration to routes reaching the named entry points, so a filtered request spends the per-operation chain budget where the caller asked instead of in traversal order. The entry-point index is unaffected, and the zero value leaves the default path unchanged. Schema stays `6.9`; no re-mining. (scanoss/scanoss.api#116)
 
 
 ## [0.21.0] - 2026-08-17

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -38,6 +38,30 @@ type StitchOptions struct {
 	// MaxForwardEdgesPerAnchor caps the number of forward edges retained per
 	// anchor. Zero resolves to defaultMaxForwardEdgesPerAnchor.
 	MaxForwardEdgesPerAnchor int
+
+	// ChainEntrySignatures restricts CALL-CHAIN enumeration to routes that
+	// terminate at one of the named entry points, matched on
+	// Function.CanonicalSignature — the spelling crypto_entry_points publishes,
+	// so a consumer can feed a published entry point straight back in. It
+	// carries the served request's `entry_point_signatures`.
+	//
+	// It does NOT touch the entry-point index, which stays complete. The two
+	// answer different questions: the index says which functions reach the
+	// crypto, this says which routes are worth spending the chain budget on.
+	// Restricting the index instead would reintroduce the bug #249 fixed.
+	//
+	// Why it is needed: chains are capped at stitchMaxChainsPerOp per operation
+	// and the enumeration spends that budget in traversal order — several routes
+	// from one entry before any route from another. On a dense library the
+	// emitted chains therefore start at a small fraction of the published
+	// entries, and the entry a caller asked about is usually not among them.
+	// Naming it here spends the whole budget on routes that reach it.
+	//
+	// Zero value (nil) enumerates from every entry, so the default serving path
+	// is unchanged. A signature naming no entry contributes nothing rather than
+	// becoming a synthetic entry, and a function carrying no canonical signature
+	// cannot be named.
+	ChainEntrySignatures []string
 }
 
 // Defaults applied by forwardCapsFrom when the corresponding StitchOptions
@@ -145,7 +169,8 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		// callgraph matches live byte-for-byte (the parity contract) and stays
 		// bounded on high-fan-in libraries (BouncyCastle, 18k functions) where the
 		// old all-simple-paths forward DFS hangs.
-		traceBackward(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, roots, &out)
+		traceBackward(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, roots,
+			chainEntryNodes(roots, functionsByNode, opts.ChainEntrySignatures), &out)
 		attachAnnotationSupportingCalls(closure, fragments, &out)
 		composeDependencyEntryPoints(root, closure, fragments, adjacency, ambiguousCandidates, &out)
 		if opts.ForwardClosure {
@@ -1148,6 +1173,30 @@ type backwardChain struct {
 // entries are preserved (one chain per entry). This replaces the old forward DFS
 // that enumerated all simple paths (O(paths)) and emitted the extra re-convergent
 // chains live never produces.
+// chainEntryNodes resolves StitchOptions.ChainEntrySignatures to the subset of
+// roots they name. It returns nil when no signature was supplied — the signal to
+// enumerate from every entry, keeping the default path unchanged — and an empty
+// (non-nil) set when signatures were supplied but none names a root, which
+// correctly yields no chains rather than falling back to all of them.
+func chainEntryNodes(roots []graphNode, functionsByNode map[graphNode]Function, signatures []string) map[graphNode]bool {
+	if len(signatures) == 0 {
+		return nil
+	}
+	wanted := make(map[string]bool, len(signatures))
+	for _, sig := range signatures {
+		if sig != "" {
+			wanted[sig] = true
+		}
+	}
+	out := make(map[graphNode]bool, len(wanted))
+	for _, r := range roots {
+		if sig := functionsByNode[r].CanonicalSignature; sig != "" && wanted[sig] {
+			out[r] = true
+		}
+	}
+	return out
+}
+
 func traceBackward(
 	adjacency map[graphNode][]adjacencyEdge,
 	opsByNode map[graphNode][]CryptoOperation,
@@ -1155,12 +1204,20 @@ func traceBackward(
 	fragments map[ComponentKey]Fragment,
 	functionsByNode map[graphNode]Function,
 	roots []graphNode,
+	chainEntries map[graphNode]bool,
 	out *Result,
 ) {
 	reverse := reverseAdjacency(adjacency)
 	entrySet := make(map[graphNode]bool, len(roots))
 	for _, r := range roots {
 		entrySet[r] = true
+	}
+
+	// The index is built from entrySet (every entry, always); only the chain
+	// enumeration honours the caller's restriction. See ChainEntrySignatures.
+	chainEntrySet := entrySet
+	if chainEntries != nil {
+		chainEntrySet = chainEntries
 	}
 
 	// supportingSeen dedupes supporting-call emission across surviving chains so a
@@ -1179,8 +1236,15 @@ func traceBackward(
 		// The route total is counted before enumerating (condensedBackwardChains
 		// returns it) but is not published: the served contract has no field for
 		// it, and this package stays free of a logger by design.
-		chains, _, _ := condensedBackwardChains(opNode, reverse, entrySet)
+		chains, _, _ := condensedBackwardChains(opNode, reverse, chainEntrySet)
 		if len(chains) == 0 {
+			if chainEntries != nil && !chainEntries[opNode] {
+				// Restricted enumeration and no requested entry reaches this
+				// operation. The self-chain fallback below exists for a crypto call
+				// nothing calls at all; synthesizing it here would assert the
+				// operation is reachable from an entry that does not reach it.
+				continue
+			}
 			// No backward chain reached an entry (the op node has no callers, or none
 			// of its callers are entries). Mirror live's buildBaseCallChains fallback:
 			// emit a single-node chain so a self-contained crypto call is still

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -1214,7 +1214,7 @@ func traceBackward(
 	}
 
 	// The index is built from entrySet (every entry, always); only the chain
-	// enumeration honours the caller's restriction. See ChainEntrySignatures.
+	// enumeration honors the caller's restriction. See ChainEntrySignatures.
 	chainEntrySet := entrySet
 	if chainEntries != nil {
 		chainEntrySet = chainEntries

--- a/pkg/graphfrag/stitch_chain_entries_test.go
+++ b/pkg/graphfrag/stitch_chain_entries_test.go
@@ -1,0 +1,162 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import (
+	"sort"
+	"testing"
+)
+
+// chainEntryFixture builds a diamond: two entries (alpha, beta) both reach the
+// crypto sink through the same mid function. Both have in-degree 0, so both are
+// entries, and the finding is reachable from either — the shape where a chain
+// budget has to choose which entry's routes to emit.
+func chainEntryFixture() (ComponentKey, DependencyGraph, map[ComponentKey]Fragment) {
+	root := ComponentKey{Purl: "pkg:maven/com.acme/app", Version: "1.0.0"}
+	frag := Fragment{
+		Component: root,
+		Module:    "com.acme:app",
+		Functions: []Function{
+			{Signature: "alpha#0", FunctionName: "com.acme.App.alpha", CanonicalSignature: "com.acme.App.alpha(): void", FilePath: "App.java"},
+			{Signature: "beta#0", FunctionName: "com.acme.App.beta", CanonicalSignature: "com.acme.App.beta(): void", FilePath: "App.java"},
+			{Signature: "mid#0", FunctionName: "com.acme.App.mid", CanonicalSignature: "com.acme.App.mid(): void", FilePath: "App.java"},
+			{Signature: "sink#0", FunctionName: "com.acme.App.sink", CanonicalSignature: "com.acme.App.sink(): void", FilePath: "App.java"},
+		},
+		InternalEdges: []InternalEdge{
+			{Caller: "alpha#0", Callee: "mid#0", Resolution: ResolutionExact},
+			{Caller: "beta#0", Callee: "mid#0", Resolution: ResolutionExact},
+			{Caller: "mid#0", Callee: "sink#0", Resolution: ResolutionExact},
+		},
+		CryptoOperations: []CryptoOperation{
+			{Function: "sink#0", FindingID: "f-sink", RuleID: "r", Symbol: "Crypto.sink"},
+		},
+	}
+	return root, DependencyGraph{}, map[ComponentKey]Fragment{root: frag}
+}
+
+// entryPointSignatures collects the published entry-point index, sorted.
+func entryPointSignatures(t *testing.T, res *Result, root ComponentKey, module string) []string {
+	t.Helper()
+	export := res.ToCallgraphExport(root, ScanMeta{RootModule: module, Ecosystem: "java"})
+	out := make([]string, 0, len(export.CryptoEntryPoints))
+	for _, ep := range export.CryptoEntryPoints {
+		out = append(out, ep.CanonicalSignature)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestStitchChainEntrySignatures_RestrictsChainsNotTheIndex is the point of the
+// option: the caller narrows which routes are worth emitting without narrowing
+// the answer to "which functions reach this crypto". Deriving the index from the
+// chains is the bug #249 fixed, so this asserts the index is byte-identical
+// whether or not the restriction is applied.
+func TestStitchChainEntrySignatures_RestrictsChainsNotTheIndex(t *testing.T) {
+	t.Parallel()
+
+	root, deps, fragments := chainEntryFixture()
+	module := fragments[root].Module
+
+	all, err := StitchWithOptions(root, deps, fragments, StitchOptions{EntryRootedOnly: true})
+	if err != nil {
+		t.Fatalf("StitchWithOptions (unrestricted): %v", err)
+	}
+	only, err := StitchWithOptions(root, deps, fragments, StitchOptions{
+		EntryRootedOnly:      true,
+		ChainEntrySignatures: []string{"com.acme.App.alpha(): void"},
+	})
+	if err != nil {
+		t.Fatalf("StitchWithOptions (restricted): %v", err)
+	}
+
+	if got := rootFrameSignatures(all); len(got) != 2 {
+		t.Fatalf("unrestricted chain heads = %v, want both entries", got)
+	}
+	gotHeads := rootFrameSignatures(only)
+	if len(gotHeads) != 1 || gotHeads[0] != "alpha#0" {
+		t.Errorf("restricted chain heads = %v, want only alpha#0", gotHeads)
+	}
+
+	// The finding is still reported — restricting the routes must not hide it.
+	if got := reachableFindingIDs(only); len(got) != 1 || got[0] != "f-sink" {
+		t.Errorf("restricted findings = %v, want f-sink", got)
+	}
+
+	allIndex := entryPointSignatures(t, all, root, module)
+	onlyIndex := entryPointSignatures(t, only, root, module)
+	if len(allIndex) != len(onlyIndex) {
+		t.Fatalf("index changed with the restriction:\n unrestricted %v\n restricted   %v", allIndex, onlyIndex)
+	}
+	for i := range allIndex {
+		if allIndex[i] != onlyIndex[i] {
+			t.Fatalf("index changed with the restriction:\n unrestricted %v\n restricted   %v", allIndex, onlyIndex)
+		}
+	}
+	// beta reaches the crypto and is published even though no route was emitted
+	// for it — the property a signature filter must not break.
+	var sawBeta bool
+	for _, sig := range onlyIndex {
+		if sig == "com.acme.App.beta(): void" {
+			sawBeta = true
+		}
+	}
+	if !sawBeta {
+		t.Errorf("index = %v, want beta listed: it reaches the crypto", onlyIndex)
+	}
+}
+
+// TestStitchChainEntrySignatures_UnknownSignatureEmitsNoChain guards the
+// fail-quiet direction: a signature naming nothing must yield no routes, and must
+// NOT fall through to the self-chain fallback, which would report the operation
+// as reachable from an entry that does not reach it.
+func TestStitchChainEntrySignatures_UnknownSignatureEmitsNoChain(t *testing.T) {
+	t.Parallel()
+
+	root, deps, fragments := chainEntryFixture()
+
+	res, err := StitchWithOptions(root, deps, fragments, StitchOptions{
+		EntryRootedOnly:      true,
+		ChainEntrySignatures: []string{"com.acme.App.absent(): void"},
+	})
+	if err != nil {
+		t.Fatalf("StitchWithOptions: %v", err)
+	}
+	if len(res.Chains) != 0 {
+		t.Errorf("chains = %d, want none: the signature names no entry", len(res.Chains))
+	}
+
+	// The index empties out with them, and deliberately so: it is published per
+	// emitted finding graph, and with no route emitted there is no finding graph
+	// to anchor it to. That is the honest answer to "show me what my entry
+	// reaches" when the entry reaches nothing — and it is what lets a served
+	// request report the signature back as unmatched instead of pruning the
+	// findings against an index that would contradict it.
+	if index := entryPointSignatures(t, res, root, fragments[root].Module); len(index) != 0 {
+		t.Errorf("index = %v, want empty: nothing the caller named reaches a crypto operation", index)
+	}
+}
+
+// TestStitchChainEntrySignatures_NilKeepsEveryEntry pins the default: no
+// signatures means no restriction, so the serving path is unchanged.
+func TestStitchChainEntrySignatures_NilKeepsEveryEntry(t *testing.T) {
+	t.Parallel()
+
+	root, deps, fragments := chainEntryFixture()
+
+	base, err := StitchWithOptions(root, deps, fragments, StitchOptions{EntryRootedOnly: true})
+	if err != nil {
+		t.Fatalf("StitchWithOptions (base): %v", err)
+	}
+	empty, err := StitchWithOptions(root, deps, fragments, StitchOptions{
+		EntryRootedOnly:      true,
+		ChainEntrySignatures: []string{},
+	})
+	if err != nil {
+		t.Fatalf("StitchWithOptions (empty slice): %v", err)
+	}
+
+	if len(base.Chains) != len(empty.Chains) {
+		t.Errorf("chains = %d with an empty slice, want %d (no restriction)", len(empty.Chains), len(base.Chains))
+	}
+}

--- a/pkg/graphfrag/stitch_chain_entries_test.go
+++ b/pkg/graphfrag/stitch_chain_entries_test.go
@@ -40,8 +40,8 @@ func entryPointSignatures(t *testing.T, res *Result, root ComponentKey, module s
 	t.Helper()
 	export := res.ToCallgraphExport(root, ScanMeta{RootModule: module, Ecosystem: "java"})
 	out := make([]string, 0, len(export.CryptoEntryPoints))
-	for _, ep := range export.CryptoEntryPoints {
-		out = append(out, ep.CanonicalSignature)
+	for i := range export.CryptoEntryPoints {
+		out = append(out, export.CryptoEntryPoints[i].CanonicalSignature)
 	}
 	sort.Strings(out)
 	return out


### PR DESCRIPTION
Adds `StitchOptions.ChainEntrySignatures`, so a served request that names entry points gets call chains that actually start at them.

## Why

Chains are capped at `stitchMaxChainsPerOp` (128) per crypto operation, and the enumeration spends that budget in traversal order — several routes from one entry before any route from another. On a dense library the emitted chains therefore start at a small fraction of the published entries.

Measured on `pkg:maven/redis.clients/jedis@5.1.0` against the deployed API:

| | |
|---|---|
| published entry points | 864 |
| chains emitted for the TLS finding | 128 (the cap) |
| distinct entries those chains start at | 90 |
| routes starting at one single entry | 13 |
| routes starting at `Jedis.set` | 0 |

`Jedis.set` reaches that finding at `chain_depth: 5` and the index says so, but no emitted route starts there. A consumer filtering by their own call site gets the asset (after scanoss/scanoss.api#116) and no route — the answer to "does it reach" without the answer to "how".

Naming the entry spends the whole budget on routes that reach it.

## What it does

`ChainEntrySignatures` narrows the set of nodes where the backward walk is allowed to terminate, matched on `Function.CanonicalSignature` — the spelling `crypto_entry_points` publishes, so a consumer can feed a published entry point straight back in. It carries the served request's `entry_point_signatures`.

The walk itself is unchanged: it still starts at the crypto operation and goes backwards. Only the boundary set differs, so this adds no traversal and is cheaper than the unrestricted enumeration — fewer terminals, fewer routes.

## What it deliberately does NOT do

**The entry-point index is untouched and stays complete.** The two answer different questions: the index says which functions reach the crypto, this says which routes are worth spending the budget on. Restricting the index would reintroduce exactly the loss #249 fixed. A test asserts the index is identical with and without the restriction, including an entry that is published while no route was emitted for it.

## Compatibility

The zero value enumerates from every entry, so the default serving path is unchanged — the existing suite passes untouched. The callgraph export schema stays `6.9`: no field is added or removed, only which chains are selected when a caller opts in. No re-mining.

## Edge case

A signature naming no entry yields no chains rather than falling through to the single-node self-chain fallback. That fallback exists for a crypto call nothing calls at all; firing it here would assert the operation is reachable from an entry that does not reach it.

## Tests

- `TestStitchChainEntrySignatures_RestrictsChainsNotTheIndex` — restricted chains come only from the named entry, the finding is still reported, and the index is unchanged.
- `TestStitchChainEntrySignatures_UnknownSignatureEmitsNoChain` — no chains, no synthetic self-chain.
- `TestStitchChainEntrySignatures_NilKeepsEveryEntry` — the default is untouched.

Run locally: `go build ./...`, `go test ./...`, `gofmt`, `go vet`. The only failures are the six `internal/engine` Postgres cache tests, which fail identically on `main` without this change (they need a Postgres instance).

## Follow-up

Consuming this needs a release plus a bump in scanoss.api, where `entry_point_signatures` would be passed into the stitch. Until then the API filter selects the right assets (scanoss/scanoss.api#116) but their `call_chains` can be empty.
