### PR TITLE
feat(callgraph): add Bellman Groth16 contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/bellman.yaml
+++ b/internal/callgraph/contracts/rust/bellman.yaml
@@ -1,0 +1,89 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: bellman
+  coordinates:
+    - bellman
+  version_range: ">=0.0.3,<0.15.0"
+  description: "Groth16 zkSNARK proving system and circuit machinery"
+
+# API read at bellman 0.14.0 (src/groth16/generator.rs, prover.rs, verifier.rs),
+# with the change point read at 0.6.0 and 0.7.0 and the oldest API-bearing
+# release read at 0.0.3.
+#
+# VERSION RANGE STARTS AT 0.0.3, NOT AT THE MATRIX'S OLDEST ROW. 0.0.1 is in the
+# matrix but carries no library at all: its archive has no lib.rs, only main.rs,
+# and no groth16 module. Nothing here can resolve against it, and saying so is
+# more useful than a range that implies coverage it cannot have. The early
+# history is not monotonic either -- 0.0.7 has a lib.rs but no groth16 module,
+# while 0.0.3 and 0.0.9 both have one.
+#
+# THE ONE API CHANGE IS 0.6.0 -> 0.7.0, and it is in the TYPES, not the call
+# shape (src/groth16/verifier.rs at each version):
+#
+#   <= 0.6.0   `E: Engine`,          verify_proof -> Result<bool, SynthesisError>
+#   >= 0.7.0   `E: MultiMillerLoop`, verify_proof -> Result<(), VerificationError>
+#
+# Arities and parameter counts are identical across the whole range, so one set
+# of contracts covers it. `verify_proof` below declares the >= 0.7.0 return type,
+# which holds for 17 of the 23 matrix rows and every recent release. The schema's
+# `when` condition matches on argument VALUES, not on versions, so a
+# version-conditional return type cannot be expressed here; the pre-0.7.0 type is
+# recorded in this comment instead of being silently wrong for one of the two.
+#
+# ARITIES READ FROM THE DECLARATIONS, NOT FROM PROSE. A first pass counted them
+# with a regex over the parameter lines and got `create_random_proof` wrong,
+# because from 0.9.0 the third parameter is spelled `mut rng: &mut R` and a
+# `^\s+[a-z_]+:` pattern skips it. Read from the signatures:
+#   generate_random_parameters(circuit, rng)                                -> 2
+#   generate_parameters(circuit, g1, g2, alpha, beta, gamma, delta, tau)    -> 8
+#   create_random_proof(circuit, params, rng)                               -> 3
+#   create_proof(circuit, params, r, s)                                     -> 4
+#   prepare_verifying_key(vk)                                               -> 1
+#   verify_proof(pvk, proof, public_inputs)                                 -> 3
+#
+# skipped-non-crypto: ConstraintSystem::alloc, alloc_input, enforce, namespace,
+#   LinearCombination and Namespace. That is how any circuit is expressed,
+#   cryptographic or not, and contracting it would pull every consumer that
+#   builds a circuit into the crypto call graph. The scanoss/crypto_rules
+#   constraint-bookkeeping-negative fixture pins that it carries no finding.
+#
+# KEY SHAPE: THESE ARE FREE FUNCTIONS, NOT METHODS. The call-site FQN the parser
+# emits is `bellman::groth16.generate_random_parameters` -- module path joined
+# with `::`, then a DOT before the function name. The Rust key normalisation
+# only rewrites the separator in front of a receiver TYPE and returns keys with
+# fewer than two dots unchanged, so an authored `bellman::groth16::<fn>` never
+# resolves against the emitted key. Authored in the call-site shape instead,
+# which is the same convention as the existing `x25519_dalek.x25519` contract.
+# Verified by exporting a call graph and reading the signatures, not assumed.
+contracts:
+  - method: bellman::groth16.generate_random_parameters
+    arity: 2
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["bellman::Circuit", "&mut rand_core::RngCore"]
+    role: factory
+  - method: bellman::groth16.generate_parameters
+    arity: 8
+    return: { type: core::result::Result, confidence: high }
+    role: factory
+  - method: bellman::groth16.create_random_proof
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["bellman::Circuit", "bellman::groth16::ParameterSource", "&mut rand_core::RngCore"]
+    role: operation
+  - method: bellman::groth16.create_proof
+    arity: 4
+    return: { type: core::result::Result, confidence: high }
+    role: operation
+  - method: bellman::groth16.prepare_verifying_key
+    arity: 1
+    return: { type: bellman::groth16::PreparedVerifyingKey, confidence: high }
+    parameter_types: ["&bellman::groth16::VerifyingKey"]
+    role: factory
+  - method: bellman::groth16.verify_proof
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&bellman::groth16::PreparedVerifyingKey", "&bellman::groth16::Proof", "&[E::Fr]"]
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/groth16.yaml
+++ b/internal/callgraph/contracts/rust/groth16.yaml
@@ -1,0 +1,68 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: groth16
+  coordinates:
+    - groth16
+  version_range: ">=0.1.0,<0.2.0"
+  description: "Groth16 zkSNARK proving system and circuit machinery"
+
+# API read at groth16 0.1.0 (src/generator.rs, prover.rs, verifier.rs).
+#
+# The groth16 crate is the Groth16 proving system extracted from bellman by the
+# same authors. It DEPENDS on bellman for the circuit machinery and re-exposes
+# the identical function names at its own CRATE ROOT rather than under a
+# `groth16` module. So `groth16::verify_proof` and `bellman::groth16::verify_proof`
+# are two different keys naming two different crates, and the resolved call-site
+# keys confirm the parser keeps them apart:
+#
+#   groth16.verify_proof(?, ?, ?)
+#   bellman::groth16.verify_proof(?, ?, ?)
+#
+# The matrix lists exactly one version, 0.1.0, and the range is pinned to it.
+# It depends on bellman 0.14, so it carries the post-0.7.0 shape throughout:
+# `E: MultiMillerLoop` and `verify_proof -> Result<(), VerificationError>`.
+#
+# Arities are identical to bellman's and were read from the declarations, not
+# from prose. skipped-non-crypto is the same as bellman's: ConstraintSystem
+# bookkeeping is how any circuit is expressed and carries no crypto asset.
+#
+# KEY SHAPE: THESE ARE FREE FUNCTIONS, NOT METHODS. The call-site FQN the parser
+# emits is `groth16.generate_random_parameters` -- module path joined
+# with `::`, then a DOT before the function name. The Rust key normalisation
+# only rewrites the separator in front of a receiver TYPE and returns keys with
+# fewer than two dots unchanged, so an authored `groth16::<fn>` never
+# resolves against the emitted key. Authored in the call-site shape instead,
+# which is the same convention as the existing `x25519_dalek.x25519` contract.
+# Verified by exporting a call graph and reading the signatures, not assumed.
+contracts:
+  - method: groth16.generate_random_parameters
+    arity: 2
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["bellman::Circuit", "&mut rand_core::RngCore"]
+    role: factory
+  - method: groth16.generate_parameters
+    arity: 8
+    return: { type: core::result::Result, confidence: high }
+    role: factory
+  - method: groth16.create_random_proof
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["bellman::Circuit", "groth16::ParameterSource", "&mut rand_core::RngCore"]
+    role: operation
+  - method: groth16.create_proof
+    arity: 4
+    return: { type: core::result::Result, confidence: high }
+    role: operation
+  - method: groth16.prepare_verifying_key
+    arity: 1
+    return: { type: groth16::PreparedVerifyingKey, confidence: high }
+    parameter_types: ["&groth16::VerifyingKey"]
+    role: factory
+  - method: groth16.verify_proof
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&groth16::PreparedVerifyingKey", "&groth16::Proof", "&[E::Fr]"]
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_bellman_test.go
+++ b/internal/callgraph/contracts/rust_bellman_test.go
@@ -1,0 +1,166 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// bellman and the groth16 crate are the same proving system by the same
+// authors: bellman exposes it under `bellman::groth16`, groth16 exposes the
+// identical function names at its own crate root. A contract keyed on the wrong
+// one resolves silently and mislabels the crate rather than failing, so assert
+// the exact key, arity, owning library, role and return type for both.
+func TestLoadEmbeddedRustIncludesBellmanContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		lib    string
+		role   string
+		ret    string
+	}{
+		{"bellman::groth16.generate_random_parameters", 2, "bellman", "factory", "core::result::Result"},
+		{"bellman::groth16.generate_parameters", 8, "bellman", "factory", "core::result::Result"},
+		{"bellman::groth16.create_random_proof", 3, "bellman", "operation", "core::result::Result"},
+		{"bellman::groth16.create_proof", 4, "bellman", "operation", "core::result::Result"},
+		{"bellman::groth16.prepare_verifying_key", 1, "bellman", "factory", "bellman::groth16::PreparedVerifyingKey"},
+		{"bellman::groth16.verify_proof", 3, "bellman", "operation", "core::result::Result"},
+
+		{"groth16.generate_random_parameters", 2, "groth16", "factory", "core::result::Result"},
+		{"groth16.create_random_proof", 3, "groth16", "operation", "core::result::Result"},
+		{"groth16.prepare_verifying_key", 1, "groth16", "factory", "groth16::PreparedVerifyingKey"},
+		{"groth16.verify_proof", 3, "groth16", "operation", "core::result::Result"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		c := got[0]
+		if c.SourceLibrary != tc.lib {
+			t.Errorf("%s: library = %q, want %q", tc.method, c.SourceLibrary, tc.lib)
+		}
+		if c.Role != tc.role {
+			t.Errorf("%s: role = %q, want %q", tc.method, c.Role, tc.role)
+		}
+		if c.Return.Type != tc.ret {
+			t.Errorf("%s: return = %q, want %q", tc.method, c.Return.Type, tc.ret)
+		}
+	}
+}
+
+// THE KEY SHAPE IS THE WHOLE POINT OF THIS TEST.
+//
+// These are FREE FUNCTIONS, not methods. The call-site FQN the parser emits is
+// `bellman::groth16.generate_random_parameters` -- module path joined with
+// "::", then a DOT before the function name. The Rust key normalisation only
+// rewrites the separator in front of a receiver TYPE, and returns keys with
+// fewer than two dots unchanged, so a contract authored as
+// `bellman::groth16::generate_random_parameters` never resolves against the key
+// the parser actually produces. That mistake was made first here, and the
+// exported call graph showed `verify_proof(?, ?, ?)` with no parameter types --
+// indistinguishable from having no contract at all.
+func TestBellmanContractsResolveFromEmittedCallSiteKeys(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	// Exactly the keys observed in an exported call graph.
+	tests := []struct {
+		callSiteKey string
+		arity       int
+		wantLib     string
+	}{
+		{"bellman::groth16.generate_random_parameters", 2, "bellman"},
+		{"bellman::groth16.generate_random_parameters", -1, "bellman"},
+		{"bellman::groth16.verify_proof", 3, "bellman"},
+		{"groth16.verify_proof", 3, "groth16"},
+		{"groth16.verify_proof", -1, "groth16"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.callSiteKey, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract for an emitted call-site key", tc.callSiteKey, tc.arity)
+			continue
+		}
+		if got[0].SourceLibrary != tc.wantLib {
+			t.Errorf("%s: library = %q, want %q", tc.callSiteKey, got[0].SourceLibrary, tc.wantLib)
+		}
+	}
+}
+
+// `bellman::groth16` contains the substring `groth16`. Assert the two crates
+// stay distinct at the contract layer, not only in the detection rules: one
+// consumer call site must never be attributable to both.
+func TestBellmanAndGroth16ContractsDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	bellman := kb.ContractsFor("bellman::groth16.verify_proof", 3)
+	groth := kb.ContractsFor("groth16.verify_proof", 3)
+	if len(bellman) == 0 || len(groth) == 0 {
+		t.Fatalf("expected both keys to resolve; bellman=%d groth16=%d", len(bellman), len(groth))
+	}
+	if bellman[0].SourceLibrary == groth[0].SourceLibrary {
+		t.Errorf("both keys resolved to %q: the crates collapsed", bellman[0].SourceLibrary)
+	}
+}
+
+// A contract that resolves but declares no parameter types still exports
+// "verify_proof(?, ?, ?)", which reads exactly like a missing contract.
+func TestBellmanContractsDeclareParameterTypes(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		want   []string
+	}{
+		{"bellman::groth16.generate_random_parameters", 2, []string{"bellman::Circuit", "&mut rand_core::RngCore"}},
+		{"bellman::groth16.verify_proof", 3, []string{"&bellman::groth16::PreparedVerifyingKey", "&bellman::groth16::Proof", "&[E::Fr]"}},
+		{"groth16.verify_proof", 3, []string{"&groth16::PreparedVerifyingKey", "&groth16::Proof", "&[E::Fr]"}},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		pt := got[0].ParameterTypes
+		if len(pt) != len(tc.want) {
+			t.Errorf("%s: parameter_types = %v, want %v", tc.method, pt, tc.want)
+			continue
+		}
+		for i := range pt {
+			if pt[i] != tc.want[i] {
+				t.Errorf("%s: parameter_types[%d] = %q, want %q", tc.method, i, pt[i], tc.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds Rust knowledge-base contracts for `bellman` and the extracted `groth16`
crate, covering the published `0.0.3`-`0.14.0` and `0.1.0` ranges.

## The key shape is the point of this change

These are **free functions, not methods**. The call-site FQN the parser emits is

```
bellman::groth16.generate_random_parameters
```

— module path joined with `::`, then a **dot** before the function name. The Rust
key normalisation only rewrites the separator in front of a receiver *type*, and
returns keys with fewer than two dots unchanged, so a contract authored as
`bellman::groth16::generate_random_parameters` never resolves against the key
the parser actually produces.

That mistake was made here first. The contracts loaded, the unit lookups passed
on the authored spelling, and the exported call graph still showed
`verify_proof(?, ?, ?)` with no parameter types — indistinguishable from having
no contract at all. It was caught by exporting a call graph and reading the
signatures rather than trusting the file. Authored in the call-site shape now,
the same convention as the existing `x25519_dalek.x25519` contract:

```
bellman::groth16.verify_proof(&bellman::groth16::PreparedVerifyingKey, &bellman::groth16::Proof, &[E::Fr])
groth16.verify_proof(&groth16::PreparedVerifyingKey, &groth16::Proof, &[E::Fr])
```

## Two crates that must not collapse

`bellman` exposes Groth16 under a `groth16` module; the `groth16` crate exposes
the identical function names at its own crate root and depends on bellman. The
two are kept as separate keys, and a test asserts they resolve to different
libraries — one consumer call site must never be attributable to both.

## Arities were read from the declarations

A first pass counted them with a regex over the parameter lines and got
`create_random_proof` wrong, because from 0.9.0 its third parameter is spelled
`mut rng: &mut R` and a `^\s+[a-z_]+:` pattern skips it. Read from the
signatures instead: setup 2, explicit-setup 8, prove 3, create_proof 4,
prepare_verifying_key 1, verify 3 — stable across the whole range.

## Version range

`bellman` starts at **0.0.3**, not at the matrix's oldest row. `0.0.1` carries no
library at all — its archive has only `main.rs` and no `groth16` module — so
nothing here can resolve against it, and saying so is more useful than a range
implying coverage it cannot have. The early history is not monotonic either:
`0.0.7` has a `lib.rs` but no `groth16` module.

The one API change is `0.6.0` → `0.7.0`, and it is in the types rather than the
call shape: `E: Engine` becomes `E: MultiMillerLoop`, and `verify_proof` returns
`Result<(), VerificationError>` instead of `Result<bool, SynthesisError>`
(`src/groth16/verifier.rs`). Arities are unchanged, so one set of contracts
covers the range; the schema's `when` condition matches argument values rather
than versions, so the pre-0.7.0 return type is recorded in a comment instead of
being silently wrong for one half of the range.

## What is deliberately absent

`ConstraintSystem::alloc`, `alloc_input`, `enforce`, `namespace` and
`LinearCombination`. That is how any circuit is expressed, cryptographic or not,
and contracting it would pull every consumer that builds a circuit into the
crypto call graph.

## Tests

Full suite green (31 packages, 0 failures), `make lint` reports 0 issues at the
pinned golangci-lint version. Additive only: zero deletions.