### PR TITLE
feat(callgraph): add GHASH and Poly1305 contracts for the Rust KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Rust callgraph contracts for the RustCrypto universal hashes, GHASH and Poly1305: construction, the streaming update lifecycle and tag output. Both expose their key size as a parameter role. (#337)
+### Added
 - Rust callgraph contracts for sodiumoxide: XSalsa20-Poly1305 authenticated encryption, Ed25519 signatures, HMAC-SHA-512-256 authentication, scrypt password hashing, and the SHA-256/SHA-512 hashes. Supporting calls for these carry a lifecycle category, and password derivation exposes its two cost limits as parameter roles. (#338)
 ### Fixed
 - C++ types declared inside a namespace opened by a macro (`NAMESPACE_BEGIN(X)`) now resolve to their qualified identity instead of a bare one. Mining such a library previously attributed none of its crypto to the library's own types, because a rule or contract anchored on the qualified name could not match its sources. Crypto++ 8.9.0 goes from 0 to 9 library-attributed entry points. (#96)

--- a/internal/callgraph/contracts/rust/ghash.yaml
+++ b/internal/callgraph/contracts/rust/ghash.yaml
@@ -1,0 +1,42 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ghash
+  coordinates:
+    - ghash
+  version_range: ">=0.5.0,<0.6.0"
+  description: "RustCrypto GHASH universal hash over GF(2^128)"
+
+# Inventory sources: ghash 0.5 crate documentation and the APIs selected by the
+# scanoss/crypto_rules ghash rule. The crate exposes one type implementing the
+# universal_hash trait, so the surface is its construction plus that lifecycle.
+#
+# skipped-non-crypto: the Block, Key and Tag type aliases and their conversions.
+contracts:
+  - method: ghash::GHash.new
+    arity: 1
+    return: {type: ghash::GHash, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: ghash::GHash.new_with_init_block
+    arity: 2
+    return: {type: ghash::GHash, confidence: high}
+    role: factory
+  - method: ghash::GHash.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ghash::GHash.update_padded
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ghash::GHash.finalize
+    arity: 0
+    return: {type: ghash::Tag, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/poly1305.yaml
+++ b/internal/callgraph/contracts/rust/poly1305.yaml
@@ -1,0 +1,42 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: poly1305
+  coordinates:
+    - poly1305
+  version_range: ">=0.8.0,<0.9.0"
+  description: "RustCrypto Poly1305 universal hash"
+
+# Inventory sources: poly1305 0.8 crate documentation and the APIs selected by
+# the scanoss/crypto_rules poly1305 rule. One type implementing the
+# universal_hash trait, plus the crate's one-shot helper.
+#
+# skipped-non-crypto: the Block, Key and Tag type aliases and their conversions.
+contracts:
+  - method: poly1305::Poly1305.new
+    arity: 1
+    return: {type: poly1305::Poly1305, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: key
+        role: metadata-contributing
+        contributes: {property: keySize, derivation: argument_bit_length}
+  - method: poly1305::Poly1305.compute_unpadded
+    arity: 1
+    return: {type: poly1305::Tag, confidence: high}
+    role: operation
+  - method: poly1305::Poly1305.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: poly1305::Poly1305.update_padded
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: poly1305::Poly1305.finalize
+    arity: 0
+    return: {type: poly1305::Tag, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/rust_universal_hash_contract_wiring_test.go
+++ b/internal/callgraph/rust_universal_hash_contract_wiring_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The universal-hash KBs are keyed on what the Rust parser emits, so a parser
+// identity change must fail here rather than leaving the contracts unmatched.
+func TestUniversalHashContractsResolveParsedCallIdentities(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	dir := t.TempDir()
+	src := `use ghash::GHash;
+use poly1305::Poly1305;
+
+fn authenticate(k16: &[u8; 16], k32: &[u8; 32], data: &[u8]) {
+    let mut a = GHash::new(k16.into());
+    a.update_padded(data);
+    let _t = a.finalize();
+    let mut b = Poly1305::new(k32.into());
+    b.update_padded(data);
+    let _u = b.finalize();
+}`
+	if err := os.WriteFile(filepath.Join(dir, "main.rs"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewRustParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call-site keys join segments with "."; the KBs keep Rust's "::" module
+	// separator and ContractsFor bridges the two.
+	want := map[string]struct{ role, library string }{
+		"ghash.GHash.new":                 {"factory", "ghash"},
+		"ghash.GHash.update_padded":       {"operation", "ghash"},
+		"ghash.GHash.finalize":            {"output", "ghash"},
+		"poly1305.Poly1305.new":           {"factory", "poly1305"},
+		"poly1305.Poly1305.update_padded": {"operation", "poly1305"},
+		"poly1305.Poly1305.finalize":      {"output", "poly1305"},
+	}
+	seen := map[string]bool{}
+
+	for _, analysis := range analyses {
+		for _, fn := range analysis.Functions {
+			for _, call := range fn.Calls {
+				callee := call.Callee
+				method, _ := splitMethodArity(&callee)
+				expect, ok := want[method]
+				if !ok {
+					continue
+				}
+				got := kb.ContractsFor(method, len(call.Arguments))
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d, want exactly one contract",
+						method, len(call.Arguments), len(got))
+				}
+				if got[0].Role != expect.role || got[0].SourceLibrary != expect.library {
+					t.Fatalf("contract for %q = %#v, want %s %s", method, got[0], expect.library, expect.role)
+				}
+				seen[method] = true
+			}
+		}
+	}
+
+	for method := range want {
+		if !seen[method] {
+			t.Fatalf("parsed calls did not cover %q; seen = %v", method, seen)
+		}
+	}
+}


### PR DESCRIPTION
Tier 0 family `rustcrypto-universal-hashes`, ecosystem rust. Closes the contract half of the family's coverage gap. The rules land in scanoss/crypto_rules and must merge first, since a contract inventories the symbols those rules select.

Family ID `rustcrypto-universal-hashes`. Canonical family RustCrypto universal hashes. PURLs: `pkg:cargo/ghash`, `pkg:cargo/poly1305`.

## What changed

Two KB files, ten contracts. Both crates expose a single type implementing the shared `universal_hash` trait, so each surface is a construction plus that lifecycle:

| Crate | Contracts |
|---|---|
| `ghash` | `GHash::new`, `new_with_init_block` (factory); `update`, `update_padded` (operation); `finalize` (output) |
| `poly1305` | `Poly1305::new` (factory); `compute_unpadded`, `update`, `update_padded` (operation); `finalize` (output) |

## Method identity

Keys are what the Rust parser emits, verified by parsing real calls rather than assumed. The parser produces `ghash.GHash.new` at the call site; the KB is authored with Rust's `::` module separator as `ghash::GHash.new`, and `ContractsFor` bridges the two.

`TestUniversalHashContractsResolveParsedCallIdentities` pins all six identities the fixture produces, so a change to the parser or to the normalisation fails here instead of silently leaving the contracts unmatched.

## Parameter roles

Each constructor's key argument contributes `keySize` by bit length. The two crates differ — GHASH takes a 16-byte key, Poly1305 a 32-byte one — so the derivation carries the difference rather than the contract hardcoding it.

## Scope

Both crates in the family are contracted in full: their public surface is one type each. The `Block`, `Key` and `Tag` aliases and their conversions are `skipped-non-crypto`.

## Verification

`go test ./...` passes. `make lint` at the repository's pinned golangci-lint reports 0 issues. The local end-to-end gate ran before this PR was opened; details in the tracker PR.