### PR TITLE
docs(changelog): drop issue numbers that are not this repository's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - A Rust local type alias (`type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;`) now resolves calls made through it to the aliased path, so a detection made through that spelling carries reachability instead of none.
 ### Fixed
-- The ghash and poly1305 contracts now target the versions the coverage matrix lists, 0.6.x and 0.9.x. Both previously declared ranges ending immediately below them. The ghash `new_with_init_block` contract is removed: that constructor no longer exists in 0.6.0. (#337)
+- The ghash and poly1305 contracts now target the versions the coverage matrix lists, 0.6.x and 0.9.x. Both previously declared ranges ending immediately below them. The ghash `new_with_init_block` contract is removed: that constructor no longer exists in 0.6.0.
 ### Fixed
-- The ed25519 contract now targets the 3.x line and covers `Signature::from_components`. It previously declared a range ending before 3.0.0, which excluded the version the coverage matrix lists. (#336)
+- The ed25519 contract now targets the 3.x line and covers `Signature::from_components`. It previously declared a range ending before 3.0.0, which excluded the version the coverage matrix lists.
 ### Added
-- Rust callgraph contracts for the RustCrypto signature crates `dsa`, `ecdsa` and `ed25519`: key construction for each, and the Ed25519 signature type the crate exposes in place of an implementation. Signing and verification reach these crates through shared traits, so the contracts anchor on the stable key identities. (#336)
+- Rust callgraph contracts for the RustCrypto signature crates `dsa`, `ecdsa` and `ed25519`: key construction for each, and the Ed25519 signature type the crate exposes in place of an implementation. Signing and verification reach these crates through shared traits, so the contracts anchor on the stable key identities.
 ### Added
-- Rust callgraph contracts for the RustCrypto universal hashes, GHASH and Poly1305: construction, the streaming update lifecycle and tag output. Both expose their key size as a parameter role. (#337)
+- Rust callgraph contracts for the RustCrypto universal hashes, GHASH and Poly1305: construction, the streaming update lifecycle and tag output. Both expose their key size as a parameter role.
 ### Added
-- Rust callgraph contracts for sodiumoxide: XSalsa20-Poly1305 authenticated encryption, Ed25519 signatures, HMAC-SHA-512-256 authentication, scrypt password hashing, and the SHA-256/SHA-512 hashes. Supporting calls for these carry a lifecycle category, and password derivation exposes its two cost limits as parameter roles. (#338)
+- Rust callgraph contracts for sodiumoxide: XSalsa20-Poly1305 authenticated encryption, Ed25519 signatures, HMAC-SHA-512-256 authentication, scrypt password hashing, and the SHA-256/SHA-512 hashes. Supporting calls for these carry a lifecycle category, and password derivation exposes its two cost limits as parameter roles.
 ### Fixed
 - C++ types declared inside a namespace opened by a macro (`NAMESPACE_BEGIN(X)`) now resolve to their qualified identity instead of a bare one. Mining such a library previously attributed none of its crypto to the library's own types, because a rule or contract anchored on the qualified name could not match its sources. Crypto++ 8.9.0 goes from 0 to 9 library-attributed entry points. (#96)
 ### Added


### PR DESCRIPTION
Five `[Unreleased]` entries cite `(#336)`, `(#337)` or `(#338)`. Those numbers do not exist in this repository — a reader following them lands on nothing — and they are issue numbers of a private repository, whose numbering a public changelog should not publish.

Only the five parenthetical citations are removed; no entry text changes. `(#96)` and `(#289)` stay: both exist here.

Same class as the earlier cleanup, which missed these because they do not name the repository — a bare `(#N)` reads as a local reference and only fails when resolved.