### PR TITLE
feat(callgraph): add arkworks algebra contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/ark-bls12-381.yaml
+++ b/internal/callgraph/contracts/rust/ark-bls12-381.yaml
@@ -1,0 +1,124 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ark-bls12-381
+  coordinates:
+    - ark-bls12-381
+    - ark_bls12_381
+  version_range: ">=0.2.0,<0.7.0"
+  description: "BLS12-381 pairing-friendly curve instantiated for the arkworks stack"
+
+# API read at ark-bls12-381 0.6.0 (src/curves/mod.rs, src/curves/g1.rs,
+# src/curves/g2.rs, src/fields/), with the pre-rename spellings read at 0.3.0
+# and 0.2.0 because the matrix range starts there:
+#
+#   0.2.0  curves/mod.rs:16 `pub type Bls12_381 = Bls12<Parameters>`; the
+#          pairing methods come from ark-ec's `PairingEngine`, so the era's
+#          spelling is `product_of_pairings`, not `multi_pairing`.
+#   0.3.0  unchanged from 0.2.0.
+#   0.4.0  curves/mod.rs:20 `pub type Bls12_381 = Bls12<Config>` — the config
+#          type is renamed, and ark-ec renames `PairingEngine` to
+#          `pairing::Pairing` in the same release, which is where
+#          `multi_pairing` and `multi_miller_loop` replace
+#          `product_of_pairings`.
+#   0.6.0  curves/mod.rs:20 unchanged since 0.4.0.
+#
+# Both eras are contracted because a consumer pinned anywhere in the matrix
+# range reaches one or the other, and a contract covering only the newer
+# spelling leaves a third of the range resolving to "(?, ?)".
+#
+# ARITIES WERE READ FROM THE TRAIT DECLARATIONS, NOT FROM PROSE. `pairing` and
+# `multi_pairing` take two arguments (ark-ec 0.6.0 pairing.rs:117 and :87),
+# `final_exponentiation` takes one (pairing.rs:84), and the 0.2/0.3-era
+# `product_of_pairings` takes one (ark-ec 0.3.0 lib.rs:56). `generator()` is
+# nullary (ark-ec 0.6.0 lib.rs:48 for AffineRepr, lib.rs:185 for CurveGroup).
+#
+# This crate instantiates a curve; it is not a protocol. Point addition,
+# doubling, negation and the operator impls are deliberately absent — they carry
+# no crypto asset, and the scanoss/crypto_rules raw-arithmetic-negative fixture
+# pins that they produce no finding either.
+#
+# skipped-non-crypto: Add/Sub/Mul/Neg operator impls, CanonicalSerialize and
+#   CanonicalDeserialize, Zero/One, and the field tower internals (Fq2, Fq6,
+#   Fq12) that a consumer does not construct directly.
+# parameter_types record the CONSUMER-FACING types. The trait declares
+# `impl Into<Self::G1Prepared>`; for this curve the type a consumer actually
+# passes is the affine (or projective) point, and that is what has to resolve
+# for a consumer's variable to flow into the pairing.
+contracts:
+  - method: ark_bls12_381::Bls12_381.pairing
+    arity: 2
+    return: { type: ark_ec::pairing::PairingOutput, confidence: high }
+    parameter_types: ["ark_bls12_381::G1Affine", "ark_bls12_381::G2Affine"]
+    role: operation
+  - method: ark_bls12_381::Bls12_381.multi_pairing
+    arity: 2
+    return: { type: ark_ec::pairing::PairingOutput, confidence: high }
+    parameter_types: ["ark_bls12_381::G1Affine", "ark_bls12_381::G2Affine"]
+    role: operation
+  - method: ark_bls12_381::Bls12_381.product_of_pairings
+    arity: 1
+    return: { type: ark_bls12_381::Fq12, confidence: high }
+    parameter_types: ["ark_bls12_381::Fq12"]
+    role: operation
+  - method: ark_bls12_381::Bls12_381.miller_loop
+    arity: 2
+    return: { type: ark_ec::pairing::MillerLoopOutput, confidence: high }
+    parameter_types: ["ark_bls12_381::G1Affine", "ark_bls12_381::G2Affine"]
+    role: operation
+  - method: ark_bls12_381::Bls12_381.multi_miller_loop
+    arity: 2
+    return: { type: ark_ec::pairing::MillerLoopOutput, confidence: high }
+    parameter_types: ["ark_bls12_381::G1Affine", "ark_bls12_381::G2Affine"]
+    role: operation
+  - method: ark_bls12_381::Bls12_381.final_exponentiation
+    arity: 1
+    return: { type: core::option::Option, confidence: high }
+    parameter_types: ["ark_ec::pairing::MillerLoopOutput"]
+    role: operation
+  - method: ark_bls12_381::Fr.rand
+    arity: 1
+    return: { type: ark_bls12_381::Fr, confidence: high }
+    parameter_types: ["&mut rand::Rng"]
+    role: factory
+  - method: ark_bls12_381::Fq.rand
+    arity: 1
+    return: { type: ark_bls12_381::Fq, confidence: high }
+    parameter_types: ["&mut rand::Rng"]
+    role: factory
+  - method: ark_bls12_381::G1Affine.generator
+    arity: 0
+    return: { type: ark_bls12_381::G1Affine, confidence: high }
+    role: factory
+  - method: ark_bls12_381::G2Affine.generator
+    arity: 0
+    return: { type: ark_bls12_381::G2Affine, confidence: high }
+    role: factory
+  - method: ark_bls12_381::G1Projective.generator
+    arity: 0
+    return: { type: ark_bls12_381::G1Projective, confidence: high }
+    role: factory
+  - method: ark_bls12_381::G2Projective.generator
+    arity: 0
+    return: { type: ark_bls12_381::G2Projective, confidence: high }
+    role: factory
+  - method: ark_bls12_381::G1Projective.rand
+    arity: 1
+    return: { type: ark_bls12_381::G1Projective, confidence: high }
+    parameter_types: ["&mut rand::Rng"]
+    role: factory
+  - method: ark_bls12_381::G2Projective.rand
+    arity: 1
+    return: { type: ark_bls12_381::G2Projective, confidence: high }
+    parameter_types: ["&mut rand::Rng"]
+    role: factory
+  - method: ark_bls12_381::G1Projective.into_affine
+    arity: 0
+    return: { type: ark_bls12_381::G1Affine, confidence: high }
+    role: output
+  - method: ark_bls12_381::G2Projective.into_affine
+    arity: 0
+    return: { type: ark_bls12_381::G2Affine, confidence: high }
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/ark-ec.yaml
+++ b/internal/callgraph/contracts/rust/ark-ec.yaml
@@ -1,0 +1,128 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ark-ec
+  coordinates:
+    - ark-ec
+    - ark_ec
+  version_range: ">=0.2.0,<0.7.0"
+  description: "Generic elliptic-curve group and pairing traits for the arkworks stack"
+
+# API read at ark-ec 0.6.0 (src/pairing.rs, src/lib.rs, src/hashing/), with the
+# pre-rename era read at 0.3.0 and 0.2.0 because the matrix range starts there.
+# This crate is where the family's one API break lives:
+#
+#   0.2.0  lib.rs:41 `pub trait PairingEngine`, declared at the CRATE ROOT, with
+#          `pairing` (lib.rs:105, two arguments), `product_of_pairings`
+#          (lib.rs:56, one argument), `miller_loop` and `final_exponentiation`.
+#          The curve traits are `ProjectiveCurve` and `AffineCurve`.
+#   0.3.0  unchanged from 0.2.0.
+#   0.4.0  pairing.rs:23 `pub trait Pairing`, MOVED into a new `pairing` module,
+#          so the resolved key gains a module segment. `product_of_pairings`
+#          becomes `multi_pairing` and `multi_miller_loop` appears;
+#          `ProjectiveCurve`/`AffineCurve` become `CurveGroup`/`AffineRepr`;
+#          and a new `hashing` module appears (hashing/mod.rs:9
+#          `pub trait HashToCurve`).
+#   0.6.0  pairing.rs:23 unchanged since 0.4.0. The 0.5.0 -> 0.6.0 diff touches
+#          only internal arithmetic helpers, none of them contracted here.
+#
+# BOTH ERAS ARE KEYED SEPARATELY AND DELIBERATELY. `ark_ec::PairingEngine.pairing`
+# and `ark_ec::pairing::Pairing.pairing` are different keys, not spellings of
+# one: the trait moved modules, so a single key would resolve on one half of the
+# range and silently produce "(?, ?)" on the other.
+#
+# ARITIES READ FROM THE TRAIT DECLARATIONS: 0.6.0 pairing.rs:117 `fn pairing(p,
+# q)` and :87 `fn multi_pairing(a, b)` take two; :84 `fn final_exponentiation`
+# takes one; 0.3.0 lib.rs:56 `fn product_of_pairings(i)` takes one. `generator()`
+# is nullary (lib.rs:48 AffineRepr, lib.rs:185 CurveGroup).
+#
+# ark-ec defines no curve of its own, so these call sites name no curve. That is
+# why the matching rules emit no ellipticCurve: the concrete curve is reported
+# by the crate that instantiates it. Generic group arithmetic — addition,
+# doubling, `into_affine`, `mul_bigint`, multi-scalar multiplication — is
+# deliberately absent for the same reason it carries no crypto asset.
+#
+# skipped-non-crypto: Add/Sub/Mul/Neg operator impls, VariableBaseMSM::msm,
+#   ScalarMul, the short-Weierstrass and twisted-Edwards model internals, and
+#   CanonicalSerialize/CanonicalDeserialize.
+# parameter_types record the declared trait signature. ark-ec is generic over
+# the curve, so the associated types are named as the trait declares them
+# rather than resolved to a concrete curve, which is genuinely unknown here.
+contracts:
+  # 0.4.0 and later: the trait lives in the `pairing` module.
+  - method: ark_ec::pairing::Pairing.pairing
+    arity: 2
+    return: { type: ark_ec::pairing::PairingOutput, confidence: high }
+    parameter_types: ["ark_ec::pairing::Pairing::G1Prepared", "ark_ec::pairing::Pairing::G2Prepared"]
+    role: operation
+  - method: ark_ec::pairing::Pairing.multi_pairing
+    arity: 2
+    return: { type: ark_ec::pairing::PairingOutput, confidence: high }
+    parameter_types: ["ark_ec::pairing::Pairing::G1Prepared", "ark_ec::pairing::Pairing::G2Prepared"]
+    role: operation
+  - method: ark_ec::pairing::Pairing.miller_loop
+    arity: 2
+    return: { type: ark_ec::pairing::MillerLoopOutput, confidence: high }
+    parameter_types: ["ark_ec::pairing::Pairing::G1Prepared", "ark_ec::pairing::Pairing::G2Prepared"]
+    role: operation
+  - method: ark_ec::pairing::Pairing.multi_miller_loop
+    arity: 2
+    return: { type: ark_ec::pairing::MillerLoopOutput, confidence: high }
+    parameter_types: ["ark_ec::pairing::Pairing::G1Prepared", "ark_ec::pairing::Pairing::G2Prepared"]
+    role: operation
+  - method: ark_ec::pairing::Pairing.final_exponentiation
+    arity: 1
+    return: { type: core::option::Option, confidence: high }
+    parameter_types: ["ark_ec::pairing::MillerLoopOutput"]
+    role: operation
+  # 0.2.0 and 0.3.0: the trait is at the crate root and the names differ.
+  - method: ark_ec::PairingEngine.pairing
+    arity: 2
+    return: { type: ark_ec::PairingEngine::Fqk, confidence: high }
+    parameter_types: ["ark_ec::PairingEngine::G1Affine", "ark_ec::PairingEngine::G2Affine"]
+    role: operation
+  - method: ark_ec::PairingEngine.product_of_pairings
+    arity: 1
+    return: { type: ark_ec::PairingEngine::Fqk, confidence: high }
+    parameter_types: ["ark_ec::PairingEngine::G1Prepared"]
+    role: operation
+  - method: ark_ec::PairingEngine.miller_loop
+    arity: 1
+    return: { type: ark_ec::PairingEngine::Fqk, confidence: high }
+    parameter_types: ["ark_ec::PairingEngine::G1Prepared"]
+    role: operation
+  - method: ark_ec::PairingEngine.final_exponentiation
+    arity: 1
+    return: { type: core::option::Option, confidence: high }
+    parameter_types: ["ark_ec::PairingEngine::Fqk"]
+    role: operation
+  # hash-to-curve, 0.4.0 and later only.
+  - method: ark_ec::hashing::HashToCurve.hash_to_curve
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: operation
+  - method: ark_ec::hashing::map_to_curve_hasher::MapToCurveBasedHasher.new
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  # Base-point derivation. Nullary on both curve traits.
+  - method: ark_ec::AffineRepr.generator
+    arity: 0
+    return: { type: ark_ec::AffineRepr, confidence: medium }
+    role: factory
+  - method: ark_ec::CurveGroup.generator
+    arity: 0
+    return: { type: ark_ec::CurveGroup, confidence: medium }
+    role: factory
+  - method: ark_ec::AffineCurve.prime_subgroup_generator
+    arity: 0
+    return: { type: ark_ec::AffineCurve, confidence: medium }
+    role: factory
+  - method: ark_ec::ProjectiveCurve.prime_subgroup_generator
+    arity: 0
+    return: { type: ark_ec::ProjectiveCurve, confidence: medium }
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/ark-ff.yaml
+++ b/internal/callgraph/contracts/rust/ark-ff.yaml
@@ -1,0 +1,89 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ark-ff
+  coordinates:
+    - ark-ff
+    - ark_ff
+  version_range: ">=0.2.0,<0.7.0"
+  description: "Finite-field arithmetic for the arkworks stack, with hash-to-field"
+
+# API read at ark-ff 0.6.0 (src/fields/mod.rs, src/fields/prime.rs,
+# src/fields/field_hashers/mod.rs), with the earlier layout read at 0.3.0 and
+# 0.2.0 because the matrix range starts there:
+#
+#   0.2.0  fields/mod.rs:350 `pub trait PrimeField`; `pub mod bytes` exists;
+#          there is NO field_hashers module.
+#   0.3.0  fields/mod.rs:351 `pub trait PrimeField`; still no field_hashers.
+#   0.4.0  fields/prime.rs:27 `pub trait PrimeField` — the trait MOVES out of
+#          fields/mod.rs into its own module, `pub mod bytes` is replaced by
+#          `bits`, and src/fields/field_hashers/ appears.
+#   0.6.0  fields/prime.rs:27 unchanged; field_hashers/mod.rs:13
+#          `pub trait HashToField`, :42 `pub struct DefaultFieldHasher`,
+#          :88 `pub fn hash_to_field`.
+#
+# ark-ff is a maths crate. Addition, multiplication, inversion, squaring,
+# `sqrt`, `legendre` and the BigInteger surface are ordinary arithmetic and are
+# deliberately absent: contracting them would type every consumer that does
+# field maths into the crypto call graph, which is exactly what this family's
+# plan asks the ruleset NOT to do, and the scanoss/crypto_rules
+# raw-arithmetic-negative fixture pins that they carry no finding either.
+#
+# What IS contracted: hash-to-field, which is the message-to-field-element step
+# of RFC 9380 and a genuine primitive; and uniform sampling of a field element,
+# which is how a secret scalar is produced. `from_be_bytes_mod_order` and
+# `from_le_bytes_mod_order` are excluded on purpose — they are byte-order
+# conversions of an existing buffer, not sampling, and the entropy came from
+# somewhere else.
+#
+# ARITIES READ FROM THE DECLARATIONS: field_hashers/mod.rs:19 `fn new(domain)`
+# and the impl at :47 `fn hash_to_field(&self, message)` take one non-receiver
+# argument each; fields/mod.rs:247 `fn from_random_bytes(bytes)` and :257
+# `fn from_random_bytes_with_flags(bytes)` take one.
+#
+# skipped-non-crypto: Add/Sub/Mul/Div/Neg operator impls, inverse, square,
+#   sqrt, legendre, the BigInteger surface, Zero/One, and
+#   CanonicalSerialize/CanonicalDeserialize.
+# parameter_types record the declared signature read from the source lines
+# cited above. The domain-separation tag and the message are both byte slices.
+contracts:
+  # hash-to-field, 0.4.0 and later only.
+  - method: ark_ff::field_hashers::DefaultFieldHasher.new
+    arity: 1
+    return: { type: ark_ff::field_hashers::DefaultFieldHasher, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: ark_ff::field_hashers::HashToField.new
+    arity: 1
+    return: { type: ark_ff::field_hashers::HashToField, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: ark_ff::field_hashers::HashToField.hash_to_field
+    arity: 1
+    return: { type: ark_ff::Field, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: operation
+  # Uniform sampling. Present across the whole matrix range, which is what gives
+  # 0.2.0 and 0.3.0 coverage at all.
+  - method: ark_ff::Field.from_random_bytes
+    arity: 1
+    return: { type: core::option::Option, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: ark_ff::Field.from_random_bytes_with_flags
+    arity: 1
+    return: { type: core::option::Option, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: ark_ff::PrimeField.from_random_bytes
+    arity: 1
+    return: { type: core::option::Option, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: ark_ff::UniformRand.rand
+    arity: 1
+    return: { type: ark_ff::Field, confidence: medium }
+    parameter_types: ["&mut rand::Rng"]
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_arkworks_test.go
+++ b/internal/callgraph/contracts/rust_arkworks_test.go
@@ -1,0 +1,160 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The three arkworks crates ship together and reach each other's APIs, so a
+// contract keyed on the wrong crate resolves silently and mislabels the
+// receiver rather than failing. Assert the exact key, the owning library, the
+// arity, the role and the return type for each.
+//
+// The pairing methods are reached through a concrete curve type in
+// ark-bls12-381 and through the trait in ark-ec. Both keys must exist and must
+// report DIFFERENT libraries: that is what keeps one consumer call site from
+// being counted against two crates.
+func TestLoadEmbeddedRustIncludesArkworksContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		lib    string
+		role   string
+		ret    string
+	}{
+		// ark-bls12-381: the concrete curve. `product_of_pairings` is the
+		// 0.2/0.3-era spelling that `multi_pairing` replaced in 0.4.0.
+		{"ark_bls12_381::Bls12_381.pairing", 2, "ark-bls12-381", "operation", "ark_ec::pairing::PairingOutput"},
+		{"ark_bls12_381::Bls12_381.multi_pairing", 2, "ark-bls12-381", "operation", "ark_ec::pairing::PairingOutput"},
+		{"ark_bls12_381::Bls12_381.product_of_pairings", 1, "ark-bls12-381", "operation", "ark_bls12_381::Fq12"},
+		{"ark_bls12_381::Bls12_381.final_exponentiation", 1, "ark-bls12-381", "operation", "core::option::Option"},
+		{"ark_bls12_381::Fr.rand", 1, "ark-bls12-381", "factory", "ark_bls12_381::Fr"},
+		{"ark_bls12_381::G1Affine.generator", 0, "ark-bls12-381", "factory", "ark_bls12_381::G1Affine"},
+		{"ark_bls12_381::G2Projective.rand", 1, "ark-bls12-381", "factory", "ark_bls12_381::G2Projective"},
+
+		// ark-ec: the generic traits, both eras. `PairingEngine` sits at the
+		// crate root in 0.2/0.3; `pairing::Pairing` gains a module segment in
+		// 0.4.0, so these are different keys and not spellings of one.
+		{"ark_ec::pairing::Pairing.pairing", 2, "ark-ec", "operation", "ark_ec::pairing::PairingOutput"},
+		{"ark_ec::pairing::Pairing.multi_pairing", 2, "ark-ec", "operation", "ark_ec::pairing::PairingOutput"},
+		{"ark_ec::PairingEngine.pairing", 2, "ark-ec", "operation", "ark_ec::PairingEngine::Fqk"},
+		{"ark_ec::PairingEngine.product_of_pairings", 1, "ark-ec", "operation", "ark_ec::PairingEngine::Fqk"},
+		{"ark_ec::hashing::HashToCurve.hash_to_curve", 1, "ark-ec", "operation", "core::result::Result"},
+
+		// ark-ff: hash-to-field (0.4.0+) and uniform sampling (whole range).
+		{"ark_ff::field_hashers::DefaultFieldHasher.new", 1, "ark-ff", "factory", "ark_ff::field_hashers::DefaultFieldHasher"},
+		{"ark_ff::field_hashers::HashToField.hash_to_field", 1, "ark-ff", "operation", "ark_ff::Field"},
+		{"ark_ff::Field.from_random_bytes", 1, "ark-ff", "factory", "core::option::Option"},
+		{"ark_ff::PrimeField.from_random_bytes", 1, "ark-ff", "factory", "core::option::Option"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		c := got[0]
+		if c.SourceLibrary != tc.lib {
+			t.Errorf("%s: library = %q, want %q", tc.method, c.SourceLibrary, tc.lib)
+		}
+		if c.Role != tc.role {
+			t.Errorf("%s: role = %q, want %q", tc.method, c.Role, tc.role)
+		}
+		if c.Return.Type != tc.ret {
+			t.Errorf("%s: return = %q, want %q", tc.method, c.Return.Type, tc.ret)
+		}
+	}
+}
+
+// A call-site FQN joins every segment with "." while the KB is authored with
+// Rust's "::" module separator, and Rust callees carry no encoded arity so
+// callers pass -1. Both shapes, and the unknown arity, must resolve — otherwise
+// the contract is present in the file and absent in practice, which is the
+// failure this family's exported call graph showed as "pairing(?, ?)".
+func TestArkworksContractsResolveFromCallSiteKeyShapes(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		callSiteKey string
+		arity       int
+		wantLib     string
+	}{
+		{"ark_bls12_381.Bls12_381.pairing", 2, "ark-bls12-381"},
+		{"ark_bls12_381.Bls12_381.pairing", -1, "ark-bls12-381"},
+		{"ark_ec::pairing.Pairing.pairing", 2, "ark-ec"},
+		{"ark_ec::pairing.Pairing.pairing", -1, "ark-ec"},
+		{"ark_ff::field_hashers.DefaultFieldHasher.new", 1, "ark-ff"},
+		{"ark_ff::field_hashers.DefaultFieldHasher.new", -1, "ark-ff"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.callSiteKey, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.callSiteKey, tc.arity)
+			continue
+		}
+		if got[0].SourceLibrary != tc.wantLib {
+			t.Errorf("%s: library = %q, want %q", tc.callSiteKey, got[0].SourceLibrary, tc.wantLib)
+		}
+	}
+}
+
+// The exported canonical_signature is only as good as parameter_types: a
+// contract that resolves but declares none still exports "pairing(?, ?)", which
+// reads exactly like a missing contract. Pin the parameter types for the call
+// shapes a consumer writes.
+func TestArkworksContractsDeclareParameterTypes(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   []string
+	}{
+		{"ark_bls12_381::Bls12_381.pairing", 2, []string{"ark_bls12_381::G1Affine", "ark_bls12_381::G2Affine"}},
+		{"ark_bls12_381::Fr.rand", 1, []string{"&mut rand::Rng"}},
+		{"ark_ec::pairing::Pairing.pairing", 2, []string{"ark_ec::pairing::Pairing::G1Prepared", "ark_ec::pairing::Pairing::G2Prepared"}},
+		{"ark_ff::field_hashers::DefaultFieldHasher.new", 1, []string{"&[u8]"}},
+		{"ark_ff::Field.from_random_bytes", 1, []string{"&[u8]"}},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		pt := got[0].ParameterTypes
+		if len(pt) != len(tc.want) {
+			t.Errorf("%s: parameter_types = %v, want %v", tc.method, pt, tc.want)
+			continue
+		}
+		for i := range pt {
+			if pt[i] != tc.want[i] {
+				t.Errorf("%s: parameter_types[%d] = %q, want %q", tc.method, i, pt[i], tc.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds Rust knowledge-base contracts for the arkworks algebra crates —
`ark-bls12-381`, `ark-ec` and `ark-ff` — covering the published `0.2.0`-`0.6.0`
range.

## Why

Without a contract these call sites export as `pairing(?, ?)` with no parameter
types, so a consumer's typed variables do not flow through the pairing and the
entry point is never synthesised. With the contracts loaded the same scan
exports:

```
ark_bls12_381.Bls12_381.pairing(ark_bls12_381::G1Affine, ark_bls12_381::G2Affine)
ark_ec::pairing.Pairing.pairing(ark_ec::pairing::Pairing::G1Prepared, ...)
ark_ff::field_hashers.DefaultFieldHasher.new(&[u8])
```

## Both trait eras are keyed separately

`ark-ec` moved its pairing trait at 0.4.0: `PairingEngine` at the crate root
(`lib.rs:41`) became `pairing::Pairing` in a new module (`pairing.rs:23`), and
`product_of_pairings` became `multi_pairing`. Those are different resolved keys,
not two spellings of one, so a single key would resolve on half the range and
silently export `(?, ?)` on the other half. Both are contracted.

## Arities and parameter types were read from the declarations

Not from prose: `pairing.rs:117` `fn pairing(p, q)` and `:87`
`fn multi_pairing(a, b)` take two arguments, `:84` `fn final_exponentiation`
takes one, and the 0.2/0.3-era `fn product_of_pairings(i)` takes one.
`generator()` is nullary on both curve traits.

## What is deliberately absent

These crates are arithmetic. Operator impls, `into_affine`, `mul_bigint`,
multi-scalar multiplication, `inverse`, `square`, `sqrt`, `legendre` and the
BigInteger surface carry no crypto asset, and contracting them would pull every
consumer that does field maths into the crypto call graph. Each contract file
records that under a `skipped-non-crypto` note.

`ark-ec` emits no curve identity because it is generic over the curve; the
concrete curve is carried by the crate that instantiates it.

## Tests

`rust_arkworks_test.go` asserts the exact key, arity, owning library, role and
return type for each contract, that both the authored `::` key shape and the
dot-joined call-site shape resolve (including at unknown arity), and that the
parameter types are declared — a contract that resolves but declares none still
exports `(?, ?)`, which reads exactly like a missing contract.

Full suite green (31 packages, 0 failures) and `make lint` reports 0 issues at
the pinned golangci-lint version. Additive only: zero deletions.