### PR TITLE
feat(callgraph): add der, pkcs1, pkcs8, sec1 and spki contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ internal/callgraph/contracts/
 │                          #   bcrypt, argon2-cffi, pynacl, pyopenssl, m2crypto,
 │                          #   pyjwt, flask-jwt-extended, pyotp, werkzeug, boto3,
 │                          #   azure-keyvault-keys, azure-keyvault-secrets
-└── rust/                  # ring, chacha20poly1305 (+ bootstrap)
+└── rust/                  # ring, chacha20poly1305, der, pkcs1, pkcs8, sec1, spki (+ bootstrap)
 ```
 
 **One YAML file = one library version**. Adding a new library is a new YAML, not a code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Rust callgraph contracts for the RustCrypto formats crates `der`, `pkcs1`, `pkcs8`, `sec1`, and `spki`. These model SecretDocument and PKCS#1 / PKCS#8 / SEC1 / SPKI key-document codecs, including encrypted PKCS#8 decrypt/encrypt. Generic DER `Document` / `Decode::from_der` is not contracted.
 ### Fixed
 - The ghash and poly1305 contracts now target the versions the coverage matrix lists, 0.6.x and 0.9.x. Both previously declared ranges ending immediately below them. The ghash `new_with_init_block` contract is removed: that constructor no longer exists in 0.6.0. (#337)
 ### Fixed

--- a/internal/callgraph/contracts/rust/der.yaml
+++ b/internal/callgraph/contracts/rust/der.yaml
@@ -1,0 +1,34 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: der
+  coordinates:
+    - der
+  version_range: ">=0.7.0,<0.9.0"
+  description: "RustCrypto ASN.1 DER encoding; SecretDocument holds key material"
+
+# Inventory sources: der 0.8 docs (https://docs.rs/der/latest/der/struct.SecretDocument.html)
+# and the scanoss/crypto_rules der SecretDocument rules.
+#
+# contracted: SecretDocument PEM/DER load, encode_msg, and PEM serialize.
+# skipped-non-crypto: Document, Decode/Encode on built-in ASN.1 types, Header,
+# Tag, Length, OID parse, and generic from_der on non-secret documents.
+contracts:
+  - method: der::SecretDocument.from_pem
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: der::SecretDocument.read_der_file
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: der::SecretDocument.encode_msg
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: der::SecretDocument.to_pem
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/pkcs1.yaml
+++ b/internal/callgraph/contracts/rust/pkcs1.yaml
@@ -1,0 +1,44 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: pkcs1
+  coordinates:
+    - pkcs1
+  version_range: ">=0.7.0,<0.8.0"
+  description: "RustCrypto PKCS#1 RSA private and public key encoding"
+
+# Inventory sources: pkcs1 0.7 docs (https://docs.rs/pkcs1/latest/pkcs1/)
+# and the scanoss/crypto_rules pkcs1 key rules.
+#
+# contracted: Decode/Encode RSA private and public key DER entry points.
+# skipped-non-crypto: OtherPrimeInfo, UintRef, ObjectIdentifier.
+# skipped-informative-return: RsaOaepParams / RsaPssParams are algorithm
+# parameter structs owned by the rsa crate's encrypt/sign path, not key
+# document codecs.
+contracts:
+  - method: pkcs1::DecodeRsaPrivateKey.from_pkcs1_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs1::RsaPrivateKey.from_pkcs1_pem
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs1::EncodeRsaPrivateKey.to_pkcs1_der
+    arity: 0
+    return: {type: core::result::Result, confidence: high}
+    role: output
+  - method: pkcs1::DecodeRsaPublicKey.from_pkcs1_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs1::RsaPublicKey.from_pkcs1_pem
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs1::EncodeRsaPublicKey.to_pkcs1_der
+    arity: 0
+    return: {type: core::result::Result, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/pkcs8.yaml
+++ b/internal/callgraph/contracts/rust/pkcs8.yaml
@@ -1,0 +1,52 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: pkcs8
+  coordinates:
+    - pkcs8
+  version_range: ">=0.10.0,<0.12.0"
+  description: "RustCrypto PKCS#8 private key encoding, including encrypted keys"
+
+# Inventory sources: pkcs8 0.11 docs (https://docs.rs/pkcs8/latest/pkcs8/)
+# and the scanoss/crypto_rules pkcs8 key rules.
+#
+# contracted: DecodePrivateKey / EncodePrivateKey DER codecs, PrivateKeyInfo
+# from_der and encrypt, EncryptedPrivateKeyInfo decrypt.
+# skipped-non-crypto: AlgorithmIdentifier re-exports, ObjectIdentifier, Version.
+# encrypt() default wrapping (scrypt log2(N)=15,r=8,p=1 and AES-256-CBC) is
+# not modelled as a cipher contract; the finding is the private-key asset.
+contracts:
+  - method: pkcs8::DecodePrivateKey.from_pkcs8_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs8::DecodePrivateKey.from_pkcs8_pem
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs8::PrivateKeyInfo.from_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs8::EncodePrivateKey.to_pkcs8_der
+    arity: 0
+    return: {type: core::result::Result, confidence: high}
+    role: output
+  - method: pkcs8::DecodePrivateKey.from_pkcs8_encrypted_der
+    arity: 2
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: pkcs8::EncryptedPrivateKeyInfo.decrypt
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+  - method: pkcs8::PrivateKeyInfo.encrypt
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: operation
+  - method: pkcs8::EncodePrivateKey.to_pkcs8_encrypted_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/sec1.yaml
+++ b/internal/callgraph/contracts/rust/sec1.yaml
@@ -1,0 +1,33 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: sec1
+  coordinates:
+    - sec1
+  version_range: ">=0.7.0,<0.9.0"
+  description: "RustCrypto SEC1 elliptic-curve private key and point encoding"
+
+# Inventory sources: sec1 0.8 docs (https://docs.rs/sec1/latest/sec1/)
+# and the scanoss/crypto_rules sec1 key rules.
+#
+# contracted: Decode/Encode EC private key DER/PEM and EncodedPoint::from_bytes.
+# skipped-non-crypto: EcParameters OID parsing, LineEnding, ALGORITHM_OID.
+contracts:
+  - method: sec1::DecodeEcPrivateKey.from_sec1_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: sec1::EcPrivateKey.from_sec1_pem
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: sec1::EncodeEcPrivateKey.to_sec1_der
+    arity: 0
+    return: {type: core::result::Result, confidence: high}
+    role: output
+  - method: sec1::point::EncodedPoint.from_bytes
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/spki.yaml
+++ b/internal/callgraph/contracts/rust/spki.yaml
@@ -1,0 +1,35 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: spki
+  coordinates:
+    - spki
+  version_range: ">=0.7.0,<0.9.0"
+  description: "RustCrypto X.509 SubjectPublicKeyInfo encoding"
+
+# Inventory sources: spki 0.8 docs (https://docs.rs/spki/latest/spki/)
+# and the scanoss/crypto_rules spki public-key rules.
+#
+# contracted: DecodePublicKey / EncodePublicKey DER codecs and
+# SubjectPublicKeyInfo::from_der.
+# skipped-non-crypto: AlgorithmIdentifier construction, ObjectIdentifier parse,
+# DigestWriter, SPKI fingerprint (SHA-256 of the encoding is not a hash API).
+contracts:
+  - method: spki::DecodePublicKey.from_public_key_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: spki::DecodePublicKey.from_public_key_pem
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: spki::SubjectPublicKeyInfo.from_der
+    arity: 1
+    return: {type: core::result::Result, confidence: high}
+    role: factory
+  - method: spki::EncodePublicKey.to_public_key_der
+    arity: 0
+    return: {type: core::result::Result, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_formats_test.go
+++ b/internal/callgraph/contracts/rust_formats_test.go
@@ -1,0 +1,58 @@
+package contracts_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedRustIncludesFormatContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	type row struct {
+		method  string
+		arity   int
+		library string
+		role    string
+	}
+	tests := []row{
+		{"der::SecretDocument.from_pem", 1, "der", "factory"},
+		{"der::SecretDocument.encode_msg", 1, "der", "factory"},
+		{"der::SecretDocument.to_pem", 2, "der", "output"},
+		{"pkcs1::DecodeRsaPrivateKey.from_pkcs1_der", 1, "pkcs1", "factory"},
+		{"pkcs1::EncodeRsaPrivateKey.to_pkcs1_der", 0, "pkcs1", "output"},
+		{"pkcs1::DecodeRsaPublicKey.from_pkcs1_der", 1, "pkcs1", "factory"},
+		{"pkcs1::EncodeRsaPublicKey.to_pkcs1_der", 0, "pkcs1", "output"},
+		{"pkcs8::DecodePrivateKey.from_pkcs8_der", 1, "pkcs8", "factory"},
+		{"pkcs8::PrivateKeyInfo.from_der", 1, "pkcs8", "factory"},
+		{"pkcs8::EncodePrivateKey.to_pkcs8_der", 0, "pkcs8", "output"},
+		{"pkcs8::DecodePrivateKey.from_pkcs8_encrypted_der", 2, "pkcs8", "factory"},
+		{"pkcs8::EncryptedPrivateKeyInfo.decrypt", 1, "pkcs8", "operation"},
+		{"pkcs8::PrivateKeyInfo.encrypt", 1, "pkcs8", "operation"},
+		{"sec1::DecodeEcPrivateKey.from_sec1_der", 1, "sec1", "factory"},
+		{"sec1::EncodeEcPrivateKey.to_sec1_der", 0, "sec1", "output"},
+		{"sec1::point::EncodedPoint.from_bytes", 1, "sec1", "factory"},
+		{"spki::DecodePublicKey.from_public_key_der", 1, "spki", "factory"},
+		{"spki::SubjectPublicKeyInfo.from_der", 1, "spki", "factory"},
+		{"spki::EncodePublicKey.to_public_key_der", 0, "spki", "output"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			t.Parallel()
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d contracts, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].SourceLibrary != tt.library || got[0].Role != tt.role {
+				t.Fatalf("ContractsFor(%q, %d) = %#v, want %s %s", tt.method, tt.arity, got[0], tt.library, tt.role)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Family ID: `rustcrypto-formats`. Canonical family: RustCrypto formats. Refs scanoss/crypto-mining-service#332.
- Adds Rust KB contracts for `der`, `pkcs1`, `pkcs8`, `sec1`, and `spki`.
- Models SecretDocument and the PKCS#1 / PKCS#8 / SEC1 / SPKI key-document codecs, including encrypted PKCS#8 decrypt/encrypt.
- Generic DER `Document` / `Decode::from_der` is not contracted. encrypt() wrapping defaults are not modelled as cipher contracts.

## Unique PURLs
- `pkg:cargo/der`
- `pkg:cargo/pkcs1`
- `pkg:cargo/pkcs8`
- `pkg:cargo/sec1`
- `pkg:cargo/spki`

## Inventory
- contracted: SecretDocument PEM/DER load and encode; PKCS#1 RSA private/public codecs; PKCS#8 DecodePrivateKey / EncodePrivateKey plus encrypted decrypt/encrypt; SEC1 private-key codecs and EncodedPoint::from_bytes; SPKI DecodePublicKey / EncodePublicKey and SubjectPublicKeyInfo::from_der
- skipped-non-crypto: generic DER Document, AlgorithmIdentifier, ObjectIdentifier, field/group arithmetic, signature byte conversions

## Local verification
- [x] `go test ./internal/callgraph/contracts/ -count=1`

## Merge order
Merge after the matching crypto_rules PR and before the mining-service validation PR.