### PR TITLE
fix(callgraph): resolve C++ types inside macro-opened namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- C++ types declared inside a namespace opened by a macro (`NAMESPACE_BEGIN(X)`) now resolve to their qualified identity instead of a bare one. Mining such a library previously attributed none of its crypto to the library's own types, because a rule or contract anchored on the qualified name could not match its sources. Crypto++ 8.9.0 goes from 0 to 9 library-attributed entry points. (#96)
 ### Added
 - Crypto++ callgraph contracts for the SHA-256 hash lifecycle, the first C++ library knowledge base. Supporting calls for Crypto++ now carry a lifecycle `category` and the truncated-digest length as a parameter role; previously the C++ KB was an empty placeholder and those calls were exported uncategorized. (#96)
 

--- a/internal/callgraph/cpp_namespace_macro_test.go
+++ b/internal/callgraph/cpp_namespace_macro_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A library that opens its namespace with a macro leaves its declarations as
+// siblings of the macro call, not children, so scope has to carry forward. Without
+// that, every type in such a library resolves unqualified and no rule or contract
+// anchored on the qualified name matches the library's own sources.
+func TestCPPParserResolvesMacroOpenedNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name, src, wantType string
+	}{
+		{
+			name: "macro opened",
+			src: `NAMESPACE_BEGIN(CryptoPP)
+void SHA256::InitState(int *state) { (void)state; }
+NAMESPACE_END`,
+			wantType: "CryptoPP::SHA256",
+		},
+		{
+			name: "nested macro namespaces",
+			src: `NAMESPACE_BEGIN(CryptoPP)
+NAMESPACE_BEGIN(Weak1)
+void MD5::Init(int *state) { (void)state; }
+NAMESPACE_END
+NAMESPACE_END`,
+			wantType: "CryptoPP::Weak1::MD5",
+		},
+		{
+			name: "closed before the definition",
+			src: `NAMESPACE_BEGIN(CryptoPP)
+NAMESPACE_END
+void Local::Init(int *state) { (void)state; }`,
+			wantType: "Local",
+		},
+		{
+			name: "literal namespace still resolves",
+			src: `namespace CryptoPP {
+void SHA256::InitState(int *state) { (void)state; }
+}`,
+			wantType: "CryptoPP::SHA256",
+		},
+		{
+			name: "already qualified is not doubled",
+			src: `NAMESPACE_BEGIN(CryptoPP)
+void CryptoPP::SHA256::InitState(int *state) { (void)state; }
+NAMESPACE_END`,
+			wantType: "CryptoPP::SHA256",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "lib.cpp"), []byte(tt.src+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			analyses, err := NewCPPParser().ParseDirectory(dir, "lib")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(analyses) != 1 || len(analyses[0].Functions) != 1 {
+				t.Fatalf("analyses = %#v, want one function", analyses)
+			}
+			if got := analyses[0].Functions[0].ID.Type; got != tt.wantType {
+				t.Fatalf("Type = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}

--- a/internal/callgraph/cpp_parser.go
+++ b/internal/callgraph/cpp_parser.go
@@ -102,9 +102,101 @@ func (p *CPPParser) walkFile(node *sitter.Node, src []byte, filePath, packagePat
 		return
 	}
 	scope = cppNestedScope(node, src, scope)
+	childScope := scope
 	for i := 0; i < int(node.ChildCount()); i++ {
-		p.walkFile(node.Child(i), src, filePath, packagePath, scope, staticFunctions, localTypes, analysis)
+		child := node.Child(i)
+		if next, handled := cppMacroScope(child, src, childScope, scope); handled {
+			childScope = next
+			continue
+		}
+		p.walkFile(child, src, filePath, packagePath, childScope, staticFunctions, localTypes, analysis)
 	}
+}
+
+// cppMacroScope tracks namespaces opened by a macro instead of a `namespace`
+// block. The macro leaves the declarations as siblings, not children, so the
+// scope has to carry forward across them rather than nest. Crypto++'s
+// NAMESPACE_BEGIN(CryptoPP) is the case this exists for; without it every type
+// in such a library resolves unqualified and no contract or rule anchored on the
+// qualified name can match the library's own sources.
+func cppMacroScope(node *sitter.Node, src []byte, current, outer string) (string, bool) {
+	name, kind := cppNamespaceMacro(node, src)
+	switch kind {
+	case cppMacroOpen:
+		if current == "" {
+			return name, true
+		}
+		return current + "::" + name, true
+	case cppMacroClose:
+		if idx := strings.LastIndex(current, "::"); idx >= 0 {
+			return current[:idx], true
+		}
+		return outer, true
+	}
+	return current, false
+}
+
+const (
+	cppMacroNone = iota
+	cppMacroOpen
+	cppMacroClose
+)
+
+// cppNamespaceMacro recognizes the BEGIN/END namespace macro idiom by shape:
+// a bare identifier or a single-identifier-argument call whose name reads as a
+// namespace delimiter. Matching on shape rather than a fixed list keeps the
+// common spellings (NAMESPACE_BEGIN, BEGIN_NAMESPACE, QT_BEGIN_NAMESPACE)
+// working without enumerating every library.
+func cppNamespaceMacro(node *sitter.Node, src []byte) (string, int) {
+	if node.Type() != rustNodeExpressionStatement || node.ChildCount() == 0 {
+		return "", cppMacroNone
+	}
+	inner := node.Child(0)
+	switch inner.Type() {
+	case cNodeIdentifier:
+		if kind := cppNamespaceMacroKind(inner.Content(src)); kind == cppMacroClose {
+			return "", kind
+		}
+	case "call_expression":
+		callee := inner.ChildByFieldName("function")
+		args := inner.ChildByFieldName("arguments")
+		if callee == nil || callee.Type() != cNodeIdentifier || args == nil {
+			return "", cppMacroNone
+		}
+		kind := cppNamespaceMacroKind(callee.Content(src))
+		if kind == cppMacroNone {
+			return "", cppMacroNone
+		}
+		var names []string
+		for i := 0; i < int(args.NamedChildCount()); i++ {
+			arg := args.NamedChild(i)
+			if arg.Type() != cNodeIdentifier {
+				return "", cppMacroNone
+			}
+			names = append(names, arg.Content(src))
+		}
+		if kind == cppMacroClose {
+			return "", kind
+		}
+		if len(names) != 1 {
+			return "", cppMacroNone
+		}
+		return names[0], cppMacroOpen
+	}
+	return "", cppMacroNone
+}
+
+func cppNamespaceMacroKind(name string) int {
+	if !strings.Contains(name, "NAMESPACE") {
+		return cppMacroNone
+	}
+	switch {
+	case strings.Contains(name, "BEGIN"):
+		return cppMacroOpen
+	case strings.Contains(name, "END"):
+		return cppMacroClose
+	}
+	return cppMacroNone
 }
 
 func collectCPPDeclaredTypes(node *sitter.Node, src []byte, scope string, result map[string]bool) {
@@ -112,8 +204,14 @@ func collectCPPDeclaredTypes(node *sitter.Node, src []byte, scope string, result
 	if nextScope != scope && (node.Type() == "class_specifier" || node.Type() == "struct_specifier") {
 		result[nextScope] = true
 	}
+	childScope := nextScope
 	for i := 0; i < int(node.ChildCount()); i++ {
-		collectCPPDeclaredTypes(node.Child(i), src, nextScope, result)
+		child := node.Child(i)
+		if next, handled := cppMacroScope(child, src, childScope, nextScope); handled {
+			childScope = next
+			continue
+		}
+		collectCPPDeclaredTypes(child, src, childScope, result)
 	}
 }
 
@@ -162,8 +260,14 @@ func (p *CPPParser) extractInclude(node *sitter.Node, src []byte, analysis *File
 func (p *CPPParser) parseFunction(node *sitter.Node, src []byte, filePath, packagePath, scope string, staticFunctions, localTypes map[string]bool) *FunctionDecl {
 	declarator := node.ChildByFieldName("declarator")
 	name, typeName := cppDeclaratorIdentity(declarator, src)
-	if typeName == "" {
+	// An out-of-line definition names its type relative to the enclosing scope
+	// ("void SHA256::InitState" inside namespace CryptoPP), so the scope has to
+	// be prepended for the identity to match a caller's qualified receiver.
+	switch {
+	case typeName == "":
 		typeName = scope
+	case scope != "" && typeName != scope && !strings.HasPrefix(typeName, scope+"::"):
+		typeName = scope + "::" + typeName
 	}
 	body := node.ChildByFieldName("body")
 	if name == "" || body == nil {


### PR DESCRIPTION
## Problem

A C++ library that opens its namespace with a preprocessor macro rather than a `namespace` statement had every type inside it resolved unqualified. `NAMESPACE_BEGIN(X)` parses as an ordinary call expression and opens no block, so the declarations that follow are its siblings, not its children, and the parser's nesting-based scope never reached them.

The consequence is only visible when mining a library, and it is silent: a rule or contract anchored on the qualified name matches a consumer's call site, because a consumer writes the qualifier, but never matches the library's own sources, because inside its own namespace the library does not. Nothing errors; the library simply contributes no coverage attributed to its own types.

## Fix

Two changes in `cpp_parser.go`:

- Track scope sequentially across siblings, not only by nesting, so a namespace opened by a macro applies to the declarations that follow it until the matching close.
- Prepend the enclosing scope to an out-of-line definition's type. `void SHA256::InitState` inside namespace `CryptoPP` is `CryptoPP::SHA256`; previously the declarator's own qualifier suppressed the scope entirely. An already-fully-qualified declarator is left alone.

The macro is recognised by shape — a bare identifier or single-identifier-argument call whose name reads as a namespace delimiter — rather than by a fixed list, so the common spellings work without enumerating every library.

## Effect

Measured against Crypto++ 8.9.0 (`pkg:github/weidai11/cryptopp`), scanned with the current rules and served through the reachability API from a locally mined result:

| | before | after |
|---|---|---|
| crypto entry points | 12 | 9 |
| attributed to the library's own types | **0** | **9** |

Before, the entry points carried unqualified identities and none could be attributed to the library. After, they resolve as `CryptoPP::SM3`, `CryptoPP::Scrypt`, `CryptoPP::DES_EDE3_Info`, `CryptoPP::Weak1::MD5` and similar, including the nested-namespace cases.

## Scope

This does not make a detection rule fire on a library's own implementation file, and it should not: such a file defines the algorithm rather than using it. What it fixes is the identity the callgraph records, which is what the mined result is keyed on.

## Verification

- New `TestCPPParserResolvesMacroOpenedNamespace` covers the macro form, nested macro namespaces, a close before the definition, a literal `namespace` block, and an already-qualified declarator that must not be doubled.
- `go test ./...` passes, `gofmt` and `go vet` are clean, `git diff --check` is clean.
- End to end on a local stack: scan, mine into a local results database, and query the reachability endpoint for the exact PURL and version, comparing the served response before and after this change. The table above is that comparison.