### PR TITLE
feat(callgraph): add RustCrypto signature contracts for the Rust KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Rust callgraph contracts for the RustCrypto signature crates `dsa`, `ecdsa` and `ed25519`: key construction for each, and the Ed25519 signature type the crate exposes in place of an implementation. Signing and verification reach these crates through shared traits, so the contracts anchor on the stable key identities. (#336)
+### Added
 - Rust callgraph contracts for the RustCrypto universal hashes, GHASH and Poly1305: construction, the streaming update lifecycle and tag output. Both expose their key size as a parameter role. (#337)
 ### Added
 - Rust callgraph contracts for sodiumoxide: XSalsa20-Poly1305 authenticated encryption, Ed25519 signatures, HMAC-SHA-512-256 authentication, scrypt password hashing, and the SHA-256/SHA-512 hashes. Supporting calls for these carry a lifecycle category, and password derivation exposes its two cost limits as parameter roles. (#338)

--- a/internal/callgraph/contracts/rust/dsa.yaml
+++ b/internal/callgraph/contracts/rust/dsa.yaml
@@ -1,0 +1,30 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: dsa
+  coordinates:
+    - dsa
+  version_range: ">=0.6.0,<0.7.0"
+  description: "RustCrypto DSA signatures per FIPS 186-4"
+
+# Inventory sources: dsa 0.6 crate documentation and the APIs selected by the
+# scanoss/crypto_rules dsa rule. Signing and verification reach the crate through
+# the shared signature::Signer and Verifier traits, so the stable identities here
+# are the key constructors.
+#
+# skipped-non-crypto: Components accessors and the PKCS#8 encoding helpers.
+contracts:
+  - method: dsa::SigningKey.generate
+    arity: 2
+    return: {type: dsa::SigningKey, confidence: high}
+    role: factory
+  - method: dsa::SigningKey.from_components
+    arity: 2
+    return: {type: dsa::SigningKey, confidence: high}
+    role: factory
+  - method: dsa::VerifyingKey.from_components
+    arity: 2
+    return: {type: dsa::VerifyingKey, confidence: high}
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/ecdsa.yaml
+++ b/internal/callgraph/contracts/rust/ecdsa.yaml
@@ -1,0 +1,30 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ecdsa
+  coordinates:
+    - ecdsa
+  version_range: ">=0.16.0,<0.17.0"
+  description: "RustCrypto ECDSA signatures, generic over prime-order curves"
+
+# Inventory sources: ecdsa 0.16 crate documentation and the APIs selected by the
+# scanoss/crypto_rules ecdsa rule. The curve is a type parameter supplied by the
+# concrete curve crate, so it is not resolvable here and no curve metadata is
+# claimed.
+#
+# skipped-non-crypto: Signature encoding and byte conversions.
+contracts:
+  - method: ecdsa::SigningKey.generate
+    arity: 1
+    return: {type: ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/ed25519.yaml
+++ b/internal/callgraph/contracts/rust/ed25519.yaml
@@ -1,0 +1,27 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ed25519
+  coordinates:
+    - ed25519
+  version_range: ">=2.0.0,<3.0.0"
+  description: "RustCrypto Ed25519 signature type and traits"
+
+# Inventory sources: ed25519 2.x crate documentation and the APIs selected by the
+# scanoss/crypto_rules ed25519 rule. The crate carries no implementation: it
+# provides the Signature type other crates sign and verify with, so the surface
+# is construction and decoding rather than a crypto lifecycle.
+#
+# skipped-non-crypto: SignatureEncoding and AssociatedAlgorithmIdentifier trait
+#   methods, and the byte accessors.
+contracts:
+  - method: ed25519::Signature.from_bytes
+    arity: 1
+    return: {type: ed25519::Signature, confidence: high}
+    role: factory
+  - method: ed25519::Signature.from_slice
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/rust_signature_contract_wiring_test.go
+++ b/internal/callgraph/rust_signature_contract_wiring_test.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The signature-crate KBs are keyed on what the Rust parser emits, so a parser
+// identity change must fail here rather than leaving the contracts unmatched.
+func TestSignatureContractsResolveParsedCallIdentities(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	dir := t.TempDir()
+	src := `use dsa::SigningKey;
+use ed25519::Signature;
+
+fn build(components: u8, bytes: &[u8; 64]) {
+    let _a = SigningKey::generate(&mut rand::thread_rng(), components);
+    let _b = ecdsa::SigningKey::generate(&mut rand::thread_rng());
+    let _c = Signature::from_bytes(bytes);
+}`
+	if err := os.WriteFile(filepath.Join(dir, "main.rs"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewRustParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"dsa.SigningKey.generate":      "dsa",
+		"ecdsa.SigningKey.generate":    "ecdsa",
+		"ed25519.Signature.from_bytes": "ed25519",
+	}
+	seen := map[string]bool{}
+
+	for _, analysis := range analyses {
+		for _, fn := range analysis.Functions {
+			for _, call := range fn.Calls {
+				callee := call.Callee
+				method, _ := splitMethodArity(&callee)
+				library, ok := want[method]
+				if !ok {
+					continue
+				}
+				got := kb.ContractsFor(method, len(call.Arguments))
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d, want exactly one contract",
+						method, len(call.Arguments), len(got))
+				}
+				if got[0].SourceLibrary != library || got[0].Role != "factory" {
+					t.Fatalf("contract for %q = %#v, want %s factory", method, got[0], library)
+				}
+				seen[method] = true
+			}
+		}
+	}
+
+	for method := range want {
+		if !seen[method] {
+			t.Fatalf("parsed calls did not cover %q; seen = %v", method, seen)
+		}
+	}
+}


### PR DESCRIPTION
Tier 0 family `rustcrypto-signatures`, ecosystem rust. The rules land in scanoss/crypto_rules and must merge first, since a contract inventories the symbols those rules select.

Family ID `rustcrypto-signatures`. Canonical family RustCrypto signatures. PURLs: `pkg:cargo/dsa`, `pkg:cargo/ecdsa`, `pkg:cargo/ed25519`, `pkg:cargo/ml-dsa`.

## What changed

Three KB files, eight contracts, covering key construction for `dsa` and `ecdsa` and the signature type `ed25519` exposes in place of an implementation.

Signing and verification in this family go through the shared `signature::Signer` and `Verifier` traits. Those are generic and carry no crate identity at the call site, so the stable identities to contract are the constructors.

## ml-dsa is not contracted, and that is deliberate

The crate's entry points are generic over a parameter-set type, so the parser emits an identity carrying the turbofish — `ml_dsa::KeyPair::<ml_dsa.MlDsa65>.generate` — rather than a stable one. Authoring a key against that shape would produce a contract that loads cleanly and matches nothing.

There is precedent: `chacha20poly1305.yaml` records the same limitation for `Key::<ChaCha20Poly1305>::generate()` and keeps only the stable constructors. This follows it. ml-dsa's detection rules are unaffected and ship in the paired PR; the contract lands when generic identities resolve.

## Method identity

Keys are what the Rust parser emits, verified by parsing real calls. The parser produces `dsa.SigningKey.generate` at the call site; the KB is authored with Rust's `::` module separator and `ContractsFor` bridges the two. `TestSignatureContractsResolveParsedCallIdentities` pins the three identities the fixture produces.

## No curve, no parameter set claimed

`ecdsa` is generic over the curve, which the concrete curve crate supplies, so no curve metadata is asserted from here. The same reasoning kept parameter-set claims out of the contracts.

## Verification

`go test ./...` passes. `make lint` at the repository's pinned golangci-lint reports 0 issues. The local end-to-end gate ran before this PR was opened; details in the tracker PR.