### PR TITLE
feat(callgraph): add gotp contracts for the Go KB (Tier 0 family golang-github-com-xlzd-gotp)

### DIFF
--- a/internal/callgraph/contracts/go/gotp.yaml
+++ b/internal/callgraph/contracts/go/gotp.yaml
@@ -1,0 +1,134 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: gotp
+  coordinates:
+    - "github.com/xlzd/gotp"
+  version_range: ">=0.1.0,<0.2.0"
+  description: "gotp TOTP/HOTP one-time password library"
+
+# Inventory source: github.com/xlzd/gotp v0.1.0 module source from the Go module
+# proxy (otp.go, totp.go, hotp.go, utils.go). The library implements RFC 4226
+# HOTP and RFC 6238 TOTP over crypto/hmac with a caller-supplied hash; a nil
+# hasher resolves to HMAC-SHA1 in NewOTP. The HMAC primitive itself is covered
+# by stdlib-crypto.yaml, so only gotp-level identities are declared here.
+#
+# Dispositions for the remaining public surface:
+# - Hasher is a plain struct built as a composite literal; non-callable, omitted.
+# - Itob is an integer-serialization helper with no crypto semantics
+#   (skipped-non-crypto).
+# - IsSecretValid is a base32 format check on the secret string; it neither
+#   creates, configures, operates on, nor extracts a crypto object
+#   (skipped-non-crypto).
+# - NowWithExpiration returns (code string, expiration int64); the crypto value
+#   is the first result, so the contract declares string.
+contracts:
+  # Constructors. NewOTP returns the embedded base by value; the TOTP/HOTP
+  # constructors return pointers. digits sizes the emitted code and the hasher
+  # value selects the HMAC hash (nil selects SHA-1).
+  - method: github.com/xlzd/gotp.NewOTP
+    arity: 3
+    return: { type: github.com/xlzd/gotp.OTP, confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 1, name: digits, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+      - { index: 2, name: hasher, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/xlzd/gotp.NewTOTP
+    arity: 4
+    return: { type: "*github.com/xlzd/gotp.TOTP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 1, name: digits, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+      - { index: 2, name: interval, role: metadata-contributing, contributes: { property: interval, derivation: argument_value } }
+      - { index: 3, name: hasher, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/xlzd/gotp.NewDefaultTOTP
+    arity: 1
+    return: { type: "*github.com/xlzd/gotp.TOTP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/xlzd/gotp.NewHOTP
+    arity: 3
+    return: { type: "*github.com/xlzd/gotp.HOTP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 1, name: digits, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+      - { index: 2, name: hasher, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/xlzd/gotp.NewDefaultHOTP
+    arity: 1
+    return: { type: "*github.com/xlzd/gotp.HOTP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+
+  # Code generation and verification. These run the HMAC truncation defined by
+  # RFC 4226 section 5.3 over the configured secret.
+  - method: github.com/xlzd/gotp.(*TOTP).At
+    arity: 1
+    return: { type: string, confidence: high }
+    role: operation
+  - method: github.com/xlzd/gotp.(*TOTP).AtTime
+    arity: 1
+    return: { type: string, confidence: high }
+    role: operation
+  - method: github.com/xlzd/gotp.(*TOTP).Now
+    arity: 0
+    return: { type: string, confidence: high }
+    role: operation
+  - method: github.com/xlzd/gotp.(*TOTP).NowWithExpiration
+    arity: 0
+    return: { type: string, confidence: high }
+    role: operation
+  - method: github.com/xlzd/gotp.(*TOTP).Verify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: otp, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/xlzd/gotp.(*TOTP).VerifyTime
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: otp, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/xlzd/gotp.(*HOTP).At
+    arity: 1
+    return: { type: string, confidence: high }
+    role: operation
+  - method: github.com/xlzd/gotp.(*HOTP).Verify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: otp, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+
+  # Secret material. RandomSecret draws from math/rand seeded with the current
+  # time in v0.1.0; the weak source is a library property recorded here only as
+  # provenance for the factory role, not as a finding.
+  - method: github.com/xlzd/gotp.RandomSecret
+    arity: 1
+    return: { type: string, confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: length, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+
+  # Enrollment URIs embed the base32 secret in otpauth:// form.
+  - method: github.com/xlzd/gotp.(*TOTP).ProvisioningUri
+    arity: 2
+    return: { type: string, confidence: high }
+    role: output
+  - method: github.com/xlzd/gotp.(*HOTP).ProvisioningUri
+    arity: 3
+    return: { type: string, confidence: high }
+    role: output
+  - method: github.com/xlzd/gotp.BuildUri
+    arity: 8
+    return: { type: string, confidence: high }
+    role: output
+    parameters:
+      - { index: 4, name: algorithm, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_gotp_test.go
+++ b/internal/callgraph/contracts/go_gotp_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGotpContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{"github.com/xlzd/gotp.NewTOTP", "factory", "*github.com/xlzd/gotp.TOTP", "keyMaterial", 4},
+		{"github.com/xlzd/gotp.NewDefaultTOTP", "factory", "*github.com/xlzd/gotp.TOTP", "keyMaterial", 1},
+		{"github.com/xlzd/gotp.NewHOTP", "factory", "*github.com/xlzd/gotp.HOTP", "keyMaterial", 3},
+		{"github.com/xlzd/gotp.NewDefaultHOTP", "factory", "*github.com/xlzd/gotp.HOTP", "keyMaterial", 1},
+		{"github.com/xlzd/gotp.(*TOTP).Now", "operation", "string", "", 0},
+		{"github.com/xlzd/gotp.(*TOTP).Verify", "operation", "bool", "input", 2},
+		{"github.com/xlzd/gotp.(*HOTP).At", "operation", "string", "", 1},
+		{"github.com/xlzd/gotp.(*TOTP).ProvisioningUri", "output", "string", "", 2},
+		{"github.com/xlzd/gotp.(*HOTP).ProvisioningUri", "output", "string", "", 3},
+		{"github.com/xlzd/gotp.BuildUri", "output", "string", "algorithm", 8},
+		{"github.com/xlzd/gotp.RandomSecret", "factory", "string", "outputLength", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "gotp" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want gotp %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-github-com-xlzd-gotp` (tracker: scanoss/crypto-mining-service#232). Finder-contract phase. Depends on scanoss/crypto_rules#246 for the family rules; the YAML itself is dormant data and safe to merge in either order.

## What

`internal/callgraph/contracts/go/gotp.yaml` — 18 contracts for `github.com/xlzd/gotp` (schema v2, `version_range: ">=0.1.0,<0.2.0"`), inventoried from the v0.1.0 module source (otp.go, totp.go, hotp.go, utils.go):

- **factory**: `NewOTP`, `NewTOTP`, `NewDefaultTOTP`, `NewHOTP`, `NewDefaultHOTP`, `RandomSecret` — with parameter roles for secret material (`keyMaterial`), `digits` (`outputLength`), TOTP `interval`, and the hasher argument (`algorithm`; nil resolves to HMAC-SHA1 in `NewOTP`).
- **operation**: `(*TOTP).At/AtTime/Now/NowWithExpiration/Verify/VerifyTime`, `(*HOTP).At/Verify` — RFC 4226 §5.3 HMAC truncation over the configured secret; `Verify*` tag the compared code as `input`.
- **output**: `(*TOTP).ProvisioningUri`, `(*HOTP).ProvisioningUri`, `BuildUri` (otpauth:// URIs embedding the base32 secret; `BuildUri` tags its `algorithm` argument).

Full-surface dispositions are recorded in the file header: `Hasher` is a composite-literal struct (non-callable), `Itob` and `IsSecretValid` are non-crypto helpers, and `NowWithExpiration` declares its first result (`string`) per the stdlib-crypto convention. The HMAC primitive itself stays with `stdlib-crypto.yaml`.

## Tests

- `internal/callgraph/contracts/go_gotp_test.go` — embedded-KB load + 11 entry assertions (method, arity, role, return type, parameter contributions).
- `go test ./...` green; `make lint` 0 issues.
- Real-target validation: a small gotp consumer scanned with the family rules attributes all direct call sites to `pkg:golang/github.com/xlzd/gotp` (evidence on the tracker issue).

Part of the family PR set: rules (scanoss/crypto_rules#246) → this → tracker (scanoss/crypto-mining-service, closes #232 there).