### PR TITLE
fix(rust): resolve turbofish call identities and add password-hash contracts

### DIFF
--- a/internal/callgraph/contracts/rust/chacha20poly1305.yaml
+++ b/internal/callgraph/contracts/rust/chacha20poly1305.yaml
@@ -8,9 +8,20 @@ library:
   description: "RustCrypto ChaCha20-Poly1305 authenticated encryption"
 
 contracts:
-  # Key/nonce generation through Generate is generic (e.g.
-  # Key::<ChaCha20Poly1305>::generate()) and does not have a stable Rust parser
-  # identity yet. Keep the stable slice constructors instead.
+  # Key/nonce generation through Generate carries a turbofish; the parser strips
+  # type arguments from the callee identity, so these resolve on the type alone.
+  - method: chacha20poly1305::Key.generate
+    arity: 1
+    return: {type: chacha20poly1305::Key, confidence: high}
+    role: factory
+  - method: chacha20poly1305::Nonce.generate
+    arity: 1
+    return: {type: chacha20poly1305::Nonce, confidence: high}
+    role: factory
+  - method: chacha20poly1305::XNonce.generate
+    arity: 1
+    return: {type: chacha20poly1305::XNonce, confidence: high}
+    role: factory
   - method: chacha20poly1305::Key.from_slice
     arity: 1
     return: { type: chacha20poly1305::Key, confidence: high }

--- a/internal/callgraph/contracts/rust/pbkdf2.yaml
+++ b/internal/callgraph/contracts/rust/pbkdf2.yaml
@@ -1,0 +1,87 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: pbkdf2
+  coordinates:
+    - pbkdf2
+  version_range: ">=0.13.0,<0.14.0"
+  description: "RustCrypto PBKDF2 password-based key derivation"
+
+# Inventory sources: pbkdf2 0.13.0 crate documentation and the APIs selected by
+# the scanoss/crypto_rules pbkdf2 rules. Params::default delegates to
+# Params::RECOMMENDED, whose OWASP-aligned values are 600000 rounds and a
+# 32-byte output. The four derivation functions take the PRF as a type
+# parameter; the turbofish is stripped from the callee identity by the parser,
+# so the PRF is not claimed as metadata here.
+#
+# skipped-non-crypto: the Params accessors and the PHC string helpers.
+contracts:
+  - method: pbkdf2::Pbkdf2.default
+    arity: 0
+    return: {type: pbkdf2::Pbkdf2, confidence: high}
+    role: factory
+
+  # Free functions in a single-segment crate: the call site emits
+  # "pbkdf2.pbkdf2_hmac" and the "::" bridge only rewrites package.Type.method
+  # keys, so author the dot form here.
+  - method: pbkdf2.pbkdf2
+    arity: 4
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: rounds
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+  - method: pbkdf2.pbkdf2_array
+    arity: 3
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: rounds
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+  - method: pbkdf2.pbkdf2_hmac
+    arity: 4
+    return: {type: (), confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: rounds
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+  - method: pbkdf2.pbkdf2_hmac_array
+    arity: 3
+    return: {type: "[u8; N]", confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: rounds
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+
+  # Params::new carries the rounds the file models; contracting only the free
+  # functions left the configuration object uncovered.
+  - method: pbkdf2::Params.new
+    arity: 1
+    return: {type: pbkdf2::Params, confidence: high}
+    role: config
+    parameters:
+      - index: 0
+        name: rounds
+        role: metadata-contributing
+        contributes: {property: iterations, derivation: argument_value}
+  # The only derivation function that names the PRF at the call site rather than
+  # as a type parameter, so the algorithm argument is operation-determining.
+  - method: pbkdf2.pbkdf2_hmac_with_params
+    arity: 5
+    return: {type: (), confidence: high}
+    role: operation
+    parameters:
+      - index: 2
+        name: algorithm
+        role: operation-determining
+        contributes: {property: algorithmHashFunction, derivation: argument_value}
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/scrypt.yaml
+++ b/internal/callgraph/contracts/rust/scrypt.yaml
@@ -1,0 +1,70 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: scrypt
+  coordinates:
+    - scrypt
+  version_range: ">=0.12.0,<0.13.0"
+  description: "RustCrypto scrypt password-based key derivation"
+
+# Inventory sources: the scrypt 0.12.0 crate source (src/params.rs, src/lib.rs)
+# and the APIs selected by the scanoss/crypto_rules scrypt rules. Params::default
+# delegates to Params::RECOMMENDED, whose OWASP-aligned values are log_n 17,
+# r 8, p 1.
+#
+# Params::new takes three arguments in this range; the four-argument form is
+# new_with_output_len. The 0.11 line spelled the four-argument version `new`,
+# so an arity taken from that release matches nothing here.
+#
+# skipped-non-crypto: the Params accessors and the PHC/MCF string helpers.
+contracts:
+  - method: scrypt::Params.new
+    arity: 3
+    return: {type: core::result::Result, confidence: high}
+    role: config
+    parameters:
+      # log_n is the base-2 logarithm of the cost, not the cost itself: the
+      # detection rules publish cost 131072 while this argument reads 17. The
+      # property is named for the argument so the two are not conflated.
+      - index: 0
+        name: log_n
+        role: metadata-contributing
+        contributes: {property: logN, derivation: argument_value}
+      - index: 1
+        name: r
+        role: metadata-contributing
+        contributes: {property: blockSize, derivation: argument_value}
+      - index: 2
+        name: p
+        role: metadata-contributing
+        contributes: {property: parallelism, derivation: argument_value}
+  - method: scrypt::Params.new_with_output_len
+    arity: 4
+    return: {type: core::result::Result, confidence: high}
+    role: config
+    parameters:
+      - index: 0
+        name: log_n
+        role: metadata-contributing
+        contributes: {property: logN, derivation: argument_value}
+      - index: 1
+        name: r
+        role: metadata-contributing
+        contributes: {property: blockSize, derivation: argument_value}
+      - index: 2
+        name: p
+        role: metadata-contributing
+        contributes: {property: parallelism, derivation: argument_value}
+  - method: scrypt::Scrypt.default
+    arity: 0
+    return: {type: scrypt::Scrypt, confidence: high}
+    role: factory
+  # Free function in a single-segment crate: the call site emits "scrypt.scrypt"
+  # and the "::" bridge only rewrites package.Type.method keys, so author the
+  # dot form here.
+  - method: scrypt.scrypt
+    arity: 4
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_password_hashes_test.go
+++ b/internal/callgraph/contracts/rust_password_hashes_test.go
@@ -1,0 +1,93 @@
+package contracts_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The parser emits dot-joined keys ("scrypt.Params.new") while the KB is
+// authored with "::". Both forms must resolve to the same contract.
+func TestLoadEmbeddedRustIncludesPasswordHashContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		authored string
+		callSite string
+		arity    int
+		library  string
+		role     string
+		ret      string
+	}{
+		{"scrypt::Params.new", "scrypt.Params.new", 3, "scrypt", "config", "core::result::Result"},
+		{"scrypt::Params.new_with_output_len", "scrypt.Params.new_with_output_len", 4, "scrypt", "config", "core::result::Result"},
+		{"scrypt::Scrypt.default", "scrypt.Scrypt.default", 0, "scrypt", "factory", "scrypt::Scrypt"},
+		{"scrypt.scrypt", "scrypt.scrypt", 4, "scrypt", "operation", "core::result::Result"},
+		{"pbkdf2::Pbkdf2.default", "pbkdf2.Pbkdf2.default", 0, "pbkdf2", "factory", "pbkdf2::Pbkdf2"},
+		// The parser fix made these resolvable; contract them so it has a consumer.
+		{"chacha20poly1305::Key.generate", "chacha20poly1305.Key.generate", 1, "chacha20poly1305", "factory", "chacha20poly1305::Key"},
+		{"chacha20poly1305::Nonce.generate", "chacha20poly1305.Nonce.generate", 1, "chacha20poly1305", "factory", "chacha20poly1305::Nonce"},
+		{"chacha20poly1305::XNonce.generate", "chacha20poly1305.XNonce.generate", 1, "chacha20poly1305", "factory", "chacha20poly1305::XNonce"},
+		{"pbkdf2.pbkdf2", "pbkdf2.pbkdf2", 4, "pbkdf2", "operation", "core::result::Result"},
+		{"pbkdf2.pbkdf2_array", "pbkdf2.pbkdf2_array", 3, "pbkdf2", "operation", "core::result::Result"},
+		{"pbkdf2.pbkdf2_hmac", "pbkdf2.pbkdf2_hmac", 4, "pbkdf2", "operation", "()"},
+		{"pbkdf2.pbkdf2_hmac_array", "pbkdf2.pbkdf2_hmac_array", 3, "pbkdf2", "operation", "[u8; N]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.authored, tt.arity), func(t *testing.T) {
+			for _, key := range []string{tt.authored, tt.callSite} {
+				got := kb.ContractsFor(key, tt.arity)
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d contracts, want 1", key, tt.arity, len(got))
+				}
+				if got[0].SourceLibrary != tt.library || got[0].Role != tt.role || got[0].Return.Type != tt.ret {
+					t.Fatalf("ContractsFor(%q, %d) = %#v, want role %q return %q from %q",
+						key, tt.arity, got[0], tt.role, tt.ret, tt.library)
+				}
+			}
+		})
+	}
+}
+
+// Params::new argument positions carry the cost, block-size and parallelism
+// values a consumer reads back from the call site.
+func TestRustScryptParamsNewParameterRoles(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	got := kb.ContractsFor("scrypt.Params.new", 3)
+	if len(got) != 1 {
+		t.Fatalf("ContractsFor(scrypt.Params.new, 3) = %d contracts, want 1", len(got))
+	}
+
+	want := map[int]string{0: "logN", 1: "blockSize", 2: "parallelism"}
+	if len(got[0].Parameters) != len(want) {
+		t.Fatalf("parameters = %d, want %d", len(got[0].Parameters), len(want))
+	}
+	for _, p := range got[0].Parameters {
+		if p.Index == nil {
+			t.Fatalf("parameter %#v has no index", p)
+		}
+		prop, ok := want[*p.Index]
+		if !ok {
+			t.Fatalf("unexpected parameter index %d", *p.Index)
+		}
+		if p.Role != "metadata-contributing" || p.Contributes == nil || p.Contributes.Property != prop {
+			t.Fatalf("parameter %d = %#v, want metadata-contributing property %q", *p.Index, p, prop)
+		}
+		if p.Contributes.Derivation != "argument_value" {
+			t.Fatalf("parameter %d derivation = %q, want argument_value", *p.Index, p.Contributes.Derivation)
+		}
+	}
+}

--- a/internal/callgraph/rust_parser.go
+++ b/internal/callgraph/rust_parser.go
@@ -17,6 +17,7 @@ const (
 	rustNodeExpressionStatement = "expression_statement"
 	rustNodeFieldExpression     = "field_expression"
 	rustNodeFunctionItem        = "function_item"
+	rustNodeGenericFunction     = "generic_function"
 )
 
 // RustParser extracts function declarations, calls, and imports from Rust source files
@@ -475,6 +476,13 @@ func (p *RustParser) parseCallExpr(node *sitter.Node, src []byte, filePath strin
 	raw := funcNode.Content(src)
 	args := p.extractRustCallArguments(node, src)
 
+	// A turbofish wraps the callee in a generic_function whose first child is
+	// the plain callee node; unwrap it so the cases below see the same shapes
+	// they would without the type arguments.
+	if funcNode.Type() == rustNodeGenericFunction && funcNode.ChildCount() > 0 {
+		funcNode = funcNode.Child(0)
+	}
+
 	var call *FunctionCall
 	switch funcNode.Type() {
 	case javaNodeScopedIdentifier:
@@ -514,7 +522,7 @@ func (p *RustParser) parseCallExpr(node *sitter.Node, src []byte, filePath strin
 
 // parseScopedCall handles calls like `Type::method()` or `module::func()`.
 func (p *RustParser) parseScopedCall(node *sitter.Node, src []byte, filePath string, line int, args []string, analysis *FileAnalysis) *FunctionCall {
-	content := node.Content(src)
+	content := stripRustTypeArguments(node.Content(src))
 	lastSep := strings.LastIndex(content, "::")
 	if lastSep <= 0 {
 		return nil
@@ -560,6 +568,46 @@ func (p *RustParser) parseScopedCall(node *sitter.Node, src []byte, filePath str
 		Line:      line,
 		Arguments: args,
 	}
+}
+
+// stripRustTypeArguments removes turbofish type arguments from a scoped path so
+// the callee identity does not vary with them: "Key::<ChaCha20Poly1305>::generate"
+// becomes "Key::generate". Nested arguments are skipped by depth. A ">" that
+// closes a return arrow is not a closer, and an unbalanced path is returned
+// unchanged rather than truncated: a mangled path becomes a wrong callee
+// identity, which is worse than leaving the turbofish in place.
+func stripRustTypeArguments(path string) string {
+	if !strings.Contains(path, "::<") {
+		return path
+	}
+	var b strings.Builder
+	depth := 0
+	for i := 0; i < len(path); i++ {
+		if depth == 0 && strings.HasPrefix(path[i:], "::<") {
+			depth = 1
+			i += 2
+			continue
+		}
+		if depth > 0 {
+			switch path[i] {
+			case '<':
+				depth++
+			case '>':
+				// The ">" of a "->" closes nothing; it belongs to a fn-pointer
+				// or closure return type inside the argument list.
+				if i > 0 && path[i-1] == '-' {
+					continue
+				}
+				depth--
+			}
+			continue
+		}
+		b.WriteByte(path[i])
+	}
+	if depth != 0 {
+		return path
+	}
+	return b.String()
 }
 
 // splitRustScopedCallee turns a resolved `<module path>::<maybe Type>` prefix

--- a/internal/callgraph/rust_parser_turbofish_test.go
+++ b/internal/callgraph/rust_parser_turbofish_test.go
@@ -1,0 +1,84 @@
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A turbofish must not change a call's identity: neither the generic_function
+// wrapper on a free function nor type arguments inside a scoped path.
+func TestRustParserResolvesTurbofishCalls(t *testing.T) {
+	dir := t.TempDir()
+	src := `use pbkdf2::Pbkdf2;
+use chacha20poly1305::{ChaCha20Poly1305, Key};
+
+fn derive(pw: &[u8], salt: &[u8], out: &mut [u8]) {
+    pbkdf2::pbkdf2_hmac::<sha2::Sha256>(pw, salt, 600000, out);
+    let _a = pbkdf2::pbkdf2_hmac_array::<sha2::Sha256, 32>(pw, salt, 600000);
+    let _d = Pbkdf2::default();
+    let _k = Key::<ChaCha20Poly1305>::generate(&mut rng);
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.rs"), []byte(src), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	analyses, err := NewRustParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatalf("ParseDirectory: %v", err)
+	}
+
+	type key struct {
+		method string
+		arity  int
+	}
+	got := map[key]bool{}
+	for _, a := range analyses {
+		for _, fn := range a.Functions {
+			for _, c := range fn.Calls {
+				id := c.Callee
+				m, _ := splitMethodArity(&id)
+				got[key{m, len(c.Arguments)}] = true
+			}
+		}
+	}
+
+	want := []key{
+		{"pbkdf2.pbkdf2_hmac", 4},
+		{"pbkdf2.pbkdf2_hmac_array", 3},
+		{"pbkdf2.Pbkdf2.default", 0},
+		{"chacha20poly1305.Key.generate", 1},
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("missing call %s#%d; got %v", w.method, w.arity, got)
+		}
+	}
+}
+
+func TestStripRustTypeArguments(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"pbkdf2::pbkdf2_hmac", "pbkdf2::pbkdf2_hmac"},
+		{"Key::<ChaCha20Poly1305>::generate", "Key::generate"},
+		{"a::<Vec<Vec<u8>>>::b", "a::b"},
+		{"a::<T, 32>::b::<U>::c", "a::b::c"},
+		{"a::<[u8; 32]>::b", "a::b"},
+		{"Foo::<Bar::<u8>>::baz", "Foo::baz"},
+		{"a::<>::b", "a::b"},
+		// The ">" of a return arrow closes nothing.
+		{"foo::<fn() -> u8>::bar", "foo::bar"},
+		{"foo::<fn(&[u8]) -> u32>::bar", "foo::bar"},
+		// Unbalanced input is returned unchanged: a truncated path becomes a
+		// wrong callee identity, which is worse than an unstripped one.
+		{"foo::<T", "foo::<T"},
+		{"foo::<Vec<u8>::bar", "foo::<Vec<u8>::bar"},
+		// A qualified path carries no "::<" and passes through.
+		{"<Sha256 as Digest>::new", "<Sha256 as Digest>::new"},
+	}
+	for _, tt := range tests {
+		if got := stripRustTypeArguments(tt.in); got != tt.want {
+			t.Errorf("stripRustTypeArguments(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/cli/scan_cancellation_integration_test.go
+++ b/internal/cli/scan_cancellation_integration_test.go
@@ -196,21 +196,22 @@ func writeFile(t *testing.T, path, content string) {
 func waitForChildPID(t *testing.T, path string) int {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	var last string
 	for time.Now().Before(deadline) {
 		contents, err := os.ReadFile(path)
 		if err == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(contents)))
-			if parseErr != nil {
-				t.Fatalf("parse child pid %q: %v", contents, parseErr)
+			// The file appears before the writer has finished, so an empty or
+			// partial read means "not ready yet", not "malformed".
+			last = strings.TrimSpace(string(contents))
+			if pid, parseErr := strconv.Atoi(last); parseErr == nil {
+				return pid
 			}
-			return pid
-		}
-		if !errors.Is(err, os.ErrNotExist) {
+		} else if !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("read child pid: %v", err)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("scanner did not start its child process")
+	t.Fatalf("scanner did not start its child process (last pid file contents %q)", last)
 	return 0
 }
 


### PR DESCRIPTION
Fixes two defects in the Rust parser's handling of turbofish calls, and adds contract KB entries for the pbkdf2 and scrypt crates.

Depends on scanoss/crypto_rules#223 for the rule identities the contracts pair with.

## Parser

`parseCallExpr` switched on the callee node type but had no case for `generic_function`, the node tree-sitter produces when a call carries type arguments. Two distinct shapes were affected:

| Source | Before | After |
| --- | --- | --- |
| `pbkdf2::pbkdf2_hmac::<Sha256>(..)` | **no call recorded at all** | `pbkdf2.pbkdf2_hmac` arity 4 |
| `Key::<ChaCha20Poly1305>::generate(..)` | `chacha20poly1305::Key::<ChaCha20Poly1305>.generate` | `chacha20poly1305.Key.generate` |

The first wraps the callee in `generic_function`, whose first child is the plain callee node; the switch fell through and returned `nil`, so the call was dropped. The fix unwraps it.

The second keeps `scoped_identifier` as the callee, so a call *was* produced — with the type arguments baked into its identity. That key matches nothing and looks like data, which is worse than a dropped call: a dropped call reads as zero coverage, a polluted identity reads as coverage that never matches.

`stripRustTypeArguments` removes `::<…>` groups by depth. Two edge cases it must not get wrong, both pinned by tests:

- the `>` of a return arrow closes nothing — `foo::<fn() -> u8>::bar` must yield `foo::bar`, not `foo u8>::bar`;
- an unbalanced path is returned unchanged rather than truncated, because a truncated path becomes a wrong callee identity, which is the failure this change exists to remove.

`Key::<ChaCha20Poly1305>::generate` is now contracted rather than left as a note, so the parser fix has a consumer for its own headline example.

## Contracts

`scrypt.yaml` and `pbkdf2.yaml`, with argument positions carrying the values a consumer reads back from the call site.

Two authoring notes worth recording:

**Arity is version-specific.** `scrypt::Params::new` takes three arguments in the 0.12 line; the four-argument form is `new_with_output_len`. The four-argument spelling of `new` belongs to 0.11, and an arity taken from that release matches nothing in the declared range.

**`log_n` is not `cost`.** The detection rules publish `cost: 131072`; the constructor argument reads 17. The contract names the property `logN` after the crate's own vocabulary so the two are not conflated.

**Free functions in a single-segment crate must be authored in the dot form** (`scrypt.scrypt`). `rustAuthoredKey` only rewrites three-segment `package.Type.method` keys, so a two-segment free-function key passes through unchanged and a `::` spelling never matches. The wiring test asserts both the authored and call-site forms resolve, which is how this surfaced.

## Verification

- `go test ./...` green; `make lint` reports 0 issues
- The turbofish test pins both shapes by **exact key**, not merely that a call was produced — the second defect produced a call, so an existence assertion would have passed against the bug
- `TestStripRustTypeArguments` covers nested and repeated groups, `::<>`, array types, qualified paths, return arrows and unbalanced input
- Return types and arities were verified against the crate sources rather than documentation
- End to end on a local stack: 111 versions of argon2/pbkdf2/scrypt mined with this parser, and a consumer scan resolves `pbkdf2::pbkdf2_hmac::<sha2::Sha256>(..)`, which produced no call before this change
