### PR TITLE
feat(graphfrag): serve cross-component call chains with their frames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,8 @@ from semantic `return.type`, which may intentionally model only one inferred val
 
 Schema version is `"2"` — schema `"1"` is hard-rejected. The YAML schema version is
 INTERNAL to the loader; the partner-facing export schema is independent (currently
-`6.12` for the callgraph export — `pkg/graphfrag.CallgraphSchemaVersion` — and
-`graph-fragment-1.12` for the fragment export — `pkg/graphfrag.SchemaVersion`).
+`6.13` for the callgraph export — `pkg/graphfrag.CallgraphSchemaVersion` — and
+`graph-fragment-1.13` for the fragment export — `pkg/graphfrag.SchemaVersion`).
 
 To add a library:
 1. Drop a new YAML at `internal/callgraph/contracts/<ecosystem>/<library>.yaml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Graph fragments record one minimum-length route per reachable finding, and the stitched export serves a call chain that spans the component boundary instead of the single frame holding the crypto. A finding reached through a dependency now names every call from the consumer's own method down to the crypto. The entry-point index already stated the distance; the route it measures was computed and discarded. `analysis.call_chains` stays `partial`, because the dependency's leg was recorded under that dependency's own chain cap. A component keeps serving what it serves today until it is re-mined, and a closure mixing re-mined and older members reports each accordingly. (#289)
+- Callgraph export schema `6.13` and graph-fragment schema `1.13` add `call_chains[].entry_resolution` and `entry_declared_type`, reporting how the call arriving at each frame was established and, for a dispatch, the static type that could not be narrowed. Both absent on a chain's first frame. A route is chosen by minimum length, so a dispatch edge that happens to be spurious is exactly the kind of hop a route prefers; naming it lets a consumer keep the certain part of a route and read the rest as indicative. Graph fragments add `crypto_entry_points[].reachable_findings[].route` as indexes into `functions[]`, absent on fragments exported earlier. On the largest component measured the route costs 1.89 MB on a 506 MB fragment. (#289)
+
 
 ## [0.23.0] - 2026-08-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.24.0] - 2026-08-20
 ### Added
 - Graph fragments record one minimum-length route per reachable finding, and the stitched export serves a call chain that spans the component boundary instead of the single frame holding the crypto. A finding reached through a dependency now names every call from the consumer's own method down to the crypto. The entry-point index already stated the distance; the route it measures was computed and discarded. `analysis.call_chains` stays `partial`, because the dependency's leg was recorded under that dependency's own chain cap. A component keeps serving what it serves today until it is re-mined, and a closure mixing re-mined and older members reports each accordingly. (#289)
 - Callgraph export schema `6.13` and graph-fragment schema `1.13` add `call_chains[].entry_resolution` and `entry_declared_type`, reporting how the call arriving at each frame was established and, for a dispatch, the static type that could not be narrowed. Both absent on a chain's first frame. A route is chosen by minimum length, so a dispatch edge that happens to be spurious is exactly the kind of hop a route prefers; naming it lets a consumer keep the certain part of a route and read the rest as indicative. Graph fragments add `crypto_entry_points[].reachable_findings[].route` as indexes into `functions[]`, absent on fragments exported earlier. On the largest component measured the route costs 1.89 MB on a 506 MB fragment. (#289)
-
 
 ## [0.23.0] - 2026-08-20
 ### Added
@@ -504,3 +505,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.20.0]: https://github.com/scanoss/crypto-finder/compare/v0.19.0...v0.20.0
 [0.21.0]: https://github.com/scanoss/crypto-finder/compare/v0.20.0...v0.21.0
 [0.22.0]: https://github.com/scanoss/crypto-finder/compare/v0.21.0...v0.22.0
+[0.23.0]: https://github.com/scanoss/crypto-finder/compare/v0.22.0...v0.23.0
+[0.24.0]: https://github.com/scanoss/crypto-finder/compare/v0.23.0...v0.24.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,8 +42,8 @@ target source tree
    ▼
 6. Enrichment + export    OID enrichment (internal/enricher); writers (internal/output,
    (internal/enricher,     internal/converter) emit interim JSON or CycloneDX CBOM;
-                            internal/scan,         --export-callgraph emits the schema-6.12 reachability export;
-                            pkg/graphfrag)         --export-graph-fragment emits a graph-fragment-1.12 fragment
+                            internal/scan,         --export-callgraph emits the schema-6.13 reachability export;
+                            pkg/graphfrag)         --export-graph-fragment emits a graph-fragment-1.13 fragment
 ```
 
 Schema-6.12 key-length evidence follows this boundary: contract-derived key
@@ -95,7 +95,7 @@ Errors become terminal only at the CLI boundary, with a stable machine-readable 
 
 | Package | Responsibility |
 |---------|----------------|
-| `graphfrag` | The graph-fragment model and wire schema (`graph-fragment-1.12`), fragment decode/encode, the tiered fail-closed **stitcher** that composes per-component fragments into transitive reachability, and the renderers (`ToCallgraphExport` — stamps callgraph schema `6.12` — and `ToFindingsEnvelope`). |
+| `graphfrag` | The graph-fragment model and wire schema (`graph-fragment-1.13`), fragment decode/encode, the tiered fail-closed **stitcher** that composes per-component fragments into transitive reachability, and the renderers (`ToCallgraphExport` — stamps callgraph schema `6.13` — and `ToFindingsEnvelope`). |
 | `graphfrag/equiv` | Semantic diff asserting a stitched callgraph equals a live one (the equivalence guarantee the renderers rely on). |
 | `paramcondition` | Parser for the crypto-rules `parameterCondition` grammar (`param[<selector>]<op><value>`) into structured predicates. |
 | `schema` | Interim report JSON contract (format version `1.6`) and compatibility unmarshalling. |
@@ -125,7 +125,7 @@ The type-inference engine consumes YAML knowledge bases under `internal/callgrap
 | Hierarchy `child → [A]` vs `[B]` (no subset) | **Hard error** naming both libraries |
 | Hierarchy `child → [A]` vs `[A, B]` | Union (subset accepted) |
 
-KB YAML schema version is `"2"` (internal to the loader). It is **independent** of the partner-facing export schemas (callgraph `6.12`, `graph-fragment-1.12`). See [AGENTS.md](../AGENTS.md#knowledge-base-layout-callgraph-inferred-types) for the authoring recipe.
+KB YAML schema version is `"2"` (internal to the loader). It is **independent** of the partner-facing export schemas (callgraph `6.13`, `graph-fragment-1.13`). See [AGENTS.md](../AGENTS.md#knowledge-base-layout-callgraph-inferred-types) for the authoring recipe.
 
 ### 3. Detection vs reachability
 
@@ -146,8 +146,8 @@ Four independent version numbers ship in the outputs — do not conflate them:
 | Version | Constant | Current | Bumps when |
 |---------|----------|---------|------------|
 | Interim report format | `schema.InterimFormatVersion` | `1.6` | The findings.json envelope changes |
-| Callgraph export schema | `graphfrag.CallgraphSchemaVersion` | `6.12` | The partner-facing reachability contract changes |
-| Graph-fragment schema | `graphfrag.SchemaVersion` | `graph-fragment-1.12` | The fragment wire format changes |
+| Callgraph export schema | `graphfrag.CallgraphSchemaVersion` | `6.13` | The partner-facing reachability contract changes |
+| Graph-fragment schema | `graphfrag.SchemaVersion` | `graph-fragment-1.13` | The fragment wire format changes |
 | Graph algorithm version | `graphfrag.GraphAlgoVersion` | `graph-algo-2` | Callgraph **construction** changes in a way that alters the structural graph (cache key for `annotate`) |
 
 Every schema bump is recorded in [CHANGELOG.md](../CHANGELOG.md) (a hard repo requirement) and the format details live in [OUTPUT_FORMATS.md](OUTPUT_FORMATS.md).

--- a/internal/scan/export_schema_test.go
+++ b/internal/scan/export_schema_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scanoss/crypto-finder/internal/engine"
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/internal/output"
+	"github.com/scanoss/crypto-finder/pkg/graphfrag"
 )
 
 func TestGeneratedExportsMatchSchemas(t *testing.T) {
@@ -182,7 +183,7 @@ func callgraphResolvedKeyLengthDocument(provenance string, bits any) map[string]
 		resolved["bits"] = bits
 	}
 	return map[string]any{
-		"schema_version": "6.12",
+		"schema_version": graphfrag.CallgraphSchemaVersion,
 		"scan_metadata":  map[string]any{},
 		"finding_graphs": []any{map[string]any{
 			"finding_id":          "keygen-init",

--- a/internal/scan/fragment_export.go
+++ b/internal/scan/fragment_export.go
@@ -80,7 +80,7 @@ func (w *graphFragmentJSONWriter) writeResult(result *engine.DepScanResult) erro
 		return err
 	}
 
-	cryptoAnnotations, supportingCalls, entryPoints := materializeGraphFragmentCrypto(ctx, result)
+	cryptoAnnotations, supportingCalls, entryPoints := materializeGraphFragmentCrypto(ctx, result, functionIndex)
 	meta.CryptoOps = len(cryptoAnnotations)
 	if err := writeGraphFragmentArrayField(w, "crypto_annotations", cryptoAnnotations, true); err != nil {
 		return err
@@ -343,13 +343,18 @@ func BuildGraphFragmentExport(result *engine.DepScanResult) graphfrag.GraphFragm
 	}
 	sort.Strings(functionKeys)
 
+	// Same numbering the streaming writer assigns, and built here rather than
+	// re-derived later: a route resolved against a different order would name
+	// the wrong functions and still look well-formed.
+	functionIndex := make(map[string]int, len(functionKeys))
 	for _, key := range functionKeys {
 		decl := result.CallGraph.Functions[key]
+		functionIndex[key] = len(out.Functions)
 		out.Functions = append(out.Functions, buildGraphFragmentFunction(ctx, decl.ID, decl))
 	}
 	out.InternalEdges, out.ExternalCalls = buildGraphFragmentResolvedEdges(ctx)
 
-	out.CryptoAnnotations, out.SupportingCalls, out.CryptoEntryPoints = materializeGraphFragmentCrypto(ctx, result)
+	out.CryptoAnnotations, out.SupportingCalls, out.CryptoEntryPoints = materializeGraphFragmentCrypto(ctx, result, functionIndex)
 	out.ScanMetadata.FunctionCount = len(out.Functions)
 	out.ScanMetadata.InternalEdges = len(out.InternalEdges)
 	out.ScanMetadata.ExternalCalls = len(out.ExternalCalls)
@@ -1274,6 +1279,7 @@ func compatibleParentSignatures(ctx *exportBuildContext, parents []string, metho
 func materializeGraphFragmentCrypto(
 	ctx *exportBuildContext,
 	result *engine.DepScanResult,
+	functionIndex map[string]int,
 ) (
 	[]graphfrag.GraphFragmentCryptoOp,
 	[]graphfrag.GraphFragmentSupporting,
@@ -1328,7 +1334,7 @@ func materializeGraphFragmentCrypto(
 	sort.SliceStable(supportingOut, func(i, j int) bool {
 		return supportingOut[i].SupportingID < supportingOut[j].SupportingID
 	})
-	return annotations, supportingOut, flattenGraphFragmentEntryPoints(ctx.kb, entries)
+	return annotations, supportingOut, flattenGraphFragmentEntryPoints(ctx.kb, entries, functionIndex)
 }
 
 // fragmentEntryPointChains returns reverse-reachability chains for fragment
@@ -1404,6 +1410,10 @@ type graphFragmentEntryPointData struct {
 	ownerVisibility    string
 	findings           map[string]graphfrag.GraphFragmentReachableFinding
 	supporting         map[string]graphfrag.GraphFragmentReachableSupportingCall
+	// routes holds, per finding id, the function keys of the minimum-depth route
+	// this entry point takes to it. Keys here and indexes on the wire: the
+	// numbering of functions[] is only known when the fragment is flattened.
+	routes map[string][]string
 }
 
 func addGraphFragmentFindingReachability(
@@ -1427,6 +1437,10 @@ func addGraphFragmentFindingReachability(
 				ChainDepth:      depth,
 				FindingGraphRef: findingID,
 			}
+			// chain[pos:] is that depth spelled out: the frames from this entry
+			// point to the function holding the crypto. Recording it is what lets
+			// a consumer name the route the depth only measures.
+			entry.routes[findingID] = chainNodeKeys(chain[pos:])
 		}
 	}
 }
@@ -1456,6 +1470,21 @@ func addGraphFragmentSupportingReachability(
 	}
 }
 
+// chainNodeKeys is the function key of each node, in chain order. An empty key
+// discards the whole route: a route missing a frame would assert a call that is
+// not in the graph, and the depth still answers how far the crypto is.
+func chainNodeKeys(nodes []callGraphChainNode) []string {
+	keys := make([]string, 0, len(nodes))
+	for i := range nodes {
+		key := nodes[i].FunctionKey
+		if key == "" {
+			return nil
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func ensureGraphFragmentEntryPoint(entries map[string]*graphFragmentEntryPointData, node *callGraphChainNode) *graphFragmentEntryPointData {
 	key := node.FunctionKey
 	if key == "" {
@@ -1479,12 +1508,17 @@ func ensureGraphFragmentEntryPoint(entries map[string]*graphFragmentEntryPointDa
 		ownerVisibility:    node.OwnerVisibility,
 		findings:           make(map[string]graphfrag.GraphFragmentReachableFinding),
 		supporting:         make(map[string]graphfrag.GraphFragmentReachableSupportingCall),
+		routes:             make(map[string][]string),
 	}
 	entries[key] = entry
 	return entry
 }
 
-func flattenGraphFragmentEntryPoints(kb *contracts.KnowledgeBase, entries map[string]*graphFragmentEntryPointData) []graphfrag.GraphFragmentCryptoEntryPoint {
+func flattenGraphFragmentEntryPoints(
+	kb *contracts.KnowledgeBase,
+	entries map[string]*graphFragmentEntryPointData,
+	functionIndex map[string]int,
+) []graphfrag.GraphFragmentCryptoEntryPoint {
 	if len(entries) == 0 {
 		return nil
 	}
@@ -1502,7 +1536,7 @@ func flattenGraphFragmentEntryPoints(kb *contracts.KnowledgeBase, entries map[st
 			ParameterTypes:           cloneStringSlice(entry.parameterTypes),
 			Visibility:               entry.visibility,
 			OwnerVisibility:          entry.ownerVisibility,
-			ReachableFindings:        flattenGraphFragmentReachableFindings(entry.findings),
+			ReachableFindings:        flattenGraphFragmentReachableFindings(entry.findings, entry.routes, functionIndex),
 			ReachableSupportingCalls: flattenGraphFragmentReachableSupporting(entry.supporting),
 			// issue-103 WU3: parameter_roles carried on the fragment so the
 			// stitch/served path can pick them up via the by-function_key
@@ -1514,16 +1548,40 @@ func flattenGraphFragmentEntryPoints(kb *contracts.KnowledgeBase, entries map[st
 	return out
 }
 
-func flattenGraphFragmentReachableFindings(values map[string]graphfrag.GraphFragmentReachableFinding) []graphfrag.GraphFragmentReachableFinding {
+func flattenGraphFragmentReachableFindings(
+	values map[string]graphfrag.GraphFragmentReachableFinding,
+	routes map[string][]string,
+	functionIndex map[string]int,
+) []graphfrag.GraphFragmentReachableFinding {
 	if len(values) == 0 {
 		return nil
 	}
 	keys := sortedKeys(values)
 	out := make([]graphfrag.GraphFragmentReachableFinding, 0, len(keys))
 	for _, key := range keys {
-		out = append(out, values[key])
+		finding := values[key]
+		finding.Route = routeIndexes(routes[key], functionIndex)
+		out = append(out, finding)
 	}
 	return out
+}
+
+// routeIndexes resolves function keys to their position in the exported
+// functions array. A key the array does not hold drops the whole route, for the
+// same reason chainNodeKeys does.
+func routeIndexes(route []string, functionIndex map[string]int) []int {
+	if len(route) == 0 || functionIndex == nil {
+		return nil
+	}
+	indexes := make([]int, 0, len(route))
+	for _, key := range route {
+		idx, ok := functionIndex[key]
+		if !ok {
+			return nil
+		}
+		indexes = append(indexes, idx)
+	}
+	return indexes
 }
 
 func flattenGraphFragmentReachableSupporting(values map[string]graphfrag.GraphFragmentReachableSupportingCall) []graphfrag.GraphFragmentReachableSupportingCall {

--- a/internal/scan/fragment_export_test.go
+++ b/internal/scan/fragment_export_test.go
@@ -1016,7 +1016,7 @@ func TestFlattenGraphFragmentEntryPoints_PopulatesParameterRoles(t *testing.T) {
 		},
 	}
 
-	out := flattenGraphFragmentEntryPoints(kb, entries)
+	out := flattenGraphFragmentEntryPoints(kb, entries, nil)
 	if len(out) != 1 {
 		t.Fatalf("flattenGraphFragmentEntryPoints = %#v, want 1 entry", out)
 	}

--- a/internal/scan/mine_path_equivalence_test.go
+++ b/internal/scan/mine_path_equivalence_test.go
@@ -131,7 +131,13 @@ func oracleMinePathFragmentCrypto(
 	sort.SliceStable(supportingOut, func(i, j int) bool {
 		return supportingOut[i].SupportingID < supportingOut[j].SupportingID
 	})
-	return annotations, supportingOut, flattenGraphFragmentEntryPoints(ctx.kb, entries)
+	// Same numbering the exporter assigns, so a route the oracle resolves is
+	// comparable to the one the real path resolves.
+	functionIndex := make(map[string]int, len(ctx.graph.Functions))
+	for i, key := range sortedKeys(ctx.graph.Functions) {
+		functionIndex[key] = i
+	}
+	return annotations, supportingOut, flattenGraphFragmentEntryPoints(ctx.kb, entries, functionIndex)
 }
 
 // oracleFragmentEntryPointChains mirrors fragmentEntryPointChains without calling it.

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -30,7 +30,7 @@ import (
 // the graph-fragment stitch path (ToCallgraphExport), so the two can never drift
 // — a consumer that serves stitched output stamps the SAME version a live
 // `--scan-dependencies --export-callgraph` run produces.
-const CallgraphSchemaVersion = "6.12"
+const CallgraphSchemaVersion = "6.13"
 
 // Reachability states stamped on finding_graphs[].reachability (6.8+, issue
 // #242). The legacy `reachable *bool` keeps its semantics through 6.x;
@@ -380,6 +380,18 @@ type ExportChainNode struct {
 	StartLine int `json:"start_line,omitempty"`
 	// DependencyInfo is stamped for non-root frames. Nil for root-component frames.
 	DependencyInfo *ExportDependencyInfo `json:"dependency_info,omitempty"`
+	// EntryResolution reports how the call that arrives at this frame was
+	// established (6.13+): `exact` where the callee is certain, or a dispatch
+	// kind where the analysis could not narrow the receiver and considered every
+	// compatible implementation. EntryDeclaredType names the static type in that
+	// case. Both absent on the first frame of a chain, which no call arrives at.
+	//
+	// A route is chosen by minimum length, and a dispatch edge that happens to be
+	// spurious is always a shortcut, so it is exactly the kind of hop a route
+	// prefers. Reading them lets a consumer keep the certain part of a route and
+	// treat the rest as indicative.
+	EntryResolution   string `json:"entry_resolution,omitempty"`
+	EntryDeclaredType string `json:"entry_declared_type,omitempty"`
 	// EntryCall is the call-site data-flow for the edge that led to this frame.
 	// Nil on the root frame and on frames derived from legacy 1.0/1.1 fragments.
 	EntryCall *ExportEntryCall `json:"entry_call,omitempty"`
@@ -587,6 +599,7 @@ func (r *Result) ToCallgraphExport(root ComponentKey, meta ScanMeta) CallgraphEx
 		}
 		fg.Reachability = stitchedReachability(fg.CallChains, len(r.Suppressed) > 0)
 		fg.Analysis = stitchedFindingAnalysis(&fg)
+		r.markComposedRouteAnalysis(&fg, grp.anchorNode)
 		r.upgradeComposedReachability(&fg)
 		out.FindingGraphs = append(out.FindingGraphs, fg)
 	}
@@ -637,6 +650,18 @@ func mergeDirectFindingPURL(current *string, conflict *bool, purlValue string) {
 		*current = ""
 		*conflict = true
 	}
+}
+
+// markComposedRouteAnalysis keeps the analysis partial for a finding whose chain
+// came from a composed route. The route spans the component boundary and names
+// every frame, but its dependency leg was recorded under that dependency's
+// mine-time chain cap, so the search behind it was bounded — which is what this
+// field reports.
+func (r *Result) markComposedRouteAnalysis(fg *ExportFindingGraph, anchor graphNode) {
+	if fg == nil || fg.Analysis == nil || !r.composedRouteChains[anchor] {
+		return
+	}
+	fg.Analysis.CallChains = AnalysisPartial
 }
 
 // upgradeComposedReachability marks a finding proven through a composed
@@ -1193,6 +1218,8 @@ func buildExportNode(frame *CallFrame, root ComponentKey, ecosystem string) Expo
 		FilePath:           fn.FilePath,
 		StartLine:          fn.StartLine,
 		EntryCall:          exportEntryCall(frame.EntryCall, fn),
+		EntryResolution:    string(frame.EntryResolution),
+		EntryDeclaredType:  frame.EntryDeclaredType,
 	}
 	// Stamp dependency_info on non-root frames (ADR-4). The module string comes
 	// from the CallFrame.Module (Fragment.Module, set at stitch time), falling

--- a/pkg/graphfrag/callgraph_export_test.go
+++ b/pkg/graphfrag/callgraph_export_test.go
@@ -635,10 +635,10 @@ func TestToCallgraphExport_SeparatesTruncatedFindingIDByOccurrenceKey(t *testing
 // carrying the rule-vs-callgraph conflict marker.
 // The bump is unconditional: it
 // advances regardless of whether any given export emits the new fields.
-func TestCallgraphSchemaVersion_Is612(t *testing.T) {
+func TestCallgraphSchemaVersion_Is613(t *testing.T) {
 	t.Parallel()
 
-	if CallgraphSchemaVersion != "6.12" {
-		t.Fatalf("CallgraphSchemaVersion = %q, want %q", CallgraphSchemaVersion, "6.12")
+	if CallgraphSchemaVersion != "6.13" {
+		t.Fatalf("CallgraphSchemaVersion = %q, want %q", CallgraphSchemaVersion, "6.13")
 	}
 }

--- a/pkg/graphfrag/composed_route_test.go
+++ b/pkg/graphfrag/composed_route_test.go
@@ -1,0 +1,228 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import (
+	"testing"
+)
+
+// routeFixture is composeFixture with both legs of the cross-component route
+// named: the root's stitched frames reach the dependency's entry point, and the
+// dependency's fragment records how that entry point gets to the crypto.
+//
+//	Factory.create -> Factory.Extended.<init> -> Client.<init>   (stitched)
+//	Client.<init> -> Client.handshake -> Ssl.init                (mine-time route)
+//
+// The two legs share Client.<init>, which is what the join has to reconcile.
+func routeFixture() (ComponentKey, DependencyGraph, map[ComponentKey]Fragment) {
+	root, deps, fragments := composeFixture()
+
+	dep := ComponentKey{Purl: "pkg:maven/org.example/client", Version: "2.0.0"}
+	depFragment := fragments[dep]
+	depFragment.Functions = append(depFragment.Functions,
+		Function{
+			Signature: "org.example.client.(Client).handshake#0", FunctionName: "org.example.client.Client.handshake",
+			CanonicalSignature: "org.example.client.Client.handshake(): void", Visibility: "private", OwnerVisibility: "public",
+		},
+		Function{
+			Signature: "org.example.client.(Ssl).init#0", FunctionName: "org.example.client.Ssl.init",
+			CanonicalSignature: "org.example.client.Ssl.init(): void", Visibility: "private", OwnerVisibility: "public",
+		},
+	)
+	depFragment.CryptoEntryPoints[0].ReachableFindings[0].Route = []string{
+		"org.example.client.(Client).<init>#1$Map",
+		"org.example.client.(Client).handshake#0",
+		"org.example.client.(Ssl).init#0",
+	}
+	depFragment.CryptoEntryPoints[0].ReachableFindings[0].ChainDepth = 3
+	fragments[dep] = depFragment
+
+	return root, deps, fragments
+}
+
+func stitchRouteFixture(t *testing.T, sig string) CallgraphExport {
+	t.Helper()
+	root, deps, fragments := routeFixture()
+	var sigs []string
+	if sig != "" {
+		sigs = []string{sig}
+	}
+	res, err := StitchWithOptions(root, deps, fragments, StitchOptions{
+		EntryRootedOnly:      true,
+		ChainEntrySignatures: sigs,
+	})
+	if err != nil {
+		t.Fatalf("stitch: %v", err)
+	}
+	return res.ToCallgraphExport(root, ScanMeta{Ecosystem: "java", RootModule: "org.example.wrapper"})
+}
+
+// TestComposedRouteSpansTheBoundary is the point of the whole change: a chain
+// filtered by the consumer's own call reaches the crypto instead of stopping at
+// the frame that holds it.
+func TestComposedRouteSpansTheBoundary(t *testing.T) {
+	t.Parallel()
+
+	cg := stitchRouteFixture(t, "org.example.wrapper.Factory.create(): Client")
+	if len(cg.FindingGraphs) != 1 {
+		t.Fatalf("finding graphs = %d, want 1", len(cg.FindingGraphs))
+	}
+	fg := cg.FindingGraphs[0]
+	if len(fg.CallChains) != 1 {
+		t.Fatalf("call chains = %d, want 1", len(fg.CallChains))
+	}
+	chain := fg.CallChains[0]
+
+	want := []string{
+		"org.example.wrapper.(Factory).create#0",
+		"org.example.wrapper.(Factory.Extended).<init>#1",
+		"org.example.client.(Client).<init>#1$Map",
+		"org.example.client.(Client).handshake#0",
+		"org.example.client.(Ssl).init#0",
+	}
+	if len(chain) != len(want) {
+		var got []string
+		for _, n := range chain {
+			got = append(got, n.FunctionKey)
+		}
+		t.Fatalf("chain = %v, want %v", got, want)
+	}
+	for i, key := range want {
+		if chain[i].FunctionKey != key {
+			t.Errorf("frame %d = %q, want %q", i, chain[i].FunctionKey, key)
+		}
+	}
+
+	// The shared frame appears once. Both legs name it, and a chain that
+	// repeated it would claim a call from a function to itself.
+	seen := map[string]int{}
+	for _, n := range chain {
+		seen[n.FunctionKey]++
+	}
+	for key, n := range seen {
+		if n > 1 {
+			t.Errorf("frame %q appears %d times, want once", key, n)
+		}
+	}
+
+	if fg.Reachability != ReachabilityReachable {
+		t.Errorf("reachability = %q, want %q", fg.Reachability, ReachabilityReachable)
+	}
+	// Partial however whole the route reads: its dependency leg was recorded
+	// under that dependency's own chain cap.
+	if fg.Analysis == nil || fg.Analysis.CallChains != AnalysisPartial {
+		t.Errorf("analysis = %+v, want call_chains %q", fg.Analysis, AnalysisPartial)
+	}
+}
+
+// TestComposedRouteFallsBackWithoutADependencyLeg pins the degradation: a
+// fragment that named no route still answers, with the single frame holding the
+// crypto. Half a route would place the crypto somewhere it is not.
+func TestComposedRouteFallsBackWithoutADependencyLeg(t *testing.T) {
+	t.Parallel()
+
+	// composeFixture is routeFixture without the mine-time route.
+	root, deps, fragments := composeFixture()
+	res, err := StitchWithOptions(root, deps, fragments, StitchOptions{
+		EntryRootedOnly:      true,
+		ChainEntrySignatures: []string{"org.example.wrapper.Factory.create(): Client"},
+	})
+	if err != nil {
+		t.Fatalf("stitch: %v", err)
+	}
+	cg := res.ToCallgraphExport(root, ScanMeta{Ecosystem: "java", RootModule: "org.example.wrapper"})
+	if len(cg.FindingGraphs) != 1 {
+		t.Fatalf("finding graphs = %d, want 1", len(cg.FindingGraphs))
+	}
+	if got := len(cg.FindingGraphs[0].CallChains[0]); got != 1 {
+		t.Errorf("chain has %d frames, want the single crypto-holding frame", got)
+	}
+	if cg.FindingGraphs[0].Reachability != ReachabilityReachable {
+		t.Errorf("reachability = %q, want the verdict regardless", cg.FindingGraphs[0].Reachability)
+	}
+}
+
+// TestComposedRouteRejectsAMismatchedJoin: the two legs must actually meet. A
+// dependency route starting somewhere else describes a different journey, and
+// splicing the two would invent a call.
+func TestComposedRouteRejectsAMismatchedJoin(t *testing.T) {
+	t.Parallel()
+
+	root, deps, fragments := routeFixture()
+	dep := ComponentKey{Purl: "pkg:maven/org.example/client", Version: "2.0.0"}
+	depFragment := fragments[dep]
+	route := depFragment.CryptoEntryPoints[0].ReachableFindings[0].Route
+	// Head no longer the entry point the stitched leg arrives at.
+	depFragment.CryptoEntryPoints[0].ReachableFindings[0].Route =
+		append([]string{"org.example.client.(Client).handshake#0"}, route[1:]...)
+	fragments[dep] = depFragment
+
+	res, err := StitchWithOptions(root, deps, fragments, StitchOptions{
+		EntryRootedOnly:      true,
+		ChainEntrySignatures: []string{"org.example.wrapper.Factory.create(): Client"},
+	})
+	if err != nil {
+		t.Fatalf("stitch: %v", err)
+	}
+	cg := res.ToCallgraphExport(root, ScanMeta{Ecosystem: "java", RootModule: "org.example.wrapper"})
+	if len(cg.FindingGraphs) != 1 {
+		t.Fatalf("finding graphs = %d, want 1", len(cg.FindingGraphs))
+	}
+	if got := len(cg.FindingGraphs[0].CallChains[0]); got != 1 {
+		t.Errorf("chain has %d frames, want the fallback: the legs do not meet", got)
+	}
+}
+
+// TestComposedRouteAnnotatesEachFrame: a route is only evidence if a reader can
+// tell a certain hop from an inferred one. The head carries none, since no call
+// arrives at it.
+func TestComposedRouteAnnotatesEachFrame(t *testing.T) {
+	t.Parallel()
+
+	cg := stitchRouteFixture(t, "org.example.wrapper.Factory.create(): Client")
+	chain := cg.FindingGraphs[0].CallChains[0]
+
+	if chain[0].EntryResolution != "" {
+		t.Errorf("head frame resolution = %q, want empty: no call arrives at it", chain[0].EntryResolution)
+	}
+	// The stitched leg is exact in this fixture; the dependency leg's own hops
+	// are not in the stitched adjacency and report nothing rather than borrowing
+	// a resolution they were not given.
+	if got := chain[1].EntryResolution; got != string(ResolutionExact) {
+		t.Errorf("frame 1 resolution = %q, want %q", got, ResolutionExact)
+	}
+	if got := chain[2].EntryResolution; got != string(ResolutionExact) {
+		t.Errorf("frame 2 resolution = %q, want %q", got, ResolutionExact)
+	}
+}
+
+// TestUnfilteredRouteUnchanged: the default path must not move. The composed
+// route only ever supplies a chain a restricted enumeration could not produce.
+func TestUnfilteredRouteUnchanged(t *testing.T) {
+	t.Parallel()
+
+	withRoute := stitchRouteFixture(t, "")
+
+	root, deps, fragments := composeFixture()
+	res, err := StitchWithOptions(root, deps, fragments, StitchOptions{EntryRootedOnly: true})
+	if err != nil {
+		t.Fatalf("stitch: %v", err)
+	}
+	withoutRoute := res.ToCallgraphExport(root, ScanMeta{Ecosystem: "java", RootModule: "org.example.wrapper"})
+
+	if len(withRoute.FindingGraphs) != len(withoutRoute.FindingGraphs) {
+		t.Fatalf("finding graphs = %d with a route, %d without",
+			len(withRoute.FindingGraphs), len(withoutRoute.FindingGraphs))
+	}
+	for i := range withRoute.FindingGraphs {
+		a, b := withRoute.FindingGraphs[i], withoutRoute.FindingGraphs[i]
+		if len(a.CallChains) != len(b.CallChains) {
+			t.Errorf("finding %s: chains = %d with a route, %d without",
+				a.FindingID, len(a.CallChains), len(b.CallChains))
+		}
+		if a.Reachability != b.Reachability {
+			t.Errorf("finding %s: reachability %q vs %q", a.FindingID, a.Reachability, b.Reachability)
+		}
+	}
+}

--- a/pkg/graphfrag/composed_route_test.go
+++ b/pkg/graphfrag/composed_route_test.go
@@ -82,7 +82,7 @@ func TestComposedRouteSpansTheBoundary(t *testing.T) {
 		"org.example.client.(Ssl).init#0",
 	}
 	if len(chain) != len(want) {
-		var got []string
+		got := make([]string, 0, len(chain))
 		for _, n := range chain {
 			got = append(got, n.FunctionKey)
 		}
@@ -154,8 +154,7 @@ func TestComposedRouteRejectsAMismatchedJoin(t *testing.T) {
 	depFragment := fragments[dep]
 	route := depFragment.CryptoEntryPoints[0].ReachableFindings[0].Route
 	// Head no longer the entry point the stitched leg arrives at.
-	depFragment.CryptoEntryPoints[0].ReachableFindings[0].Route =
-		append([]string{"org.example.client.(Client).handshake#0"}, route[1:]...)
+	depFragment.CryptoEntryPoints[0].ReachableFindings[0].Route = append([]string{"org.example.client.(Client).handshake#0"}, route[1:]...)
 	fragments[dep] = depFragment
 
 	res, err := StitchWithOptions(root, deps, fragments, StitchOptions{

--- a/pkg/graphfrag/export.go
+++ b/pkg/graphfrag/export.go
@@ -43,7 +43,7 @@ import (
 // hierarchy stitching. 1.10 adds optional occurrence_key propagation for
 // canonical crypto annotations. 1.11 adds resolved key-length call evidence.
 // 1.12 adds the rule-vs-callgraph key-length conflict marker on that evidence.
-const SchemaVersion = "graph-fragment-1.12"
+const SchemaVersion = "graph-fragment-1.13"
 
 // GraphAlgoVersion identifies the callgraph-CONSTRUCTION algorithm version. It
 // is independent of the binary version (cf_version) and the wire schema
@@ -474,8 +474,17 @@ type GraphFragmentCryptoEntryPoint struct {
 
 // GraphFragmentReachableFinding is a finding reachable from an entrypoint.
 type GraphFragmentReachableFinding struct {
-	FindingID       string `json:"finding_id"`
-	ChainDepth      int    `json:"chain_depth"`
+	FindingID  string `json:"finding_id"`
+	ChainDepth int    `json:"chain_depth"`
+	// Route names one minimum-length route from the entry point to the function
+	// holding the finding, as indexes into Functions, entry-point-first and
+	// inclusive of both ends — so its length equals ChainDepth. Indexes rather
+	// than keys for the same reason the compact edges use them: on a dense
+	// component the keys cost an order of magnitude more than the graph they
+	// describe. Absent on fragments exported before graph-fragment-1.13, and on
+	// any entry point whose route the producer could not name; ChainDepth stays
+	// the answer either way.
+	Route           []int  `json:"route,omitempty"`
 	FindingGraphRef string `json:"finding_graph_ref,omitempty"`
 }
 

--- a/pkg/graphfrag/export_test.go
+++ b/pkg/graphfrag/export_test.go
@@ -196,7 +196,7 @@ func TestGraphFragmentCryptoOp_JSONRoundTrip(t *testing.T) {
 // call evidence.
 func TestSchemaVersion_Is_1_12(t *testing.T) {
 	t.Parallel()
-	if SchemaVersion != "graph-fragment-1.12" {
-		t.Errorf("SchemaVersion = %q, want graph-fragment-1.12", SchemaVersion)
+	if SchemaVersion != "graph-fragment-1.13" {
+		t.Errorf("SchemaVersion = %q, want graph-fragment-1.13", SchemaVersion)
 	}
 }

--- a/pkg/graphfrag/ingest.go
+++ b/pkg/graphfrag/ingest.go
@@ -33,7 +33,7 @@ func (e *GraphFragmentExport) ToFragment(component ComponentKey) Fragment {
 	appendExternalCalls(&frag, e.ExternalCalls)
 	appendCryptoOperations(&frag, e.CryptoAnnotations)
 	appendSupportingCalls(&frag, e.SupportingCalls)
-	frag.CryptoEntryPoints = appendCryptoEntryPoints(frag.CryptoEntryPoints, e.CryptoEntryPoints)
+	frag.CryptoEntryPoints = appendCryptoEntryPoints(frag.CryptoEntryPoints, e.CryptoEntryPoints, functionKeys)
 	return frag
 }
 
@@ -200,7 +200,11 @@ func stringAt(values []string, idx int) string {
 	return values[idx]
 }
 
-func appendCryptoEntryPoints(dst []CryptoEntryPoint, src []GraphFragmentCryptoEntryPoint) []CryptoEntryPoint {
+func appendCryptoEntryPoints(
+	dst []CryptoEntryPoint,
+	src []GraphFragmentCryptoEntryPoint,
+	functionKeys []string,
+) []CryptoEntryPoint {
 	for i := range src {
 		ep := &src[i]
 		dst = append(dst, CryptoEntryPoint{
@@ -213,7 +217,7 @@ func appendCryptoEntryPoints(dst []CryptoEntryPoint, src []GraphFragmentCryptoEn
 			ParameterTypes:           append([]string(nil), ep.ParameterTypes...),
 			Visibility:               ep.Visibility,
 			OwnerVisibility:          ep.OwnerVisibility,
-			ReachableFindings:        toReachableFindings(ep.ReachableFindings),
+			ReachableFindings:        toReachableFindings(ep.ReachableFindings, functionKeys),
 			ReachableSupportingCalls: toReachableSupportingCalls(ep.ReachableSupportingCalls),
 			MethodRole:               ep.MethodRole,
 			RoleProvenance:           toRoleProvenance(ep.RoleProvenance),
@@ -268,7 +272,7 @@ func toParameterRoles(src []GraphFragmentParameterRole) []ParameterRole {
 	return out
 }
 
-func toReachableFindings(src []GraphFragmentReachableFinding) []ReachableFinding {
+func toReachableFindings(src []GraphFragmentReachableFinding, functionKeys []string) []ReachableFinding {
 	if len(src) == 0 {
 		return nil
 	}
@@ -277,10 +281,30 @@ func toReachableFindings(src []GraphFragmentReachableFinding) []ReachableFinding
 		out[i] = ReachableFinding{
 			FindingID:       src[i].FindingID,
 			ChainDepth:      src[i].ChainDepth,
+			Route:           toRoute(src[i].Route, functionKeys),
 			FindingGraphRef: src[i].FindingGraphRef,
 		}
 	}
 	return out
+}
+
+// toRoute resolves route indexes to function keys. An index the fragment cannot
+// resolve drops the whole route rather than a frame: a route with a hole would
+// claim a call that is not there, and the depth still answers how far the crypto
+// is.
+func toRoute(indexes []int, functionKeys []string) []string {
+	if len(indexes) == 0 {
+		return nil
+	}
+	route := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		key := functionKeyAt(functionKeys, idx)
+		if key == "" {
+			return nil
+		}
+		route = append(route, key)
+	}
+	return route
 }
 
 func toReachableSupportingCalls(src []GraphFragmentReachableSupportingCall) []ReachableSupportingCall {

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -557,7 +557,7 @@ type ReachableFinding struct {
 	// Route is one minimum-length route from the entry point to the function
 	// holding the finding, as function keys, entry-point-first and inclusive of
 	// both ends. Empty when the fragment carried none, which leaves ChainDepth
-	// as the only statement about distance — the pre-1.13 behaviour.
+	// as the only statement about distance — the pre-1.13 behavior.
 	Route           []string
 	FindingGraphRef string
 }

--- a/pkg/graphfrag/model.go
+++ b/pkg/graphfrag/model.go
@@ -552,8 +552,13 @@ type CryptoEntryPoint struct {
 
 // ReachableFinding links an entrypoint to a reachable terminal finding.
 type ReachableFinding struct {
-	FindingID       string
-	ChainDepth      int
+	FindingID  string
+	ChainDepth int
+	// Route is one minimum-length route from the entry point to the function
+	// holding the finding, as function keys, entry-point-first and inclusive of
+	// both ends. Empty when the fragment carried none, which leaves ChainDepth
+	// as the only statement about distance — the pre-1.13 behaviour.
+	Route           []string
 	FindingGraphRef string
 }
 
@@ -608,6 +613,16 @@ type Result struct {
 	// restricted chain enumeration compares against CryptoOperation identities,
 	// which are not yet in served form.
 	composedRawFindings map[string]map[string]bool
+	// composedRoutes maps a composed entry point's function key to the whole
+	// route it takes to each finding it reaches, keyed by mine-time finding id.
+	// Empty for a finding whose dependency leg the fragment did not name.
+	composedRoutes map[string]map[string][]graphNode
+	// composedRouteChains are the operation nodes whose emitted chain came from a
+	// composed route rather than an enumerated one. Keyed by node, not finding
+	// id: the ids are translated to served form on the way out and would not
+	// match. Their evidence inherits the dependency's mine-time chain cap, so the
+	// served analysis must stay partial however whole the route looks.
+	composedRouteChains map[graphNode]bool
 	// erasedByFunctionKey resolves served function keys to the erased join
 	// signature carried on fragment functions (1.9+; empty for older data).
 	erasedByFunctionKey map[string]string
@@ -690,6 +705,12 @@ type CallFrame struct {
 	Function Function
 	// EntryCall is the call-site data-flow for the edge that led to this frame (1.2+).
 	EntryCall *CallSite
+	// EntryResolution is how the edge that led to this frame was established,
+	// and EntryDeclaredType the static type it was written against when that
+	// edge is a dispatch. Empty on the first frame of a chain, which no edge
+	// leads to.
+	EntryResolution   ResolutionKind
+	EntryDeclaredType string
 	// Module is the fragment's root module string (e.g. "net.crypto:lib"), used
 	// to stamp dependency_info.module at projection time.
 	Module string

--- a/pkg/graphfrag/route_ingest_test.go
+++ b/pkg/graphfrag/route_ingest_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// routeFragmentJSON is one entry point reaching one finding three calls away,
+// with the route named as indexes into functions[].
+const routeFragmentJSON = `{
+	"schema_version": "graph-fragment-1.13",
+	"scan_metadata": {"root_module": "org.example.client", "graph_algo_version": "graph-algo-2"},
+	"functions": [
+		{"key": "org.example.client.(Api).entry#0", "canonical_signature": "org.example.client.Api.entry(): void"},
+		{"key": "org.example.client.(Api).mid#0",   "canonical_signature": "org.example.client.Api.mid(): void"},
+		{"key": "org.example.client.(Ssl).init#0",  "canonical_signature": "org.example.client.Ssl.init(): void"}
+	],
+	"crypto_entry_points": [{
+		"function_key": "org.example.client.(Api).entry#0",
+		"canonical_signature": "org.example.client.Api.entry(): void",
+		"reachable_findings": [
+			{"finding_id": "aaaa1111", "chain_depth": 3, "route": [0, 1, 2], "finding_graph_ref": "aaaa1111"}
+		]
+	}]
+}`
+
+func ingestRouteFragment(t *testing.T, body string) Fragment {
+	t.Helper()
+	var export GraphFragmentExport
+	if err := json.Unmarshal([]byte(body), &export); err != nil {
+		t.Fatalf("unmarshal fragment: %v", err)
+	}
+	return export.ToFragment(ComponentKey{Purl: "pkg:maven/org.example/client", Version: "1.0.0"})
+}
+
+func onlyReachableFinding(t *testing.T, frag Fragment) ReachableFinding {
+	t.Helper()
+	if len(frag.CryptoEntryPoints) != 1 {
+		t.Fatalf("entry points = %d, want 1", len(frag.CryptoEntryPoints))
+	}
+	rf := frag.CryptoEntryPoints[0].ReachableFindings
+	if len(rf) != 1 {
+		t.Fatalf("reachable findings = %d, want 1", len(rf))
+	}
+	return rf[0]
+}
+
+// TestIngestRouteResolvesIndexes: the wire form is indexes, the model is function
+// keys, and the route's length is the depth the same record reports.
+func TestIngestRouteResolvesIndexes(t *testing.T) {
+	t.Parallel()
+
+	rf := onlyReachableFinding(t, ingestRouteFragment(t, routeFragmentJSON))
+
+	want := []string{
+		"org.example.client.(Api).entry#0",
+		"org.example.client.(Api).mid#0",
+		"org.example.client.(Ssl).init#0",
+	}
+	if got := strings.Join(rf.Route, " -> "); got != strings.Join(want, " -> ") {
+		t.Errorf("Route = %q, want %q", got, strings.Join(want, " -> "))
+	}
+	if len(rf.Route) != rf.ChainDepth {
+		t.Errorf("route has %d frames, want ChainDepth = %d", len(rf.Route), rf.ChainDepth)
+	}
+	if rf.Route[0] != frag0Key {
+		t.Errorf("route starts at %q, want the entry point %q", rf.Route[0], frag0Key)
+	}
+}
+
+const frag0Key = "org.example.client.(Api).entry#0"
+
+// TestIngestRouteAbsent: a fragment written before the field existed keeps
+// working and simply reports no route, which is the pre-1.13 answer.
+func TestIngestRouteAbsent(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Replace(routeFragmentJSON, `, "route": [0, 1, 2]`, "", 1)
+	rf := onlyReachableFinding(t, ingestRouteFragment(t, body))
+
+	if rf.Route != nil {
+		t.Errorf("Route = %v, want nil", rf.Route)
+	}
+	if rf.ChainDepth != 3 {
+		t.Errorf("ChainDepth = %d, want 3: the depth is unaffected", rf.ChainDepth)
+	}
+}
+
+// TestIngestRouteUnresolvableIndexDropsWholeRoute: a frame that cannot be
+// resolved must not leave a hole. A route with a gap claims a call that is not
+// in the graph, so the whole route goes and the depth stands alone.
+func TestIngestRouteUnresolvableIndexDropsWholeRoute(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		route string
+	}{
+		{"index past the end", `"route": [0, 1, 99]`},
+		{"negative index", `"route": [0, -1, 2]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Replace(routeFragmentJSON, `"route": [0, 1, 2]`, tc.route, 1)
+			rf := onlyReachableFinding(t, ingestRouteFragment(t, body))
+			if rf.Route != nil {
+				t.Errorf("Route = %v, want nil: one frame was unresolvable", rf.Route)
+			}
+			if rf.ChainDepth != 3 {
+				t.Errorf("ChainDepth = %d, want 3", rf.ChainDepth)
+			}
+		})
+	}
+}

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -1381,7 +1381,7 @@ func composedRouteInbounds(
 		// The ambiguous candidates are searched too, and deliberately: an edge
 		// lands there because its dispatch could not be narrowed, so those are
 		// the least certain hops of all. Leaving exactly those unlabelled would
-		// invert the point of labelling.
+		// invert the point of labeling.
 		out[i] = lookupInbound(route[i-1], route[i], adjacency, ambiguousCandidates)
 	}
 	return out
@@ -1937,7 +1937,7 @@ const publicVisibility = "public"
 // index is may-reach by design, so a consumer-facing entry point may be
 // discovered THROUGH an ambiguous call, while finding-level reachability only
 // ever upgrades on proven paths.
-func composeReverseMaps(adjacency map[graphNode][]adjacencyEdge, ambiguousCandidates map[graphNode][]adjacencyEdge) (map[graphNode][]graphNode, map[graphNode][]graphNode) {
+func composeReverseMaps(adjacency, ambiguousCandidates map[graphNode][]adjacencyEdge) (map[graphNode][]graphNode, map[graphNode][]graphNode) {
 	reverse := make(map[graphNode][]graphNode)
 	for caller, edges := range adjacency {
 		for _, edge := range edges {

--- a/pkg/graphfrag/stitch.go
+++ b/pkg/graphfrag/stitch.go
@@ -6,6 +6,8 @@ package graphfrag
 import (
 	"sort"
 	"strings"
+
+	"github.com/scanoss/crypto-finder/pkg/graphwalk"
 )
 
 // StitchOptions tunes which root-fragment functions a stitch traces from. The
@@ -174,9 +176,11 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		// latter proves reachability through a dependency's mine-time index, which
 		// records a depth and no route, so no enumeration can confirm it.
 		composeDependencyEntryPoints(root, closure, fragments, adjacency, ambiguousCandidates, &out)
+		composedRoutes := make(map[string][]graphNode)
 		traceBackward(adjacency, opsByNode, supportingByNode, fragments, functionsByNode, roots,
 			chainEntryNodes(roots, functionsByNode, opts.ChainEntrySignatures),
-			composedChainEntryFindings(root, &out, functionsByNode, opts.ChainEntrySignatures), &out)
+			composedChainEntryFindings(root, &out, functionsByNode, opts.ChainEntrySignatures, composedRoutes),
+			composedRoutes, ambiguousCandidates, &out)
 		attachAnnotationSupportingCalls(closure, fragments, &out)
 		if opts.ForwardClosure {
 			out.forwardClosures = buildForwardClosures(adjacency, suppressed, opsByNode, supportingByNode, fragments, functionsByNode, forwardCapsFrom(opts))
@@ -201,7 +205,7 @@ func StitchWithOptions(root ComponentKey, deps DependencyGraph, fragments map[Co
 		opsByNode, historicalEntries, fragments, functionsByNode, &out)
 
 	for _, start := range roots {
-		trace(start, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, nil, nil, map[graphNode]bool{}, &out)
+		trace(start, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, inbound{}, nil, map[graphNode]bool{}, &out)
 	}
 	attachAnnotationSupportingCalls(closure, fragments, &out)
 	if opts.ForwardClosure {
@@ -337,6 +341,13 @@ type graphNode struct {
 type adjacencyEdge struct {
 	target    graphNode
 	entryCall *CallSite
+	// resolution and declaredType describe how this edge was established. They
+	// travel to the served frame because a route is only evidence if a reader
+	// can tell a certain hop from an inferred one: a dispatch edge expands to
+	// every compatible implementation, and a shortest route prefers whichever
+	// of them is the shortcut.
+	resolution   ResolutionKind
+	declaredType string
 }
 
 func dependencyClosure(root ComponentKey, deps DependencyGraph) []ComponentKey {
@@ -472,6 +483,10 @@ type callEdge struct {
 	internal                 bool
 	entryCall                *CallSite
 	resolvedReceiverType     string
+	// declaredType is the static type the call was written against. On a
+	// dispatch edge it names what the walk could not narrow, which is the whole
+	// reason a consumer would want to see it.
+	declaredType string
 }
 
 // buildAdjacency composes the traversable call graph from the fragment closure
@@ -495,9 +510,9 @@ func buildAdjacency(
 	functionsByNode map[graphNode]Function,
 	dispatchSurfaces map[graphNode][]graphNode,
 	aliasByKey map[string][]graphNode,
-) (map[graphNode][]adjacencyEdge, map[graphNode][]graphNode, []SuppressedEdge) {
+) (map[graphNode][]adjacencyEdge, map[graphNode][]adjacencyEdge, []SuppressedEdge) {
 	out := make(map[graphNode][]adjacencyEdge)
-	ambiguous := make(map[graphNode][]graphNode)
+	ambiguous := make(map[graphNode][]adjacencyEdge)
 	var suppressed []SuppressedEdge
 	ownerTypes := indexOwnerTypes(closure, fragments)
 
@@ -573,7 +588,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 		edges = append(edges, callEdge{
 			caller: e.Caller, target: e.Callee, resolution: e.Resolution,
 			method: e.MethodName, arity: e.Arity, callSite: e.CallSite, startCol: e.StartCol, endCol: e.EndCol, internal: true, entryCall: e.EntryCall,
-			resolvedReceiverType: e.ResolvedReceiverType,
+			resolvedReceiverType: e.ResolvedReceiverType, declaredType: e.DeclaredType,
 		})
 	}
 	for i := range fragment.ExternalCalls {
@@ -581,7 +596,7 @@ func collectCallEdges(fragment Fragment) []callEdge {
 		edges = append(edges, callEdge{
 			caller: c.Caller, target: c.TargetSignature, targetCanonicalSignature: c.TargetCanonicalSignature, resolution: c.Resolution,
 			method: c.MethodName, arity: c.Arity, callSite: c.CallSite, startCol: c.StartCol, endCol: c.EndCol, internal: false, entryCall: c.EntryCall,
-			resolvedReceiverType: c.ResolvedReceiverType,
+			resolvedReceiverType: c.ResolvedReceiverType, declaredType: c.DeclaredType,
 		})
 	}
 	return edges
@@ -798,7 +813,7 @@ func applyImmediateEdgePolicy(
 	ownerTypes map[graphNode]string,
 	fragments map[ComponentKey]Fragment,
 	functionsByNode map[graphNode]Function,
-	ambiguous map[graphNode][]graphNode,
+	ambiguous map[graphNode][]adjacencyEdge,
 ) map[dispatchGroupKey][]callEdge {
 	// Interface-dispatch candidates are deferred and grouped per call site so
 	// ambiguity (>1 impl in closure) is detected across all sibling edges,
@@ -815,7 +830,7 @@ func applyImmediateEdgePolicy(
 				dispatchGroups[gk] = append(dispatchGroups[gk], *e)
 				continue
 			}
-			appendAdjacencyEdges(adjacency, caller, targets.nodes, e.entryCall)
+			appendAdjacencyEdges(adjacency, caller, targets.nodes, e)
 			expandDispatchSurfaces(key, e, caller, targets.nodes, dispatchSurfaces, ownerTypes, fragments, functionsByNode, adjacency, suppressed, ambiguous)
 		case ResolutionInterfaceDispatch:
 			gk := dispatchKey(key, *e)
@@ -848,7 +863,7 @@ func expandDispatchSurfaces(
 	functionsByNode map[graphNode]Function,
 	adjacency map[graphNode][]adjacencyEdge,
 	suppressed *[]SuppressedEdge,
-	ambiguous map[graphNode][]graphNode,
+	ambiguous map[graphNode][]adjacencyEdge,
 ) {
 	for _, target := range targets {
 		impls := dispatchSurfaces[target]
@@ -856,18 +871,18 @@ func expandDispatchSurfaces(
 			continue
 		}
 		if len(impls) == 1 {
-			appendAdjacencyEdges(adjacency, caller, impls, e.entryCall)
+			appendAdjacencyEdges(adjacency, caller, impls, e)
 			continue
 		}
 		implEdges := make([]adjacencyEdge, 0, len(impls))
 		for _, impl := range impls {
-			implEdges = append(implEdges, adjacencyEdge{target: impl, entryCall: e.entryCall})
+			implEdges = append(implEdges, adjacencyEdge{target: impl, entryCall: e.entryCall, resolution: e.resolution, declaredType: e.declaredType})
 		}
 		if resolved, ok := disambiguateByReceiverType([]callEdge{*e}, implEdges, ownerTypes); ok {
 			adjacency[caller] = append(adjacency[caller], resolved)
 			continue
 		}
-		ambiguous[caller] = append(ambiguous[caller], impls...)
+		ambiguous[caller] = append(ambiguous[caller], implEdges...)
 		*suppressed = append(*suppressed, ambiguousDispatchEdge(key, dispatchKey(key, *e), implEdges, fragments, functionsByNode))
 	}
 }
@@ -893,7 +908,7 @@ func applyDispatchGroups(
 	functionsByNode map[graphNode]Function,
 	adjacency map[graphNode][]adjacencyEdge,
 	suppressed *[]SuppressedEdge,
-	ambiguous map[graphNode][]graphNode,
+	ambiguous map[graphNode][]adjacencyEdge,
 ) {
 	for _, gk := range sortedDispatchKeys(groups) {
 		group := groups[gk]
@@ -907,9 +922,7 @@ func applyDispatchGroups(
 				adjacency[caller] = append(adjacency[caller], resolved)
 				continue
 			}
-			for _, t := range targets {
-				ambiguous[caller] = append(ambiguous[caller], t.target)
-			}
+			ambiguous[caller] = append(ambiguous[caller], targets...)
 			*suppressed = append(*suppressed, ambiguousDispatchEdge(key, gk, targets, fragments, functionsByNode))
 			// len(targets) == 0: no implementation in closure -> unreachable,
 			// nothing to traverse and nothing to record.
@@ -985,10 +998,15 @@ func appendAdjacencyEdges(
 	adjacency map[graphNode][]adjacencyEdge,
 	caller graphNode,
 	targets []graphNode,
-	entryCall *CallSite,
+	edge *callEdge,
 ) {
 	for _, target := range targets {
-		adjacency[caller] = append(adjacency[caller], adjacencyEdge{target: target, entryCall: entryCall})
+		adjacency[caller] = append(adjacency[caller], adjacencyEdge{
+			target:       target,
+			entryCall:    edge.entryCall,
+			resolution:   edge.resolution,
+			declaredType: edge.declaredType,
+		})
 	}
 }
 
@@ -1002,7 +1020,7 @@ func distinctTargetEdges(edges []callEdge, resolve edgeResolver) []adjacencyEdge
 				continue
 			}
 			distinct[t] = true
-			targets = append(targets, adjacencyEdge{target: t, entryCall: e.entryCall})
+			targets = append(targets, adjacencyEdge{target: t, entryCall: e.entryCall, resolution: e.resolution, declaredType: e.declaredType})
 		}
 	}
 	return targets
@@ -1018,10 +1036,14 @@ func ambiguousDispatchEdge(
 	targets = sortedAdjacencyEdges(targets)
 	frames := make([]CallFrame, 0, len(targets))
 	for _, target := range targets {
-		frames = append(frames, buildFrame(target.target, target.entryCall, fragments, functionsByNode))
+		frames = append(frames, buildFrame(target.target, inbound{
+			entryCall:    target.entryCall,
+			resolution:   target.resolution,
+			declaredType: target.declaredType,
+		}, fragments, functionsByNode))
 	}
 	return SuppressedEdge{
-		Caller:          buildFrame(graphNode{Component: key, Function: gk.Caller}, nil, fragments, functionsByNode),
+		Caller:          buildFrame(graphNode{Component: key, Function: gk.Caller}, inbound{}, fragments, functionsByNode),
 		MethodName:      gk.MethodName,
 		Arity:           gk.Arity,
 		CallSite:        gk.CallSite,
@@ -1158,17 +1180,26 @@ const (
 // the entryCall of the FORWARD edge (caller -> node) so frame EntryCall stamping
 // stays byte-identical to the old forward DFS.
 type reverseEdge struct {
-	caller    graphNode
-	entryCall *CallSite
+	caller graphNode
+	inbound
+}
+
+// inbound describes the edge that arrives at a frame: its call site, how it was
+// established, and the static type it was written against. Grouped because the
+// three always travel together, from the adjacency to the served frame.
+type inbound struct {
+	entryCall    *CallSite
+	resolution   ResolutionKind
+	declaredType string
 }
 
 // backwardChain is the chain being grown by the BFS, in entry->...->op order.
-// entryCalls[i] is the EntryCall to stamp on nodes[i] — i.e. the call site of the
-// forward edge that ARRIVES at nodes[i] from nodes[i-1] (nil on the head/root
-// frame), exactly as the previous forward DFS stamped CallFrame.EntryCall.
+// inbounds[i] describes the edge that ARRIVES at nodes[i] from nodes[i-1]: its
+// call site, how it was established, and the type it was written against. The
+// head frame has no inbound edge and carries the zero value.
 type backwardChain struct {
-	nodes      []graphNode
-	entryCalls []*CallSite
+	nodes    []graphNode
+	inbounds []inbound
 }
 
 // traceBackward mirrors internal/callgraph.Tracer.TraceBackLimited: for each
@@ -1211,6 +1242,8 @@ func traceBackward(
 	roots []graphNode,
 	chainEntries map[graphNode]bool,
 	composedFindings map[string]bool,
+	composedRoutes map[string][]graphNode,
+	ambiguousCandidates map[graphNode][]adjacencyEdge,
 	out *Result,
 ) {
 	reverse := reverseAdjacency(adjacency)
@@ -1256,7 +1289,7 @@ func traceBackward(
 			// of its callers are entries). Mirror live's buildBaseCallChains fallback:
 			// emit a single-node chain so a self-contained crypto call is still
 			// reported. The op node IS its own entry in this case.
-			chains = []backwardChain{{nodes: []graphNode{opNode}, entryCalls: []*CallSite{nil}}}
+			chains = []backwardChain{composedRouteChain(opNode, opsByNode[opNode], composedRoutes, adjacency, ambiguousCandidates, out)}
 		}
 		for _, chain := range chains {
 			emitChain(opNode, chain, opsByNode, supportingByNode, fragments, functionsByNode, supportingSeen, out)
@@ -1273,6 +1306,7 @@ func composedChainEntryFindings(
 	out *Result,
 	functionsByNode map[graphNode]Function,
 	signatures []string,
+	routes map[string][]graphNode,
 ) map[string]bool {
 	if len(signatures) == 0 || len(out.composedEntryPoints) == 0 {
 		return nil
@@ -1296,11 +1330,79 @@ func composedChainEntryFindings(
 		for id := range out.composedRawFindings[ep.FunctionKey] {
 			findings[id] = true
 		}
+		for id, route := range out.composedRoutes[ep.FunctionKey] {
+			if existing, seen := routes[id]; !seen || len(route) < len(existing) {
+				routes[id] = route
+			}
+		}
 	}
 	if len(findings) == 0 {
 		return nil
 	}
 	return findings
+}
+
+// composedRouteChain is the chain emitted when no route could be enumerated.
+// A requested composed entry point that named its whole route to one of this
+// node's operations supplies its frames; otherwise the chain degrades to the
+// single node, which is what a crypto call nothing calls reports.
+func composedRouteChain(
+	opNode graphNode,
+	ops []CryptoOperation,
+	composedRoutes map[string][]graphNode,
+	adjacency, ambiguousCandidates map[graphNode][]adjacencyEdge,
+	out *Result,
+) backwardChain {
+	for i := range ops {
+		route := composedRoutes[ops[i].FindingID]
+		if len(route) < 2 || route[len(route)-1] != opNode {
+			continue
+		}
+		if out.composedRouteChains == nil {
+			out.composedRouteChains = make(map[graphNode]bool)
+		}
+		out.composedRouteChains[opNode] = true
+		return backwardChain{nodes: route, inbounds: composedRouteInbounds(route, adjacency, ambiguousCandidates)}
+	}
+	return backwardChain{nodes: []graphNode{opNode}, inbounds: []inbound{{}}}
+}
+
+// composedRouteInbounds resolves, for each hop of a composed route, the edge
+// that arrives at it. The stitched leg is in the adjacency; the leg the
+// dependency's fragment recorded is not, and its hops report no resolution
+// rather than borrowing one they were not given.
+func composedRouteInbounds(
+	route []graphNode,
+	adjacency map[graphNode][]adjacencyEdge,
+	ambiguousCandidates map[graphNode][]adjacencyEdge,
+) []inbound {
+	out := make([]inbound, len(route))
+	for i := 1; i < len(route); i++ {
+		// The ambiguous candidates are searched too, and deliberately: an edge
+		// lands there because its dispatch could not be narrowed, so those are
+		// the least certain hops of all. Leaving exactly those unlabelled would
+		// invert the point of labelling.
+		out[i] = lookupInbound(route[i-1], route[i], adjacency, ambiguousCandidates)
+	}
+	return out
+}
+
+func lookupInbound(
+	caller, callee graphNode,
+	adjacency, ambiguousCandidates map[graphNode][]adjacencyEdge,
+) inbound {
+	for _, group := range [2][]adjacencyEdge{adjacency[caller], ambiguousCandidates[caller]} {
+		for _, edge := range group {
+			if edge.target == callee {
+				return inbound{
+					entryCall:    edge.entryCall,
+					resolution:   edge.resolution,
+					declaredType: edge.declaredType,
+				}
+			}
+		}
+	}
+	return inbound{}
 }
 
 // composedReaches reports whether a requested composed entry point proves it
@@ -1324,7 +1426,14 @@ func reverseAdjacency(adjacency map[graphNode][]adjacencyEdge) map[graphNode][]r
 	reverse := make(map[graphNode][]reverseEdge)
 	for caller, edges := range adjacency {
 		for _, edge := range edges {
-			reverse[edge.target] = append(reverse[edge.target], reverseEdge{caller: caller, entryCall: edge.entryCall})
+			reverse[edge.target] = append(reverse[edge.target], reverseEdge{
+				caller: caller,
+				inbound: inbound{
+					entryCall:    edge.entryCall,
+					resolution:   edge.resolution,
+					declaredType: edge.declaredType,
+				},
+			})
 		}
 	}
 	for target := range reverse {
@@ -1356,7 +1465,7 @@ func emitChain(
 ) {
 	frames := make([]CallFrame, len(chain.nodes))
 	for i, node := range chain.nodes {
-		frames[i] = buildFrame(node, chain.entryCalls[i], fragments, functionsByNode)
+		frames[i] = buildFrame(node, chain.inbounds[i], fragments, functionsByNode)
 	}
 
 	// Flush supporting calls in entry->op order so output ordering matches the old
@@ -1390,14 +1499,16 @@ func emitChain(
 // identity from the fragment and the EntryCall of the edge that led to this frame.
 func buildFrame(
 	node graphNode,
-	entryCall *CallSite,
+	in inbound,
 	fragments map[ComponentKey]Fragment,
 	functionsByNode map[graphNode]Function,
 ) CallFrame {
 	frame := CallFrame{
-		Component: node.Component,
-		Signature: node.Function,
-		EntryCall: entryCall,
+		Component:         node.Component,
+		Signature:         node.Function,
+		EntryCall:         in.entryCall,
+		EntryResolution:   in.resolution,
+		EntryDeclaredType: in.declaredType,
 	}
 	if frag, ok := fragments[node.Component]; ok {
 		frame.Module = frag.Module
@@ -1442,7 +1553,7 @@ func trace(
 	supportingByNode map[graphNode][]SupportingCall,
 	fragments map[ComponentKey]Fragment,
 	functionsByNode map[graphNode]Function,
-	traversedEdgeEntryCall *CallSite,
+	traversedEdge inbound,
 	path []CallFrame,
 	visiting map[graphNode]bool,
 	out *Result,
@@ -1453,7 +1564,7 @@ func trace(
 	visiting[current] = true
 	defer delete(visiting, current)
 
-	frame := buildFrame(current, traversedEdgeEntryCall, fragments, functionsByNode)
+	frame := buildFrame(current, traversedEdge, fragments, functionsByNode)
 
 	path = append(path, frame)
 	flushSupportingCalls(current, &frame, supportingByNode, out)
@@ -1473,8 +1584,10 @@ func trace(
 		out.Chains = append(out.Chains, chain)
 	}
 	for _, edge := range adjacency[current] {
-		// Carry the EntryCall from this edge to the next frame.
-		trace(edge.target, adjacency, opsByNode, supportingByNode, fragments, functionsByNode, edge.entryCall, path, visiting, out)
+		// Carry this edge's call site and resolution to the next frame.
+		trace(edge.target, adjacency, opsByNode, supportingByNode, fragments, functionsByNode,
+			inbound{entryCall: edge.entryCall, resolution: edge.resolution, declaredType: edge.declaredType},
+			path, visiting, out)
 	}
 }
 
@@ -1593,7 +1706,7 @@ func forwardBFS(
 	caps forwardCaps,
 ) *forwardClosure {
 	fc := &forwardClosure{
-		anchor:   buildFrame(anchor, nil, fragments, functionsByNode),
+		anchor:   buildFrame(anchor, inbound{}, fragments, functionsByNode),
 		maxDepth: caps.maxDepth,
 	}
 
@@ -1713,7 +1826,7 @@ func buildForwardNode(
 	category := firstSupportingCategory(supportingByNode[node])
 	return forwardNode{
 		node:               node,
-		frame:              buildFrame(node, nil, fragments, functionsByNode),
+		frame:              buildFrame(node, inbound{}, fragments, functionsByNode),
 		depth:              depth,
 		cryptoRelevant:     len(opsByNode[node]) > 0 || category != "",
 		supportingCategory: category,
@@ -1763,7 +1876,7 @@ func composeDependencyEntryPoints(
 	closure []ComponentKey,
 	fragments map[ComponentKey]Fragment,
 	adjacency map[graphNode][]adjacencyEdge,
-	ambiguousCandidates map[graphNode][]graphNode,
+	ambiguousCandidates map[graphNode][]adjacencyEdge,
 	out *Result,
 ) {
 	reverse, reverseAll := composeReverseMaps(adjacency, ambiguousCandidates)
@@ -1789,13 +1902,13 @@ func composeDependencyEntryPoints(
 				continue
 			}
 			seed := graphNode{Component: dep, Function: ep.FunctionKey}
-			proven := backwardDistances(seed, reverse)
-			projectEntryPoint(root, ep, translate, proven, true, rootFunctions, hasIncoming, composed)
-			mayReach := backwardDistances(seed, reverseAll)
-			for node := range proven {
-				delete(mayReach, node)
+			proven := reachFrom(seed, reverse)
+			projectEntryPoint(root, dep, ep, translate, proven, true, rootFunctions, hasIncoming, composed)
+			mayReach := reachFrom(seed, reverseAll)
+			for node := range proven.Depth {
+				delete(mayReach.Depth, node)
 			}
-			projectEntryPoint(root, ep, translate, mayReach, false, rootFunctions, hasIncoming, composed)
+			projectEntryPoint(root, dep, ep, translate, mayReach, false, rootFunctions, hasIncoming, composed)
 		}
 	}
 	if len(composed) == 0 {
@@ -1810,6 +1923,7 @@ func composeDependencyEntryPoints(
 
 	out.composedFindingDepths = make(map[string]int)
 	out.composedRawFindings = make(map[string]map[string]bool)
+	out.composedRoutes = make(map[string]map[string][]graphNode)
 	for _, key := range keys {
 		appendComposedResult(root, rootFunctions[key], composed[key], hasIncoming, out)
 	}
@@ -1823,7 +1937,7 @@ const publicVisibility = "public"
 // index is may-reach by design, so a consumer-facing entry point may be
 // discovered THROUGH an ambiguous call, while finding-level reachability only
 // ever upgrades on proven paths.
-func composeReverseMaps(adjacency map[graphNode][]adjacencyEdge, ambiguousCandidates map[graphNode][]graphNode) (map[graphNode][]graphNode, map[graphNode][]graphNode) {
+func composeReverseMaps(adjacency map[graphNode][]adjacencyEdge, ambiguousCandidates map[graphNode][]adjacencyEdge) (map[graphNode][]graphNode, map[graphNode][]graphNode) {
 	reverse := make(map[graphNode][]graphNode)
 	for caller, edges := range adjacency {
 		for _, edge := range edges {
@@ -1836,7 +1950,7 @@ func composeReverseMaps(adjacency map[graphNode][]adjacencyEdge, ambiguousCandid
 	}
 	for caller, candidates := range ambiguousCandidates {
 		for _, candidate := range candidates {
-			reverseAll[candidate] = append(reverseAll[candidate], caller)
+			reverseAll[candidate.target] = append(reverseAll[candidate.target], caller)
 		}
 	}
 	return reverse, reverseAll
@@ -1867,21 +1981,26 @@ type composedEntry struct {
 	// rawIDs are the untranslated mine-time finding IDs, kept so a restricted
 	// enumeration can recognize the operations this entry point reaches.
 	rawIDs map[string]bool
+	// routes are the whole route to each finding, per untranslated finding id:
+	// the stitched frames to the dependency entry point followed by the frames
+	// the dependency's fragment recorded from there to the crypto. Absent for a
+	// finding whose dependency leg the fragment did not name.
+	routes map[string][]graphNode
 }
 
 // projectEntryPoint records, for every root-component function that reaches
 // one dependency entry point, the composed (hops + mine-time depth) records.
 func projectEntryPoint(
-	root ComponentKey,
+	root, dep ComponentKey,
 	ep *CryptoEntryPoint,
 	translate map[string]string,
-	distances map[graphNode]int,
+	reach graphwalk.Reachable[graphNode],
 	proven bool,
 	rootFunctions map[string]Function,
 	hasIncoming map[graphNode]bool,
 	composed map[string]*composedEntry,
 ) {
-	for node, distance := range distances {
+	for node, distance := range reach.Depth {
 		if node.Component != root {
 			continue
 		}
@@ -1900,11 +2019,37 @@ func projectEntryPoint(
 				supporting: make(map[string]ReachableSupportingCall),
 				provenIDs:  make(map[string]bool),
 				rawIDs:     make(map[string]bool),
+				routes:     make(map[string][]graphNode),
 			}
 			composed[node.Function] = entry
 		}
-		entry.merge(ep, translate, distance, proven)
+		entry.merge(dep, ep, translate, distance, proven, reach.Route(node))
 	}
+}
+
+// joinComposedRoute splices the two legs of a cross-component route: the
+// stitched frames from the consumer function to the dependency's entry point,
+// then the frames the dependency's fragment recorded from that entry point to
+// the crypto. Both legs name that entry point, so one copy is dropped.
+//
+// Nil when either leg is missing. Half a route is not a shorter route — it
+// would place the crypto somewhere it is not — and the depth still reports the
+// distance.
+func joinComposedRoute(dep ComponentKey, stitched []graphNode, mined []string) []graphNode {
+	if len(stitched) == 0 || len(mined) == 0 {
+		return nil
+	}
+	// The shared frame must actually be shared, or the legs describe different
+	// routes and splicing them invents a call.
+	if stitched[len(stitched)-1].Function != mined[0] {
+		return nil
+	}
+	route := make([]graphNode, 0, len(stitched)+len(mined)-1)
+	route = append(route, stitched...)
+	for _, key := range mined[1:] {
+		route = append(route, graphNode{Component: dep, Function: key})
+	}
+	return route
 }
 
 // servedFindingIDs maps a dependency's mine-time (annotation-local) finding
@@ -1936,7 +2081,14 @@ func translateFindingID(translate map[string]string, findingID string) string {
 
 // merge folds one entry point's reachable records into the composed entry,
 // keeping the minimum depth per finding/supporting id.
-func (c *composedEntry) merge(ep *CryptoEntryPoint, translate map[string]string, distance int, proven bool) {
+func (c *composedEntry) merge(
+	dep ComponentKey,
+	ep *CryptoEntryPoint,
+	translate map[string]string,
+	distance int,
+	proven bool,
+	stitched []graphNode,
+) {
 	for _, rf := range ep.ReachableFindings {
 		findingID := translateFindingID(translate, rf.FindingID)
 		c.rawIDs[rf.FindingID] = true
@@ -1946,6 +2098,11 @@ func (c *composedEntry) merge(ep *CryptoEntryPoint, translate map[string]string,
 				FindingID:       findingID,
 				ChainDepth:      depth,
 				FindingGraphRef: translateFindingID(translate, rf.FindingGraphRef),
+			}
+			if route := joinComposedRoute(dep, stitched, rf.Route); route != nil {
+				c.routes[rf.FindingID] = route
+			} else {
+				delete(c.routes, rf.FindingID)
 			}
 		}
 		if proven {
@@ -2000,6 +2157,9 @@ func appendComposedResult(root ComponentKey, fn Function, entry *composedEntry, 
 	if len(entry.rawIDs) > 0 {
 		out.composedRawFindings[fn.Signature] = entry.rawIDs
 	}
+	if len(entry.routes) > 0 {
+		out.composedRoutes[fn.Signature] = entry.routes
+	}
 	if !hasIncoming[graphNode{Component: root, Function: fn.Signature}] {
 		if out.composedRoots == nil {
 			out.composedRoots = make(map[string]bool)
@@ -2017,20 +2177,12 @@ func sortedComposedIDs(findings map[string]ReachableFinding) []string {
 	return ids
 }
 
-// backwardDistances runs a BFS over the reversed adjacency from seed and
-// returns the minimum hop count to every node that can reach it.
-func backwardDistances(seed graphNode, reverse map[graphNode][]graphNode) map[graphNode]int {
-	distances := map[graphNode]int{seed: 0}
-	queue := []graphNode{seed}
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-		for _, caller := range reverse[current] {
-			if _, seen := distances[caller]; !seen {
-				distances[caller] = distances[current] + 1
-				queue = append(queue, caller)
-			}
-		}
-	}
-	return distances
+// reachFrom walks callers backward from seed over a plain caller map. It is the
+// shared walker rather than a local BFS so the route it names is the one the
+// depth it reports measures — the two cannot drift apart.
+func reachFrom(seed graphNode, reverse map[graphNode][]graphNode) graphwalk.Reachable[graphNode] {
+	return graphwalk.Reach(seed, graphwalk.Options[graphNode]{
+		Callers: func(n graphNode) []graphNode { return reverse[n] },
+		Less:    nodeLess,
+	})
 }

--- a/pkg/graphfrag/stitch_condensed.go
+++ b/pkg/graphfrag/stitch_condensed.go
@@ -47,12 +47,12 @@ func condensedBackwardChains(
 	entrySet map[graphNode]bool,
 ) (chains []backwardChain, total int, truncated bool) {
 	callers := make(map[graphNode][]graphNode, len(reverse))
-	callSites := make(map[callSiteKey]*CallSite, len(reverse))
+	inbounds := make(map[callSiteKey]inbound, len(reverse))
 	for target, edges := range reverse {
 		list := make([]graphNode, 0, len(edges))
 		for _, edge := range edges {
 			list = append(list, edge.caller)
-			callSites[callSiteKey{caller: edge.caller, target: target}] = edge.entryCall
+			inbounds[callSiteKey{caller: edge.caller, target: target}] = edge.inbound
 		}
 		callers[target] = list
 	}
@@ -74,7 +74,7 @@ func condensedBackwardChains(
 	condensed := graphwalk.Condense(reach, nodeLess)
 	total = graphwalk.Count(reach, condensed)
 	for _, route := range graphwalk.Routes(reach, condensed, stitchMaxChainsPerOp) {
-		chains = append(chains, materializeBackwardChain(route, callSites))
+		chains = append(chains, materializeBackwardChain(route, inbounds))
 	}
 	return chains, total, len(chains) < total
 }
@@ -83,15 +83,15 @@ func condensedBackwardChains(
 // entry->op order emitChain expects, stamping each frame with the call site of the
 // edge that arrives at it. The head frame has no inbound edge, so its entry call
 // is nil, exactly as the incremental walk left it.
-func materializeBackwardChain(route []graphNode, callSites map[callSiteKey]*CallSite) backwardChain {
+func materializeBackwardChain(route []graphNode, inbounds map[callSiteKey]inbound) backwardChain {
 	nodes := make([]graphNode, 0, len(route))
 	for i := len(route) - 1; i >= 0; i-- {
 		nodes = append(nodes, route[i])
 	}
 
-	entryCalls := make([]*CallSite, len(nodes))
+	stamped := make([]inbound, len(nodes))
 	for i := 1; i < len(nodes); i++ {
-		entryCalls[i] = callSites[callSiteKey{caller: nodes[i-1], target: nodes[i]}]
+		stamped[i] = inbounds[callSiteKey{caller: nodes[i-1], target: nodes[i]}]
 	}
-	return backwardChain{nodes: nodes, entryCalls: entryCalls}
+	return backwardChain{nodes: nodes, inbounds: stamped}
 }

--- a/pkg/graphfrag/stitch_reachset.go
+++ b/pkg/graphfrag/stitch_reachset.go
@@ -64,7 +64,7 @@ func recordReachEntries(
 	functionsByNode map[graphNode]Function,
 	out *Result,
 ) {
-	distances := backwardDistances(opNode, reverse)
+	distances := reachFrom(opNode, reverse).Depth
 	if len(distances) == 0 {
 		return
 	}
@@ -83,7 +83,7 @@ func recordReachEntries(
 	entries := make([]reachEntry, 0, len(nodes))
 	for _, node := range nodes {
 		entries = append(entries, reachEntry{
-			frame: buildFrame(node, nil, fragments, functionsByNode),
+			frame: buildFrame(node, inbound{}, fragments, functionsByNode),
 			depth: distances[node] + 1,
 			root:  entrySet[node],
 		})

--- a/pkg/graphwalk/graphwalk.go
+++ b/pkg/graphwalk/graphwalk.go
@@ -72,6 +72,32 @@ type Reachable[T comparable] struct {
 	// Callers is the adjacency induced on Depth's keys. Terminals carry no
 	// entry: a chain stops there.
 	Callers map[T][]T
+	// Step is the next node on one minimum-length route from a node to the
+	// target: the callee it calls. The target carries no entry. Following Step
+	// names ONE route of Depth length — the walk still admits each node once, so
+	// this is not the route set and cannot be used to enumerate it. Naming the
+	// route the recorded Depth already measures is the whole purpose.
+	Step map[T]T
+}
+
+// Route returns one minimum-length route from `from` to the target, in
+// caller-to-callee order and inclusive of both ends. It is nil when `from` did
+// not reach the target, and its length is always Depth[from]+1.
+func (r Reachable[T]) Route(from T) []T {
+	if _, ok := r.Depth[from]; !ok {
+		return nil
+	}
+	route := []T{from}
+	current := from
+	for current != r.Target {
+		step, ok := r.Step[current]
+		if !ok {
+			return nil
+		}
+		current = step
+		route = append(route, current)
+	}
+	return route
 }
 
 // Reach walks callers breadth-first from target and records every node that
@@ -82,12 +108,17 @@ type Reachable[T comparable] struct {
 // that collected paths under the same rule would lose the second branch into any
 // shared caller — which is exactly the defect this package exists to avoid
 // repeating.
+//
+// Reachable.Step therefore names one route per node and never the route set: the
+// branch a shared caller loses is a route this walk was never entitled to report.
+// Callers that need the route set condense first and go through Routes.
 func Reach[T comparable](target T, opts Options[T]) Reachable[T] {
 	out := Reachable[T]{
 		Target:   target,
 		Depth:    map[T]int{target: 0},
 		Terminal: map[T]bool{},
 		Callers:  map[T][]T{},
+		Step:     map[T]T{},
 	}
 
 	queue := []T{target}
@@ -140,6 +171,7 @@ func (r *Reachable[T]) enqueueCallers(current T, callers []T, depth int, queue [
 			continue
 		}
 		r.Depth[caller] = depth + 1
+		r.Step[caller] = current
 		queue = append(queue, caller)
 	}
 	return queue

--- a/pkg/graphwalk/route_test.go
+++ b/pkg/graphwalk/route_test.go
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphwalk
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// routeFixture is a diamond over a cycle: alpha and beta both call mid, and beta
+// and gamma call each other. Both shapes are the ones that make a path-collecting
+// walk lose branches, so they are the ones a single-route walk has to survive.
+//
+//	sink  <- mid <- alpha            (alpha has no callers: a graph root)
+//	              <- beta  <-> gamma
+func routeFixture() Options[string] {
+	callers := map[string][]string{
+		"sink":  {"mid"},
+		"mid":   {"alpha", "beta"},
+		"beta":  {"gamma"},
+		"gamma": {"beta"},
+	}
+	return Options[string]{
+		Callers:        func(n string) []string { return callers[n] },
+		Less:           func(a, b string) bool { return a < b },
+		RootIsTerminal: true,
+	}
+}
+
+// assertRouteInvariants is the whole correctness argument, checked over every
+// node a walk admitted: a route has Depth+1 frames, every consecutive pair is a
+// real call edge, and it ends at the target.
+func assertRouteInvariants(t *testing.T, r Reachable[string], opts Options[string]) {
+	t.Helper()
+
+	nodes := make([]string, 0, len(r.Depth))
+	for n := range r.Depth {
+		nodes = append(nodes, n)
+	}
+	sort.Strings(nodes)
+
+	for _, n := range nodes {
+		route := r.Route(n)
+		if route == nil {
+			t.Errorf("Route(%q) = nil, want a route: the node was reached at depth %d", n, r.Depth[n])
+			continue
+		}
+		if got, want := len(route), r.Depth[n]+1; got != want {
+			t.Errorf("Route(%q) has %d frames, want Depth+1 = %d: %v", n, got, want, route)
+		}
+		if route[0] != n {
+			t.Errorf("Route(%q) starts at %q", n, route[0])
+		}
+		if last := route[len(route)-1]; last != r.Target {
+			t.Errorf("Route(%q) ends at %q, want the target %q: %v", n, last, r.Target, route)
+		}
+		for i := 0; i+1 < len(route); i++ {
+			caller, callee := route[i], route[i+1]
+			var found bool
+			for _, c := range opts.Callers(callee) {
+				if c == caller {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Route(%q) step %d: %q does not call %q — not a real edge: %v",
+					n, i, caller, callee, route)
+			}
+		}
+	}
+}
+
+func TestReachRoute(t *testing.T) {
+	t.Parallel()
+
+	opts := routeFixture()
+	r := Reach("sink", opts)
+
+	assertRouteInvariants(t, r, opts)
+
+	for _, tc := range []struct {
+		node string
+		want string
+	}{
+		{"sink", "sink"},
+		{"mid", "mid,sink"},
+		{"alpha", "alpha,mid,sink"},
+		{"beta", "beta,mid,sink"},
+		// gamma reaches the target only through the cycle partner.
+		{"gamma", "gamma,beta,mid,sink"},
+	} {
+		if got := strings.Join(r.Route(tc.node), ","); got != tc.want {
+			t.Errorf("Route(%q) = %q, want %q", tc.node, got, tc.want)
+		}
+	}
+}
+
+// TestReachRouteUnreached: a node the walk never admitted has no route. Returning
+// a partial one would assert a reachability the walk did not establish.
+func TestReachRouteUnreached(t *testing.T) {
+	t.Parallel()
+
+	r := Reach("sink", routeFixture())
+	if route := r.Route("absent"); route != nil {
+		t.Errorf("Route(absent) = %v, want nil", route)
+	}
+}
+
+// TestReachRouteRespectsMaxDepth pins that a route cannot exceed the frame bound
+// the walk was given, which is what keeps a stored route bounded.
+func TestReachRouteRespectsMaxDepth(t *testing.T) {
+	t.Parallel()
+
+	opts := routeFixture()
+	opts.MaxDepth = 3
+	r := Reach("sink", opts)
+
+	assertRouteInvariants(t, r, opts)
+
+	if _, admitted := r.Depth["gamma"]; admitted {
+		t.Errorf("gamma admitted at MaxDepth 3: its route needs 4 frames")
+	}
+	for n := range r.Depth {
+		if got := len(r.Route(n)); got > opts.MaxDepth {
+			t.Errorf("Route(%q) has %d frames, over MaxDepth %d", n, got, opts.MaxDepth)
+		}
+	}
+}
+
+// TestReachRouteBoundaryStops: a boundary node terminates a chain and is not
+// expanded, so nothing behind it is reachable and nothing behind it gets a route.
+func TestReachRouteBoundaryStops(t *testing.T) {
+	t.Parallel()
+
+	opts := routeFixture()
+	opts.IsBoundary = func(n string) bool { return n == "mid" }
+	r := Reach("sink", opts)
+
+	assertRouteInvariants(t, r, opts)
+
+	if !r.Terminal["mid"] {
+		t.Error("mid is a boundary and must be a terminal")
+	}
+	for _, behind := range []string{"alpha", "beta", "gamma"} {
+		if route := r.Route(behind); route != nil {
+			t.Errorf("Route(%q) = %v, want nil: it sits behind a boundary", behind, route)
+		}
+	}
+}
+
+// TestReachRouteAdditive pins that adding Step left the answer alone: the fields
+// consumers already read must not depend on it.
+func TestReachRouteAdditive(t *testing.T) {
+	t.Parallel()
+
+	r := Reach("sink", routeFixture())
+
+	wantDepth := map[string]int{"sink": 0, "mid": 1, "alpha": 2, "beta": 2, "gamma": 3}
+	if len(r.Depth) != len(wantDepth) {
+		t.Fatalf("Depth = %v, want %v", r.Depth, wantDepth)
+	}
+	for n, d := range wantDepth {
+		if r.Depth[n] != d {
+			t.Errorf("Depth[%q] = %d, want %d", n, r.Depth[n], d)
+		}
+	}
+	if !r.Terminal["alpha"] {
+		t.Error("alpha has no callers and must be a terminal")
+	}
+	if _, ok := r.Step[r.Target]; ok {
+		t.Error("the target must carry no Step entry")
+	}
+}

--- a/schemas/callgraph-schema.json
+++ b/schemas/callgraph-schema.json
@@ -12,7 +12,7 @@
   "additionalProperties": false,
   "properties": {
     "schema_version": {
-      "const": "6.12",
+      "const": "6.13",
       "type": "string",
       "description": "Version of the customer-facing callgraph contract."
     },


### PR DESCRIPTION
Fixes #289.

A finding reached across a component boundary was served with a single frame — the function holding the crypto — while the entry-point index stated the crypto was 14, 18 or 31 calls away. The route those numbers measure was computed and discarded. This stores one minimum-length route per reachable finding and splices it with the stitched leg, so the served chain spans the boundary.

## What changed

**`pkg/graphwalk`** — `Reach` already walked breadth-first and recorded `Depth`; it now records the next node toward the target as well, and `Reachable.Route` reconstructs one minimum-length route from it. The walker is shared by the scanner and the stitcher, so one change serves both. This names one route and never the route set — the package's own warning about path-collecting walks is unaffected, and callers needing the set still condense and go through `Routes`.

**Fragment (`graph-fragment-1.13`)** — `crypto_entry_points[].reachable_findings[].route` carries the route as indexes into `functions[]`, the encoding `internal_edges_compact` already uses. `omitempty`, so a fragment exported earlier stays valid and reports no route. An index the fragment cannot resolve drops the whole route rather than a frame: a route with a hole would claim a call that is not in the graph, and the depth still answers the distance.

**Mining** — `addGraphFragmentFindingReachability` already held the route: `depth := len(chain) - pos` is the length of `chain[pos:]`. It now records the slice alongside the length. The exported `functions[]` numbering is threaded in rather than re-derived, because a route resolved against a different order would name the wrong functions and still look well-formed.

**Stitch** — the composed projection's local BFS is replaced by the shared walker, so the route it names is the one the depth it reports measures. `joinComposedRoute` splices the stitched leg with the dependency's recorded leg, dropping the frame they share, and returns nothing unless both legs are present and actually meet at that frame.

**`analysis.call_chains` stays `partial`.** The route is whole, but the dependency's leg was recorded under that dependency's own chain cap, and that is what the field reports. Without this the value came out `complete` by accident: it is derived from forward-closure completeness, and the composed downgrade no longer ran once a chain made the finding reachable.

**Frame annotation (`callgraph 6.13`)** — `call_chains[].entry_resolution` and `entry_declared_type` report how the call arriving at each frame was established and, for a dispatch, the static type that could not be narrowed. Proposed and agreed on the issue. A route is chosen by minimum length, so a dispatch edge that happens to be spurious is exactly the kind of hop a route prefers; 45.8% of internal edges in the components measured here are `interface_dispatch`, and a served frame said nothing about which hops those were.

Reaching that required the ambiguous-candidate map to stop discarding its edges. An edge lands there because its dispatch could not be narrowed — the least certain hops of all — and it was keeping only the target node, so those hops were the ones left unlabelled. That inverted the point of labelling.

## Verification

Two fragments mined from Maven Central sources, stitched with the dependency graph between them, filtered by the composed entry point the root publishes:

| | Before | After |
|---|---|---|
| frames per chain | 1 | 14–31 |
| `reachability` | `reachable` | unchanged |
| `analysis.call_chains` | `partial` | unchanged |
| unfiltered request | 18 finding graphs, 7 `reachable` / 11 `unknown` | identical |

The route now spans the boundary, `dependency_info` marking where it crosses, and each hop carries how it was resolved:

```
 1. [spring-kafka ]                    KafkaTemplate.send(String, K, V): CompletableFuture
 2. [spring-kafka ] exact              KafkaTemplate.observeSend(ProducerRecord): CompletableFuture
 ...
 9. [spring-kafka ] exact              DefaultKafkaProducerFactory.createRawProducer(Map): Producer
10. [kafka-clients] exact              KafkaProducer.<init>(Map, Serializer, Serializer): KafkaProducer
13. [kafka-clients] interface_dispatch SaslChannelBuilder.configure(Map): void  via org.apache.kafka.common.Configurable
15. [kafka-clients] interface_dispatch AbstractCoordinator.close(): void  via …auth.AuthenticateCallbackHandler
```

Frame 15 reads as out of place on its own; the annotation names why it is there — `SaslChannelBuilder.close()` calls `close()` on an interface-typed handler, so every compatible implementation is a candidate.

**Route invariants over real graphs.** For every node a walk admits, a route must have `Depth+1` frames, be made of real edges, and end at the target. Checked over the whole reverse graph of two mined components: 1,212,367 nodes verified across 1,162 walks, zero failures. Routes are bounded by the existing `callGraphExportMaxDepth = 32`; measured maxima are 20 and 29.

**Fragment round-trip.** Ingesting a real mined fragment: 857 of 857 pairs carry a route, every route resolves to function keys the fragment declares, every length equals its `chain_depth`, and every route starts at the entry point publishing it.

**Size.** `kafka-clients@3.7.1` grows 111.61 MB → 111.69 MB, **+0.068%**. On the largest component measured, `bcprov-jdk18on@1.78.1`, one route per pair over 42,561 pairs is 377,954 frames — 1.89 MB on a 506 MB fragment, **+0.35%**. As function-key strings instead of indexes it would be 7.7 MB, which is why indexes are the encoding.

`go test ./...` passes: 30 packages. The three failures are the Postgres findings-cache tests in `internal/engine`, which start a container and fail with `rootless Docker not found`; identical on `main`.

## Rollout

The fragment field is additive and optional, so stored fragments keep serving what they serve today and a component gains its route when it is re-mined. A closure mixing re-mined and older members reports each accordingly. Ordering is forced: release, then the serving side, then re-mining — a fragment above the served schema ceiling is rejected. Tracked for the serving side in scanoss.api#143.

## Follow-up

Reducing the dispatch fan-out itself — resolving the receiver's concrete type where it is known, the lever #262 added for field-typed receivers — would improve reachability, depths and chains together rather than only how a route reads. Discussed on the issue as the real improvement; deliberately not attempted here.
