### PR TITLE
fix(callgraph): target the planned ghash and poly1305 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- The ghash and poly1305 contracts now target the versions the coverage matrix lists, 0.6.x and 0.9.x. Both previously declared ranges ending immediately below them. The ghash `new_with_init_block` contract is removed: that constructor no longer exists in 0.6.0. (#337)
+### Fixed
 - The ed25519 contract now targets the 3.x line and covers `Signature::from_components`. It previously declared a range ending before 3.0.0, which excluded the version the coverage matrix lists. (#336)
 ### Added
 - Rust callgraph contracts for the RustCrypto signature crates `dsa`, `ecdsa` and `ed25519`: key construction for each, and the Ed25519 signature type the crate exposes in place of an implementation. Signing and verification reach these crates through shared traits, so the contracts anchor on the stable key identities. (#336)

--- a/internal/callgraph/contracts/rust/ghash.yaml
+++ b/internal/callgraph/contracts/rust/ghash.yaml
@@ -4,14 +4,15 @@ library:
   name: ghash
   coordinates:
     - ghash
-  version_range: ">=0.5.0,<0.6.0"
+  version_range: ">=0.6.0,<0.7.0"
   description: "RustCrypto GHASH universal hash over GF(2^128)"
 
-# Inventory sources: ghash 0.5 crate documentation and the APIs selected by the
+# Inventory sources: ghash 0.6.0 crate documentation and the APIs selected by the
 # scanoss/crypto_rules ghash rule. The crate exposes one type implementing the
 # universal_hash trait, so the surface is its construction plus that lifecycle.
 #
 # skipped-non-crypto: the Block, Key and Tag type aliases and their conversions.
+# new_with_init_block existed in 0.5.x and is gone in 0.6.0; it is not contracted.
 contracts:
   - method: ghash::GHash.new
     arity: 1
@@ -22,10 +23,6 @@ contracts:
         name: key
         role: metadata-contributing
         contributes: {property: keySize, derivation: argument_bit_length}
-  - method: ghash::GHash.new_with_init_block
-    arity: 2
-    return: {type: ghash::GHash, confidence: high}
-    role: factory
   - method: ghash::GHash.update
     arity: 1
     return: {type: void, confidence: high}

--- a/internal/callgraph/contracts/rust/poly1305.yaml
+++ b/internal/callgraph/contracts/rust/poly1305.yaml
@@ -4,10 +4,10 @@ library:
   name: poly1305
   coordinates:
     - poly1305
-  version_range: ">=0.8.0,<0.9.0"
+  version_range: ">=0.9.0,<0.10.0"
   description: "RustCrypto Poly1305 universal hash"
 
-# Inventory sources: poly1305 0.8 crate documentation and the APIs selected by
+# Inventory sources: poly1305 0.9.0 crate documentation and the APIs selected by
 # the scanoss/crypto_rules poly1305 rule. One type implementing the
 # universal_hash trait, plus the crate's one-shot helper.
 #


### PR DESCRIPTION
Follow-up to scanoss/crypto-finder#297. Both contracts declared version ranges that excluded the versions the Tier 0 matrix lists.

Family ID `rustcrypto-universal-hashes`. PURLs: `pkg:cargo/ghash`, `pkg:cargo/poly1305`.

## The ranges excluded the planned versions

```yaml
ghash:     ">=0.5.0,<0.6.0"  ->  ">=0.6.0,<0.7.0"
poly1305:  ">=0.8.0,<0.9.0"  ->  ">=0.9.0,<0.10.0"
```

The matrix carries ghash up to **0.6.0** and poly1305 up to **0.9.0**. Each old upper bound stopped immediately below its planned version, so both contracts loaded cleanly and applied to nothing the campaign mines.

## One contract removed

`GHash::new_with_init_block` is gone in 0.6.0. Contracting a constructor the version does not have would be a key that never matches, so it is dropped and the removal noted in the YAML header.

`Poly1305::new` moved to the `KeyInit` trait in 0.9.0 but keeps its call shape, so its contract is unchanged.

## Root cause

The contracts were authored against ghash 0.5.1 and poly1305 0.8.0, versions chosen rather than read from `docs/crypto-coverage/tier0/input/crypto-tier0-rust.csv`. A range that excludes the planned release is invisible to the test suite: the KB loads, the wiring test passes, and nothing is covered.

## Verification

`go test ./...` passes and `make lint` at the repository's pinned golangci-lint reports 0 issues. The wiring test still resolves every remaining contract key against what the Rust parser emits.

The full local gate ran on a fresh environment against all 55 rows this family lists, including a `--scan-dependencies` proof reaching both crates from a real `Cargo.toml`.