### PR TITLE
feat(callgraph): add k256, p256, p384 and p521 contracts for the Rust KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Rust callgraph contracts for the RustCrypto elliptic-curve crates `k256`, `p256`, `p384`, and `p521`. Each crate binds its concrete SecretKey, ECDH, and ECDSA aliases; k256 also covers BIP340 Schnorr and ECDSA public-key recovery. 0.13 constructors take an RNG (`random`); 0.14 uses `Generate::generate` with no RNG argument.
 ### Fixed
 - The ghash and poly1305 contracts now target the versions the coverage matrix lists, 0.6.x and 0.9.x. Both previously declared ranges ending immediately below them. The ghash `new_with_init_block` contract is removed: that constructor no longer exists in 0.6.0. (#337)
 ### Fixed

--- a/internal/callgraph/contracts/rust/k256.yaml
+++ b/internal/callgraph/contracts/rust/k256.yaml
@@ -1,0 +1,101 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: k256
+  coordinates:
+    - k256
+  version_range: ">=0.13.0,<0.15.0"
+  description: "RustCrypto secp256k1: ECDSA, ECDH, BIP340 Schnorr, and public-key recovery"
+
+# Inventory sources: k256 0.13–0.14 docs (https://docs.rs/k256/0.14.0/k256/)
+# and the scanoss/crypto_rules k256 rules. 0.13 constructors take an RNG
+# (`random`, arity 1); 0.14 uses elliptic_curve::Generate (`generate`, arity 0).
+#
+# contracted: SecretKey and ECDSA/Schnorr key construction; ECDH ephemeral
+# generate plus diffie_hellman; ECDSA/Schnorr sign and verify; ECDSA recovery.
+# skipped-non-crypto: PKCS#8/PEM encode-decode, SEC1 point codecs, field and
+# group arithmetic, Signature byte conversions.
+# needs-follow-up: sign_digest / verify_digest and hazmat SignPrimitive.
+contracts:
+  - method: k256::SecretKey.random
+    arity: 1
+    return: {type: k256::SecretKey, confidence: high}
+    role: factory
+  - method: k256::SecretKey.generate
+    arity: 0
+    return: {type: k256::SecretKey, confidence: high}
+    role: factory
+  - method: k256::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: k256::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: k256::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: k256::ecdh::EphemeralSecret.generate
+    arity: 0
+    return: {type: k256::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: k256::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: k256::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: k256::ecdh.diffie_hellman
+    arity: 2
+    return: {type: k256::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: k256::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: k256::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: k256::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: k256::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: k256::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: k256::ecdsa::SigningKey.sign
+    arity: 1
+    return: {type: k256::ecdsa::Signature, confidence: high}
+    role: operation
+  - method: k256::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: k256::ecdsa::VerifyingKey.verify
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+  - method: k256::ecdsa::VerifyingKey.recover_from_digest
+    arity: 3
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: k256::ecdsa::VerifyingKey.recover_from_msg
+    arity: 3
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: k256::schnorr::SigningKey.random
+    arity: 1
+    return: {type: k256::schnorr::SigningKey, confidence: high}
+    role: factory
+  - method: k256::schnorr::SigningKey.generate
+    arity: 0
+    return: {type: k256::schnorr::SigningKey, confidence: high}
+    role: factory
+  - method: k256::schnorr::SigningKey.sign
+    arity: 1
+    return: {type: k256::schnorr::Signature, confidence: high}
+    role: operation
+  - method: k256::schnorr::VerifyingKey.from_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: k256::schnorr::VerifyingKey.verify
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/p256.yaml
+++ b/internal/callgraph/contracts/rust/p256.yaml
@@ -1,0 +1,74 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: p256
+  coordinates:
+    - p256
+  version_range: ">=0.13.0,<0.15.0"
+  description: "RustCrypto NIST P-256: ECDSA and ECDH"
+
+# Inventory sources: p256 0.13–0.14 docs (https://docs.rs/p256/0.14.0/p256/)
+# and the scanoss/crypto_rules p256 rules. 0.13 constructors take an RNG
+# (`random`, arity 1); 0.14 uses elliptic_curve::Generate (`generate`, arity 0).
+#
+# contracted: SecretKey and ECDSA key construction; ECDH ephemeral generate
+# plus diffie_hellman; ECDSA sign and verify.
+# skipped-non-crypto: PKCS#8/PEM encode-decode, SEC1 point codecs, field and
+# group arithmetic, Signature byte conversions.
+# needs-follow-up: sign_digest / verify_digest and generic ECDSA recovery
+# re-exports; family notes bind recovery to k256.
+contracts:
+  - method: p256::SecretKey.random
+    arity: 1
+    return: {type: p256::SecretKey, confidence: high}
+    role: factory
+  - method: p256::SecretKey.generate
+    arity: 0
+    return: {type: p256::SecretKey, confidence: high}
+    role: factory
+  - method: p256::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p256::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: p256::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: p256::ecdh::EphemeralSecret.generate
+    arity: 0
+    return: {type: p256::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: p256::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: p256::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: p256::ecdh.diffie_hellman
+    arity: 2
+    return: {type: p256::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: p256::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: p256::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: p256::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: p256::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: p256::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p256::ecdsa::SigningKey.sign
+    arity: 1
+    return: {type: p256::ecdsa::Signature, confidence: high}
+    role: operation
+  - method: p256::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p256::ecdsa::VerifyingKey.verify
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/p384.yaml
+++ b/internal/callgraph/contracts/rust/p384.yaml
@@ -1,0 +1,73 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: p384
+  coordinates:
+    - p384
+  version_range: ">=0.13.0,<0.15.0"
+  description: "RustCrypto NIST P-384: ECDSA and ECDH"
+
+# Inventory sources: p384 0.13–0.14 docs (https://docs.rs/p384/0.14.0/p384/)
+# and the scanoss/crypto_rules p384 rules. 0.13 constructors take an RNG
+# (`random`, arity 1); 0.14 uses elliptic_curve::Generate (`generate`, arity 0).
+#
+# contracted: SecretKey and ECDSA key construction; ECDH ephemeral generate
+# plus diffie_hellman; ECDSA sign and verify.
+# skipped-non-crypto: PKCS#8/PEM encode-decode, SEC1 point codecs, field and
+# group arithmetic, Signature byte conversions.
+# needs-follow-up: sign_digest / verify_digest.
+contracts:
+  - method: p384::SecretKey.random
+    arity: 1
+    return: {type: p384::SecretKey, confidence: high}
+    role: factory
+  - method: p384::SecretKey.generate
+    arity: 0
+    return: {type: p384::SecretKey, confidence: high}
+    role: factory
+  - method: p384::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p384::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: p384::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: p384::ecdh::EphemeralSecret.generate
+    arity: 0
+    return: {type: p384::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: p384::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: p384::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: p384::ecdh.diffie_hellman
+    arity: 2
+    return: {type: p384::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: p384::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: p384::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: p384::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: p384::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: p384::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p384::ecdsa::SigningKey.sign
+    arity: 1
+    return: {type: p384::ecdsa::Signature, confidence: high}
+    role: operation
+  - method: p384::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p384::ecdsa::VerifyingKey.verify
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/p521.yaml
+++ b/internal/callgraph/contracts/rust/p521.yaml
@@ -1,0 +1,73 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: p521
+  coordinates:
+    - p521
+  version_range: ">=0.13.0,<0.15.0"
+  description: "RustCrypto NIST P-521: ECDSA and ECDH"
+
+# Inventory sources: p521 0.13–0.14 docs (https://docs.rs/p521/0.14.0/p521/)
+# and the scanoss/crypto_rules p521 rules. 0.13 constructors take an RNG
+# (`random`, arity 1); 0.14 uses elliptic_curve::Generate (`generate`, arity 0).
+#
+# contracted: SecretKey and ECDSA key construction; ECDH ephemeral generate
+# plus diffie_hellman; ECDSA sign and verify.
+# skipped-non-crypto: PKCS#8/PEM encode-decode, SEC1 point codecs, field and
+# group arithmetic, Signature byte conversions.
+# needs-follow-up: sign_digest / verify_digest.
+contracts:
+  - method: p521::SecretKey.random
+    arity: 1
+    return: {type: p521::SecretKey, confidence: high}
+    role: factory
+  - method: p521::SecretKey.generate
+    arity: 0
+    return: {type: p521::SecretKey, confidence: high}
+    role: factory
+  - method: p521::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p521::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: p521::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: p521::ecdh::EphemeralSecret.generate
+    arity: 0
+    return: {type: p521::ecdh::EphemeralSecret, confidence: high}
+    role: factory
+  - method: p521::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: p521::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: p521::ecdh.diffie_hellman
+    arity: 2
+    return: {type: p521::ecdh::SharedSecret, confidence: high}
+    role: operation
+  - method: p521::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: p521::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: p521::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: p521::ecdsa::SigningKey, confidence: high}
+    role: factory
+  - method: p521::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p521::ecdsa::SigningKey.sign
+    arity: 1
+    return: {type: p521::ecdsa::Signature, confidence: high}
+    role: operation
+  - method: p521::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: p521::ecdsa::VerifyingKey.verify
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_elliptic_curves_test.go
+++ b/internal/callgraph/contracts/rust_elliptic_curves_test.go
@@ -1,0 +1,76 @@
+package contracts_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedRustIncludesEllipticCurveContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	type row struct {
+		authored string
+		callSite string
+		arity    int
+		library  string
+		role     string
+		ret      string
+	}
+	tests := []row{
+		{"k256::SecretKey.generate", "k256.SecretKey.generate", 0, "k256", "factory", "k256::SecretKey"},
+		{"k256::SecretKey.random", "k256.SecretKey.random", 1, "k256", "factory", "k256::SecretKey"},
+		{"k256::ecdh::EphemeralSecret.generate", "k256::ecdh.EphemeralSecret.generate", 0, "k256", "factory", "k256::ecdh::EphemeralSecret"},
+		{"k256::ecdh::EphemeralSecret.diffie_hellman", "k256::ecdh.EphemeralSecret.diffie_hellman", 1, "k256", "operation", "k256::ecdh::SharedSecret"},
+		{"k256::ecdh.diffie_hellman", "k256.ecdh.diffie_hellman", 2, "k256", "operation", "k256::ecdh::SharedSecret"},
+		{"k256::ecdsa::SigningKey.generate", "k256::ecdsa.SigningKey.generate", 0, "k256", "factory", "k256::ecdsa::SigningKey"},
+		{"k256::ecdsa::SigningKey.sign", "k256::ecdsa.SigningKey.sign", 1, "k256", "operation", "k256::ecdsa::Signature"},
+		{"k256::ecdsa::VerifyingKey.verify", "k256::ecdsa.VerifyingKey.verify", 2, "k256", "operation", "core::result::Result"},
+		{"k256::ecdsa::VerifyingKey.recover_from_digest", "k256::ecdsa.VerifyingKey.recover_from_digest", 3, "k256", "factory", "core::result::Result"},
+		{"k256::schnorr::SigningKey.generate", "k256::schnorr.SigningKey.generate", 0, "k256", "factory", "k256::schnorr::SigningKey"},
+		{"k256::schnorr::SigningKey.sign", "k256::schnorr.SigningKey.sign", 1, "k256", "operation", "k256::schnorr::Signature"},
+		{"p256::ecdsa::SigningKey.generate", "p256::ecdsa.SigningKey.generate", 0, "p256", "factory", "p256::ecdsa::SigningKey"},
+		{"p256::ecdh::EphemeralSecret.generate", "p256::ecdh.EphemeralSecret.generate", 0, "p256", "factory", "p256::ecdh::EphemeralSecret"},
+		{"p384::ecdsa::SigningKey.sign", "p384::ecdsa.SigningKey.sign", 1, "p384", "operation", "p384::ecdsa::Signature"},
+		{"p384::SecretKey.random", "p384.SecretKey.random", 1, "p384", "factory", "p384::SecretKey"},
+		{"p521::ecdsa::VerifyingKey.verify", "p521::ecdsa.VerifyingKey.verify", 2, "p521", "operation", "core::result::Result"},
+		{"p521::ecdh.diffie_hellman", "p521.ecdh.diffie_hellman", 2, "p521", "operation", "p521::ecdh::SharedSecret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.authored, tt.arity), func(t *testing.T) {
+			t.Parallel()
+			for _, key := range []string{tt.authored, tt.callSite} {
+				got := kb.ContractsFor(key, tt.arity)
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d contracts, want 1", key, tt.arity, len(got))
+				}
+				if got[0].SourceLibrary != tt.library || got[0].Role != tt.role || got[0].Return.Type != tt.ret {
+					t.Fatalf("ContractsFor(%q, %d) = %#v, want %s %s returning %s",
+						key, tt.arity, got[0], tt.library, tt.role, tt.ret)
+				}
+			}
+		})
+	}
+}
+
+func TestEllipticCurveGenerateArityDoesNotMatchRandom(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+	if got := kb.ContractsFor("k256::ecdsa.SigningKey.generate", 1); len(got) != 0 {
+		t.Fatalf("0.14 generate must not match arity 1, got %#v", got)
+	}
+	if got := kb.ContractsFor("k256::ecdsa.SigningKey.random", 0); len(got) != 0 {
+		t.Fatalf("0.13 random must not match arity 0, got %#v", got)
+	}
+}

--- a/internal/callgraph/rust_elliptic_curve_contract_wiring_test.go
+++ b/internal/callgraph/rust_elliptic_curve_contract_wiring_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// Curve-crate KBs bind the concrete type aliases, so a parser identity change
+// must fail here rather than resolving the generic ecdsa crate instead.
+func TestEllipticCurveContractsResolveParsedCallIdentities(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	dir := t.TempDir()
+	src := `use k256::ecdsa::SigningKey;
+use k256::ecdh::EphemeralSecret;
+use p256::ecdsa::VerifyingKey;
+
+fn demo(peer: &k256::PublicKey, msg: &[u8], sig: &k256::ecdsa::Signature) {
+    let _a = SigningKey::generate();
+    let _b = k256::SecretKey::generate();
+    let _c = EphemeralSecret::generate();
+    let _d = _c.diffie_hellman(peer);
+    let _e = _a.sign(msg);
+    let _f = VerifyingKey::from_sec1_bytes(msg);
+    let _g = k256::schnorr::SigningKey::generate();
+    let _h = p384::ecdsa::SigningKey::random(&mut rng);
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.rs"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewRustParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"k256::ecdsa.SigningKey.generate":          "k256",
+		"k256.SecretKey.generate":                  "k256",
+		"k256::ecdh.EphemeralSecret.generate":      "k256",
+		"k256::schnorr.SigningKey.generate":        "k256",
+		"p256::ecdsa.VerifyingKey.from_sec1_bytes": "p256",
+		"p384::ecdsa.SigningKey.random":            "p384",
+	}
+	seen := map[string]bool{}
+	var parsed []string
+
+	for _, analysis := range analyses {
+		for _, fn := range analysis.Functions {
+			for _, call := range fn.Calls {
+				callee := call.Callee
+				method, _ := splitMethodArity(&callee)
+				parsed = append(parsed, method)
+				library, ok := want[method]
+				if !ok {
+					continue
+				}
+				got := kb.ContractsFor(method, len(call.Arguments))
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d, want exactly one contract (method key %q); parsed = %v",
+						method, len(call.Arguments), len(got), method, parsed)
+				}
+				if got[0].SourceLibrary != library {
+					t.Fatalf("contract for %q = %#v, want library %s", method, got[0], library)
+				}
+				seen[method] = true
+			}
+		}
+	}
+
+	for method := range want {
+		if !seen[method] {
+			t.Fatalf("parsed calls did not cover %q; seen = %v; parsed = %v", method, seen, parsed)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Family ID: `rustcrypto-elliptic-curves`. Canonical family: RustCrypto elliptic curves. Refs scanoss/crypto-mining-service#331.
- Adds Rust KB contracts for `k256`, `p256`, `p384`, and `p521`. Each file binds SecretKey, ECDH, and ECDSA aliases; k256 also covers BIP340 Schnorr and ECDSA recovery.
- 0.13 factories are `random` (arity 1). 0.14 factories are `Generate::generate` (arity 0). Call-site keys keep the mixed `crate::module.Type.method` shape the Rust parser emits.

## Unique PURLs
- `pkg:cargo/k256`
- `pkg:cargo/p256`
- `pkg:cargo/p384`
- `pkg:cargo/p521`

## Inventory (approved scope: keygen, ECDH, ECDSA, k256 Schnorr/recovery)
- contracted: SecretKey/SigningKey `random` and `generate`, ECDH `EphemeralSecret` plus `diffie_hellman`, ECDSA `sign`/`verify`/`from_sec1_bytes`, k256 Schnorr `sign`/`verify`/`from_bytes`, k256 `recover_from_digest`/`recover_from_msg`
- skipped-non-crypto: PKCS#8/PEM, SEC1 codecs, field/group arithmetic, signature byte conversions
- needs-follow-up: `sign_digest`/`verify_digest`; generic recovery re-exports on p256

## Local verification
- [x] `go test ./internal/callgraph/contracts/ ./internal/callgraph/ -count=1`
- [x] Embedded contracts load; parser identities resolve to the concrete crate, not the generic `ecdsa` crate

## Merge order
Merge after the matching crypto_rules PR and before the mining-service validation PR.