### PR TITLE
feat(callgraph): add sodiumoxide contracts for the Rust KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Rust callgraph contracts for sodiumoxide: XSalsa20-Poly1305 authenticated encryption, Ed25519 signatures, HMAC-SHA-512-256 authentication, scrypt password hashing, and the SHA-256/SHA-512 hashes. Supporting calls for these carry a lifecycle category, and password derivation exposes its two cost limits as parameter roles. (#338)
 ### Fixed
 - C++ types declared inside a namespace opened by a macro (`NAMESPACE_BEGIN(X)`) now resolve to their qualified identity instead of a bare one. Mining such a library previously attributed none of its crypto to the library's own types, because a rule or contract anchored on the qualified name could not match its sources. Crypto++ 8.9.0 goes from 0 to 9 library-attributed entry points. (#96)
 ### Added

--- a/internal/callgraph/contracts/rust/sodiumoxide.yaml
+++ b/internal/callgraph/contracts/rust/sodiumoxide.yaml
@@ -1,0 +1,103 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: sodiumoxide
+  coordinates:
+    - sodiumoxide
+  version_range: ">=0.2.7,<0.3.0"
+  description: "sodiumoxide safe Rust bindings for libsodium"
+
+# Inventory sources: sodiumoxide 0.2.7 crate documentation and the APIs selected
+# by the scanoss/crypto_rules sodiumoxide rules. Each module re-exports one
+# concrete primitive: secretbox is xsalsa20poly1305, auth is hmacsha512256, sign
+# is ed25519, pwhash is scryptsalsa208sha256. Scope is those four plus the two
+# hash submodules, matching the rules that exist.
+#
+# skipped-non-crypto: Digest, Tag, Key and Nonce accessors, and the constant-time
+#   verify helpers.
+# needs-follow-up: box_, sealedbox, kx, scalarmult, aead, generichash, kdf,
+#   onetimeauth, secretstream and stream, which land with their rules. shorthash
+#   is SipHash and is out of scope as a non-cryptographic hash.
+contracts:
+
+  # Authenticated encryption: XSalsa20-Poly1305.
+  - method: sodiumoxide::crypto::secretbox.gen_key
+    arity: 0
+    return: {type: sodiumoxide::crypto::secretbox::Key, confidence: high}
+    role: factory
+  - method: sodiumoxide::crypto::secretbox.gen_nonce
+    arity: 0
+    return: {type: sodiumoxide::crypto::secretbox::Nonce, confidence: high}
+    role: factory
+  - method: sodiumoxide::crypto::secretbox.seal
+    arity: 3
+    return: {type: alloc::vec::Vec, confidence: high}
+    role: operation
+  - method: sodiumoxide::crypto::secretbox.open
+    arity: 3
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+
+  # Signatures: Ed25519.
+  - method: sodiumoxide::crypto::sign.gen_keypair
+    arity: 0
+    return: {type: sodiumoxide::crypto::sign::SecretKey, confidence: high}
+    role: factory
+  - method: sodiumoxide::crypto::sign.sign
+    arity: 2
+    return: {type: alloc::vec::Vec, confidence: high}
+    role: operation
+  - method: sodiumoxide::crypto::sign.sign_detached
+    arity: 2
+    return: {type: sodiumoxide::crypto::sign::Signature, confidence: high}
+    role: operation
+  - method: sodiumoxide::crypto::sign.verify_detached
+    arity: 3
+    return: {type: bool, confidence: high}
+    role: operation
+
+  # Secret-key authentication: HMAC-SHA-512-256.
+  - method: sodiumoxide::crypto::auth.gen_key
+    arity: 0
+    return: {type: sodiumoxide::crypto::auth::Key, confidence: high}
+    role: factory
+  - method: sodiumoxide::crypto::auth.authenticate
+    arity: 2
+    return: {type: sodiumoxide::crypto::auth::Tag, confidence: high}
+    role: operation
+  - method: sodiumoxide::crypto::auth.verify
+    arity: 3
+    return: {type: bool, confidence: high}
+    role: operation
+
+  # Password hashing: scryptsalsa208sha256. The cost parameters are the two
+  # limits, not a single work factor, so each is recorded on its own.
+  - method: sodiumoxide::crypto::pwhash.gen_salt
+    arity: 0
+    return: {type: sodiumoxide::crypto::pwhash::Salt, confidence: high}
+    role: factory
+  - method: sodiumoxide::crypto::pwhash.derive_key
+    arity: 5
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+    parameters:
+      - index: 3
+        name: opslimit
+        role: metadata-contributing
+        contributes: {property: opsLimit, derivation: argument_value}
+      - index: 4
+        name: memlimit
+        role: metadata-contributing
+        contributes: {property: memLimitBytes, derivation: argument_value}
+
+  # Hashing.
+  - method: sodiumoxide::crypto::hash::sha256.hash
+    arity: 1
+    return: {type: sodiumoxide::crypto::hash::sha256::Digest, confidence: high}
+    role: operation
+  - method: sodiumoxide::crypto::hash::sha512.hash
+    arity: 1
+    return: {type: sodiumoxide::crypto::hash::sha512::Digest, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/rust_sodiumoxide_contract_wiring_test.go
+++ b/internal/callgraph/rust_sodiumoxide_contract_wiring_test.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The sodiumoxide KB is keyed on what the Rust parser emits, so a parser
+// identity change must fail here rather than leaving the contracts unmatched.
+// Covers both call shapes a consumer writes: the imported module path and the
+// fully qualified one.
+func TestSodiumoxideContractsResolveParsedCallIdentities(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	dir := t.TempDir()
+	src := `use sodiumoxide::crypto::secretbox;
+use sodiumoxide::crypto::hash::sha256;
+
+fn roundtrip(plaintext: &[u8]) {
+    let key = secretbox::gen_key();
+    let nonce = secretbox::gen_nonce();
+    let cipher = secretbox::seal(plaintext, &nonce, &key);
+    let _ = sha256::hash(plaintext);
+    let _ = sodiumoxide::crypto::sign::sign_detached(plaintext, &key);
+    let _ = cipher;
+}`
+	if err := os.WriteFile(filepath.Join(dir, "main.rs"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewRustParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call-site keys join every identifier segment with ".", while the KB is
+	// authored with Rust's own "::" module separator; ContractsFor bridges the
+	// two. Assert on what the parser emits, so a change to either side fails.
+	want := map[string]string{
+		"sodiumoxide::crypto.secretbox.gen_key":   "factory",
+		"sodiumoxide::crypto.secretbox.gen_nonce": "factory",
+		"sodiumoxide::crypto.secretbox.seal":      "operation",
+		"sodiumoxide::crypto::hash.sha256.hash":   "operation",
+		"sodiumoxide::crypto::sign.sign_detached": "operation",
+	}
+	seen := map[string]bool{}
+
+	for _, analysis := range analyses {
+		for _, fn := range analysis.Functions {
+			for _, call := range fn.Calls {
+				callee := call.Callee
+				// The KB is looked up with the same key the inference engine builds.
+				method, _ := splitMethodArity(&callee)
+				role, expected := want[method]
+				if !expected {
+					continue
+				}
+				got := kb.ContractsFor(method, len(call.Arguments))
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d, want exactly one sodiumoxide contract",
+						method, len(call.Arguments), len(got))
+				}
+				if got[0].Role != role || got[0].SourceLibrary != "sodiumoxide" {
+					t.Fatalf("contract for %q = %#v, want sodiumoxide %s", method, got[0], role)
+				}
+				seen[method] = true
+			}
+		}
+	}
+
+	for method := range want {
+		if !seen[method] {
+			t.Fatalf("parsed calls did not cover %q; seen = %v", method, seen)
+		}
+	}
+}


### PR DESCRIPTION
Tier 0 family `sodiumoxide`, ecosystem rust. Closes the contract half of the family's coverage gap. The rules land in scanoss/crypto_rules and must merge first, since the contract inventories the symbols those rules select.

Family ID `sodiumoxide`. Canonical family sodiumoxide. PURLs: `pkg:cargo/sodiumoxide`, `pkg:cargo/libsodium-sys`.

## What changed

`internal/callgraph/contracts/rust/sodiumoxide.yaml`, 15 contracts across the four primitives the crate re-exports plus its two hash submodules.

| Module | Concrete primitive | Contracts |
|---|---|---|
| `secretbox` | XSalsa20-Poly1305 | `gen_key`, `gen_nonce` (factory); `seal`, `open` (operation) |
| `sign` | Ed25519 | `gen_keypair` (factory); `sign`, `sign_detached`, `verify_detached` (operation) |
| `auth` | HMAC-SHA-512-256 | `gen_key` (factory); `authenticate`, `verify` (operation) |
| `pwhash` | scryptsalsa208sha256 | `gen_salt` (factory); `derive_key` (operation) |
| `hash::sha256`, `hash::sha512` | SHA-256, SHA-512 | `hash` (operation) |

Each module re-exports one concrete primitive and the module name does not say which, so every algorithm above was read from the crate's documentation rather than inferred. `pwhash` is worth singling out: it is scrypt, not Argon2.

## Method identity

Keys are what the Rust parser actually emits, verified by parsing both call shapes a consumer writes rather than assuming one:

| Source | `Package` | `Type` | call-site key |
|---|---|---|---|
| `secretbox::seal(..)` after importing the module | `sodiumoxide::crypto` | `secretbox` | `sodiumoxide::crypto.secretbox.seal` |
| `sodiumoxide::crypto::sign::sign_detached(..)` | `sodiumoxide::crypto::sign` | (empty) | `sodiumoxide::crypto::sign.sign_detached` |

Call-site keys join every segment with `.`; the KB is authored with Rust's own `::` module separator and `ContractsFor` bridges the two. `TestSodiumoxideContractsResolveParsedCallIdentities` pins this end to end over both shapes, so a change to the parser or to the normalisation fails here instead of silently leaving the contracts unmatched.

## Parameter roles

The only arguments carrying crypto metadata are password derivation's two cost limits. libsodium takes them as separate operation and memory limits rather than one work factor, so each is recorded on its own: `opsLimit` as a plain value, `memLimitBytes` named for its unit so a consumer does not read it as a count.

## Scope

Contracted: the four re-exported primitives plus the two hash submodules, matching the rules that exist.

`needs-follow-up`, recorded in the YAML header rather than guessed at: `box_`, `sealedbox`, `kx`, `scalarmult`, `aead`, `generichash`, `kdf`, `onetimeauth`, `secretstream`, `stream`. These land with their rules. `shorthash` is SipHash and is out of scope as a non-cryptographic hash. Digest, Tag, Key and Nonce accessors and the constant-time comparison helpers are `skipped-non-crypto`.

`libsodium-sys` gets no contract here: it is a raw FFI surface with no Rust-side lifecycle to model, and its rules anchor directly on the C symbol names.

## Verification

`go test ./...` passes. `make lint` at the repository's pinned golangci-lint reports 0 issues. `gofmt` and `go vet` are clean.