### PR TITLE
fix(callgraph): target the ed25519 3.x line in the Rust KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The ed25519 contract now targets the 3.x line and covers `Signature::from_components`. It previously declared a range ending before 3.0.0, which excluded the version the coverage matrix lists. (#336)
 ### Added
 - Rust callgraph contracts for the RustCrypto signature crates `dsa`, `ecdsa` and `ed25519`: key construction for each, and the Ed25519 signature type the crate exposes in place of an implementation. Signing and verification reach these crates through shared traits, so the contracts anchor on the stable key identities. (#336)
 ### Added

--- a/internal/callgraph/contracts/rust/ed25519.yaml
+++ b/internal/callgraph/contracts/rust/ed25519.yaml
@@ -4,10 +4,10 @@ library:
   name: ed25519
   coordinates:
     - ed25519
-  version_range: ">=2.0.0,<3.0.0"
+  version_range: ">=3.0.0,<4.0.0"
   description: "RustCrypto Ed25519 signature type and traits"
 
-# Inventory sources: ed25519 2.x crate documentation and the APIs selected by the
+# Inventory sources: ed25519 3.0.0 crate documentation and the APIs selected by the
 # scanoss/crypto_rules ed25519 rule. The crate carries no implementation: it
 # provides the Signature type other crates sign and verify with, so the surface
 # is construction and decoding rather than a crypto lifecycle.
@@ -22,6 +22,10 @@ contracts:
   - method: ed25519::Signature.from_slice
     arity: 1
     return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: ed25519::Signature.from_components
+    arity: 2
+    return: {type: ed25519::Signature, confidence: high}
     role: factory
 
 hierarchy: {}


### PR DESCRIPTION
Follow-up to scanoss/crypto-finder#298. The contract declared a version range that excluded the version the Tier 0 matrix lists.

Family ID `rustcrypto-signatures`. PURL: `pkg:cargo/ed25519`.

## The range excluded the planned version

```yaml
version_range: ">=2.0.0,<3.0.0"   # authored
version_range: ">=3.0.0,<4.0.0"   # corrected
```

The matrix lists `ed25519` at **3.0.0**. The old upper bound stopped immediately below it, so the contract loaded cleanly and applied to nothing the campaign plans to mine.

## What survived the major bump, and what is new

`Signature::from_bytes` and `from_slice` are unchanged in 3.0.0, so the existing contracts hold at the corrected range rather than needing to be re-derived. `Signature::from_components` is new in 3.x and is now contracted as a factory.

The header records 3.0.0 as the version the API was read at, rather than a version line, so the range rests on something a reader can check.

## Root cause

Versions for a family come from `docs/crypto-coverage/tier0/input/crypto-tier0-rust.csv`, and that file was not read when the contract was authored. The range was written from the version `docs.rs/ed25519/latest` happened to serve at the time.

## Verification

`go test ./...` passes and `make lint` at the repository's pinned golangci-lint reports 0 issues.

The wiring test still resolves every contract key against what the Rust parser emits. The full local gate was re-run against all 207 versions this family's matrix lists, including a `--scan-dependencies` proof that reaches this crate through a real `Cargo.toml`: the consumer's own `Signature::from_bytes` is reported as `source: direct` with `pkg:cargo/ed25519`, and a transitive `spki 0.8.0` finding as `source: dependency`.