### PR TITLE
feat(callgraph): add aws-lc contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/aws-lc-rs.yaml
+++ b/internal/callgraph/contracts/rust/aws-lc-rs.yaml
@@ -1,0 +1,80 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: aws-lc-rs
+  coordinates:
+    - aws-lc-rs
+    - aws_lc_rs
+  version_range: ">=1.0.0,<1.18.0"
+  description: "Safe AWS-LC bindings with a ring-compatible API"
+
+# API read at aws-lc-rs 1.17.1 (src/digest.rs, src/hmac.rs, src/aead.rs,
+# src/aead/unbound_key.rs) and cross-checked at 1.0.0, 1.8.1 and 1.12.6.
+#
+# VERSION RANGE STARTS AT 1.0.0, NOT AT THE MATRIX'S OLDEST ROW. The matrix
+# lists 0.0.1, which is a placeholder release predating the API entirely.
+#
+# KEY SHAPES DIFFER BY CALLABLE KIND, and both are authored as the parser emits
+# them -- read off an exported call graph, not assumed:
+#   free function in a module   aws_lc_rs.digest.digest       -> two dots, so the
+#                               normalisation rewrites the separator in front of
+#                               the receiver: authored `aws_lc_rs::digest.digest`
+#   method on a type            aws_lc_rs::aead.UnboundKey.new -> authored
+#                               `aws_lc_rs::aead::UnboundKey.new`
+#
+# ARITIES READ FROM THE DECLARATIONS (self excluded):
+#   digest::digest(algorithm, data)                    -> 2  (digest.rs:194)
+#   hmac::sign(key, data)                              -> 2  (hmac.rs:488)
+#   hmac::verify(key, data, tag)                       -> 3  (hmac.rs:545)
+#   UnboundKey::new(algorithm, key_bytes)              -> 2  (aead/unbound_key.rs:46)
+#   LessSafeKey::new(key)                              -> 1  (aead.rs:710)
+#   LessSafeKey::seal_in_place_append_tag(&mut self, aad, in_out) -> 2 (aead.rs:467)
+#
+# NOTE ON THE SIBLING SYS CRATE. aws-lc-rs reaches raw AWS-LC through a
+# CRATE-LEVEL alias declared in lib.rs -- `extern crate aws_lc_sys as aws_lc;` --
+# with the call sites in aead.rs, digest.rs and friends. Nothing here contracts
+# that alias, and that is deliberate: the same lib.rs also carries
+# `#[cfg(feature = "fips")] extern crate aws_lc_fips_sys as aws_lc;`, so the
+# alias resolves to a different crate depending on a cargo feature. Contracting
+# it would attribute aws-lc-fips-sys call sites to aws-lc-sys. Keeping the safe
+# API here and the raw FFI in aws-lc-sys.yaml is also what stops a single
+# consumer call from being counted against both crates.
+#
+# skipped-non-crypto: Nonce/Aad/Tag wrappers, the error types, encoding
+#   helpers, and the ring-compatibility re-export shims.
+contracts:
+  - method: aws_lc_rs::digest.digest
+    arity: 2
+    return: { type: aws_lc_rs::digest::Digest, confidence: high }
+    parameter_types: ["&'static aws_lc_rs::digest::Algorithm", "&[u8]"]
+    role: operation
+  - method: aws_lc_rs::hmac.sign
+    arity: 2
+    return: { type: aws_lc_rs::hmac::Tag, confidence: high }
+    parameter_types: ["&aws_lc_rs::hmac::Key", "&[u8]"]
+    role: operation
+  - method: aws_lc_rs::hmac.verify
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&aws_lc_rs::hmac::Key", "&[u8]", "&[u8]"]
+    role: operation
+  - method: aws_lc_rs::aead::UnboundKey.new
+    arity: 2
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&'static aws_lc_rs::aead::Algorithm", "&[u8]"]
+    role: factory
+  - method: aws_lc_rs::aead::LessSafeKey.new
+    arity: 1
+    return: { type: aws_lc_rs::aead::LessSafeKey, confidence: high }
+    parameter_types: ["aws_lc_rs::aead::UnboundKey"]
+    role: factory
+  - method: aws_lc_rs::aead::LessSafeKey.seal_in_place_append_tag
+    arity: 2
+    return: { type: core::result::Result, confidence: high }
+    role: operation
+  - method: aws_lc_rs::aead::LessSafeKey.open_in_place
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/aws-lc-sys.yaml
+++ b/internal/callgraph/contracts/rust/aws-lc-sys.yaml
@@ -1,0 +1,94 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: aws-lc-sys
+  coordinates:
+    - aws-lc-sys
+    - aws_lc_sys
+  version_range: ">=0.1.0,<0.43.0"
+  description: "Raw AWS-LC FFI bindings (BoringSSL fork)"
+
+# API read at aws-lc-sys 0.42.0 (src/universal_crypto.rs) and cross-checked at
+# 0.1.0 (src/bindings.rs), where every symbol contracted here is already
+# present. The archive layout changes across the range -- 0.1.0 ships a single
+# bindings.rs, 0.14.0 onward ships one file per target triple plus a build-time
+# `include!` of OUT_DIR/bindings.rs -- but the consumer-facing symbol names and
+# signatures do not, so one set of contracts covers 0.1.0 through 0.42.0.
+#
+# KEY SHAPE: these are FREE FUNCTIONS at the crate root, so the call-site FQN the
+# parser emits is `aws_lc_sys.EVP_sha256` -- crate, then a DOT, then the
+# function, with only ONE dot in the whole key. The Rust key normalisation
+# returns keys carrying fewer than two dots unchanged, so these are authored in
+# exactly that shape. Verified by exporting a call graph and reading the emitted
+# signatures rather than assuming; the same reading is pinned by a test.
+#
+# ARITIES READ FROM THE BINDGEN DECLARATIONS, NOT FROM PROSE:
+#   EVP_aead_*()                                              -> 0
+#   EVP_sha*()                                                -> 0
+#   HMAC(evp_md, key, key_len, data, data_len, out, out_len)  -> 7
+#   ECDSA_do_sign(digest, digest_len, key)                    -> 3
+#   RSA_generate_key_ex(rsa, bits, e, cb)                     -> 4
+#   RSA_sign(hash_nid, digest, digest_len, out, out_len, rsa) -> 6
+#
+# The return types are the raw C pointer types the bindings declare. They are
+# recorded as written rather than mapped to a friendlier Rust type, because that
+# is what a consumer's variable actually holds at these call sites.
+#
+# skipped-non-crypto: the ~679 C/H sources in the archive, the per-target
+#   `extern "C"` declaration blocks themselves (declarations, not call sites),
+#   and the BIO/stack/error-queue plumbing.
+contracts:
+  - method: aws_lc_sys.EVP_aead_aes_256_gcm
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_AEAD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.EVP_aead_aes_128_gcm
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_AEAD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.EVP_aead_chacha20_poly1305
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_AEAD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.EVP_sha256
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_MD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.EVP_sha384
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_MD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.EVP_sha512
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_MD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.EVP_sha1
+    arity: 0
+    return: { type: "*const aws_lc_sys::EVP_MD", confidence: high }
+    role: factory
+  - method: aws_lc_sys.HMAC
+    arity: 7
+    return: { type: "*mut u8", confidence: high }
+    parameter_types: ["*const aws_lc_sys::EVP_MD", "*const core::ffi::c_void", "usize", "*const u8", "usize", "*mut u8", "*mut core::ffi::c_uint"]
+    role: operation
+  - method: aws_lc_sys.ECDSA_do_sign
+    arity: 3
+    return: { type: "*mut aws_lc_sys::ECDSA_SIG", confidence: high }
+    parameter_types: ["*const u8", "usize", "*const aws_lc_sys::EC_KEY"]
+    role: operation
+  - method: aws_lc_sys.ECDSA_do_verify
+    arity: 4
+    return: { type: "core::ffi::c_int", confidence: high }
+    role: operation
+  - method: aws_lc_sys.RSA_generate_key_ex
+    arity: 4
+    return: { type: "core::ffi::c_int", confidence: high }
+    parameter_types: ["*mut aws_lc_sys::RSA", "core::ffi::c_int", "*const aws_lc_sys::BIGNUM", "*mut aws_lc_sys::BN_GENCB"]
+    role: factory
+  - method: aws_lc_sys.RSA_sign
+    arity: 6
+    return: { type: "core::ffi::c_int", confidence: high }
+    parameter_types: ["core::ffi::c_int", "*const u8", "usize", "*mut u8", "*mut core::ffi::c_uint", "*mut aws_lc_sys::RSA"]
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_aws_lc_test.go
+++ b/internal/callgraph/contracts/rust_aws_lc_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// aws-lc-rs is the safe wrapper and aws-lc-sys the raw FFI beneath it. A
+// contract keyed on the wrong one resolves silently and mislabels the crate
+// rather than failing, so assert the exact key, arity, owning library, role and
+// return type for both.
+func TestLoadEmbeddedRustIncludesAwsLcContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		lib    string
+		role   string
+		ret    string
+	}{
+		// Safe API. Free functions in a module, and methods on a type.
+		{"aws_lc_rs::digest.digest", 2, "aws-lc-rs", "operation", "aws_lc_rs::digest::Digest"},
+		{"aws_lc_rs::hmac.sign", 2, "aws-lc-rs", "operation", "aws_lc_rs::hmac::Tag"},
+		{"aws_lc_rs::hmac.verify", 3, "aws-lc-rs", "operation", "core::result::Result"},
+		{"aws_lc_rs::aead::UnboundKey.new", 2, "aws-lc-rs", "factory", "core::result::Result"},
+		{"aws_lc_rs::aead::LessSafeKey.new", 1, "aws-lc-rs", "factory", "aws_lc_rs::aead::LessSafeKey"},
+
+		// Raw FFI. Free functions at the crate root.
+		{"aws_lc_sys.EVP_aead_aes_256_gcm", 0, "aws-lc-sys", "factory", "*const aws_lc_sys::EVP_AEAD"},
+		{"aws_lc_sys.EVP_sha256", 0, "aws-lc-sys", "factory", "*const aws_lc_sys::EVP_MD"},
+		{"aws_lc_sys.HMAC", 7, "aws-lc-sys", "operation", "*mut u8"},
+		{"aws_lc_sys.ECDSA_do_sign", 3, "aws-lc-sys", "operation", "*mut aws_lc_sys::ECDSA_SIG"},
+		{"aws_lc_sys.RSA_generate_key_ex", 4, "aws-lc-sys", "factory", "core::ffi::c_int"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		c := got[0]
+		if c.SourceLibrary != tc.lib {
+			t.Errorf("%s: library = %q, want %q", tc.method, c.SourceLibrary, tc.lib)
+		}
+		if c.Role != tc.role {
+			t.Errorf("%s: role = %q, want %q", tc.method, c.Role, tc.role)
+		}
+		if c.Return.Type != tc.ret {
+			t.Errorf("%s: return = %q, want %q", tc.method, c.Return.Type, tc.ret)
+		}
+	}
+}
+
+// THE KEY SHAPES DIFFER BY CALLABLE KIND and both must resolve from the FQN the
+// parser actually emits. A raw FFI free function at the crate root produces a
+// key with ONE dot (`aws_lc_sys.EVP_sha256`), which the Rust key normalisation
+// returns unchanged; a free function inside a module produces TWO
+// (`aws_lc_rs.digest.digest`), which it rewrites. Authoring either in the wrong
+// shape yields a contract that loads, passes a lookup on the authored spelling,
+// and still exports "(?, ?)" — indistinguishable from having no contract.
+// These are the keys observed in an exported call graph, verbatim.
+func TestAwsLcContractsResolveFromEmittedCallSiteKeys(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		callSiteKey string
+		arity       int
+		wantLib     string
+	}{
+		{"aws_lc_sys.EVP_aead_aes_256_gcm", 0, "aws-lc-sys"},
+		{"aws_lc_sys.EVP_aead_aes_256_gcm", -1, "aws-lc-sys"},
+		{"aws_lc_sys.EVP_sha256", 0, "aws-lc-sys"},
+		{"aws_lc_rs.digest.digest", 2, "aws-lc-rs"},
+		{"aws_lc_rs.digest.digest", -1, "aws-lc-rs"},
+		{"aws_lc_rs.hmac.sign", 2, "aws-lc-rs"},
+		{"aws_lc_rs::aead.UnboundKey.new", 2, "aws-lc-rs"},
+		{"aws_lc_rs::aead.UnboundKey.new", -1, "aws-lc-rs"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.callSiteKey, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract for an emitted call-site key", tc.callSiteKey, tc.arity)
+			continue
+		}
+		if got[0].SourceLibrary != tc.wantLib {
+			t.Errorf("%s: library = %q, want %q", tc.callSiteKey, got[0].SourceLibrary, tc.wantLib)
+		}
+	}
+}
+
+// The safe crate and the sys crate must stay distinct at the contract layer, so
+// one consumer call is never attributable to both. The family plan asks for this
+// explicitly: "prove no duplicate attribution through the sys crate".
+func TestAwsLcSafeAndSysContractsDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	safe := kb.ContractsFor("aws_lc_rs::digest.digest", 2)
+	raw := kb.ContractsFor("aws_lc_sys.EVP_sha256", 0)
+	if len(safe) == 0 || len(raw) == 0 {
+		t.Fatalf("expected both to resolve; safe=%d raw=%d", len(safe), len(raw))
+	}
+	if safe[0].SourceLibrary == raw[0].SourceLibrary {
+		t.Errorf("both resolved to %q: the safe and sys crates collapsed", safe[0].SourceLibrary)
+	}
+
+	// aws-lc-sys is a BoringSSL fork sharing symbol names with boring-sys. The
+	// contract keys are crate-qualified, so they cannot collide — assert it
+	// rather than assume it.
+	boring := kb.ContractsFor("boring_sys.EVP_sha256", 0)
+	if len(boring) > 0 && boring[0].SourceLibrary == raw[0].SourceLibrary {
+		t.Errorf("boring_sys.EVP_sha256 resolved to %q", boring[0].SourceLibrary)
+	}
+}


### PR DESCRIPTION
Adds Rust knowledge-base contracts for the safe `aws-lc-rs` API (7) and the raw
`aws-lc-sys` FFI (12).

## Key shapes differ by callable kind

Both are authored as the parser emits them, read off an exported call graph
rather than assumed:

| callable | emitted key | dots | authored as |
| --- | --- | --- | --- |
| free fn at crate root | `aws_lc_sys.EVP_sha256` | 1 | unchanged — normalisation leaves it alone |
| free fn in a module | `aws_lc_rs.digest.digest` | 2 | `aws_lc_rs::digest.digest` |
| method on a type | `aws_lc_rs::aead.UnboundKey.new` | — | `aws_lc_rs::aead::UnboundKey.new` |

Getting this wrong yields a contract that loads, passes a lookup on the authored
spelling, and still exports `(?, ?)` — indistinguishable from having no contract.
A test asserts resolution from the emitted keys verbatim.

## Arities read from the declarations

`HMAC(evp_md, key, key_len, data, data_len, out, out_len)` → 7;
`ECDSA_do_sign(digest, digest_len, key)` → 3;
`RSA_generate_key_ex(rsa, bits, e, cb)` → 4;
`RSA_sign(...)` → 6; the `EVP_aead_*` and `EVP_sha*` factories → 0.
Safe side: `digest::digest` 2, `hmac::sign` 2, `hmac::verify` 3,
`UnboundKey::new` 2, `LessSafeKey::new` 1.

Return types on the sys side are the raw C pointer types the bindings declare,
recorded as written, because that is what a consumer's variable holds.

## What is deliberately not contracted

The crate-level `extern crate aws_lc_sys as aws_lc;` alias that aws-lc-rs
declares in `lib.rs`. The same file also carries
`#[cfg(feature = "fips")] extern crate aws_lc_fips_sys as aws_lc;`, so the alias
resolves to a different crate depending on a cargo feature; contracting it would
attribute aws-lc-fips-sys call sites to aws-lc-sys. Keeping the safe API and the
raw FFI in separate contracts is also what stops one consumer call from being
counted against both crates — a test asserts they resolve to different libraries.

## Version ranges

`aws-lc-sys` `>=0.1.0,<0.43.0` — the archive layout changes across it (a single
`src/bindings.rs` at 0.1.0, per-target files from 0.14.0) but the symbols and
signatures do not.

`aws-lc-rs` starts at **1.0.0**, not the matrix's oldest row: `0.0.1` is a
placeholder whose archive has only `main.rs`.

## Tests

Full suite green (31 packages, 0 failures), `make lint` 0 issues at the pinned
golangci-lint version. Additive only: zero deletions.