### PR TITLE
feat(callgraph): pquerna/otp Go KB contracts + nested go.mod re-rooting (Tier 0)

### DIFF
--- a/internal/callgraph/builder.go
+++ b/internal/callgraph/builder.go
@@ -255,6 +255,26 @@ type parseDirWork struct {
 	importPath string
 }
 
+// NestedModuleNamer lets a parser re-root the import path when traversal
+// enters a directory that declares its own module. Mining workspaces unpack a
+// module one or more directories below the scan root (<workspace>/<host>/
+// <path>@<version>/go.mod), so without this the subtree is named after the
+// workspace directory and every cross-package call inside the module resolves
+// to the declared import path instead — leaving the two halves unmatchable in
+// the exported graph.
+type NestedModuleNamer interface {
+	NestedModulePath(dir string) string
+}
+
+func (b *Builder) subImportPath(subDir, parentPath, dirName string) string {
+	if namer, ok := b.parser.(NestedModuleNamer); ok {
+		if modulePath := namer.NestedModulePath(subDir); modulePath != "" {
+			return modulePath
+		}
+	}
+	return b.parser.SubPackagePath(parentPath, dirName)
+}
+
 // collectParseDirs reproduces analyzeDir's pre-order traversal (directory
 // first, then its subdirectories in os.ReadDir order) without parsing, so
 // analyzePackageParallel can merge parse results in exactly the order the
@@ -298,7 +318,7 @@ func (b *Builder) collectParseDirs(dir, importPath string) []parseDirWork {
 		if b.skipWalkDirectory(subDir, name) {
 			continue
 		}
-		subImportPath := b.parser.SubPackagePath(importPath, name)
+		subImportPath := b.subImportPath(subDir, importPath, name)
 		work = append(work, b.collectParseDirs(subDir, subImportPath)...)
 	}
 	return work
@@ -588,7 +608,7 @@ func (b *Builder) analyzeSubdirs(dir, importPath string, graph *CallGraph, proje
 		if b.skipWalkDirectory(subDir, name) {
 			continue
 		}
-		subImportPath := b.parser.SubPackagePath(importPath, name)
+		subImportPath := b.subImportPath(subDir, importPath, name)
 		if err := b.analyzeDir(subDir, subImportPath, graph, projectLocal); err != nil {
 			log.Debug().Err(err).Str("dir", subDir).Msg("Failed to analyze subdirectory")
 		}

--- a/internal/callgraph/contracts/go/pquerna-otp.yaml
+++ b/internal/callgraph/contracts/go/pquerna-otp.yaml
@@ -1,0 +1,143 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: pquerna-otp
+  coordinates:
+    - "github.com/pquerna/otp"
+  version_range: ">=1.0.0,<2.0.0"
+  description: "pquerna/otp HOTP/TOTP one-time password library"
+
+# Inventory source: github.com/pquerna/otp v1.0.0 through v1.5.0 module sources
+# from the Go module proxy (otp.go, hotp/hotp.go, totp/totp.go). The library
+# implements RFC 4226 HOTP and RFC 6238 TOTP over crypto/hmac; the Algorithm
+# zero value is SHA-1. The HMAC primitive is covered by stdlib-crypto.yaml.
+#
+# Version notes (declaring later-added methods across the whole range is safe;
+# a call that does not exist in an older release cannot appear at a call site
+# compiled against it): Key.URL is v1.1.0+, Key.Period v1.3.0+, Key.Digits and
+# Key.Algorithm v1.4.0+, Key.Encoder v1.5.0+.
+#
+# Dispositions for the remaining public surface:
+# - Key.Type/Issuer/AccountName return enrollment labels, not crypto material
+#   (skipped-non-crypto). Digits.Format/Length/String are passcode formatting
+#   helpers (skipped-non-crypto). Algorithm.String is a label (skipped-non-crypto).
+# - Algorithm.Hash returns a concrete hash.Hash selected by the receiver VALUE,
+#   which a static contract cannot condition on (skipped-unsupported).
+# - ValidateOpts/GenerateOpts/Key are structs reached via composite literals or
+#   constructors; non-callable fields are omitted.
+contracts:
+  # Root package: enrollment-key parsing and material extraction.
+  - method: github.com/pquerna/otp.NewKeyFromURL
+    arity: 1
+    return: { type: "*github.com/pquerna/otp.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: orig, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/pquerna/otp.(*Key).Secret
+    arity: 0
+    return: { type: string, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).URL
+    arity: 0
+    return: { type: string, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).String
+    arity: 0
+    return: { type: string, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).Image
+    arity: 2
+    return: { type: image.Image, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).Period
+    arity: 0
+    return: { type: uint64, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).Digits
+    arity: 0
+    return: { type: github.com/pquerna/otp.Digits, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).Algorithm
+    arity: 0
+    return: { type: github.com/pquerna/otp.Algorithm, confidence: high }
+    role: output
+  - method: github.com/pquerna/otp.(*Key).Encoder
+    arity: 0
+    return: { type: github.com/pquerna/otp.Encoder, confidence: high }
+    role: output
+
+  # TOTP (RFC 6238). GenerateCode/Validate carry the Google-Authenticator
+  # defaults (Period 30, Skew 1, DigitsSix, AlgorithmSHA1); the Custom
+  # variants take ValidateOpts.
+  - method: github.com/pquerna/otp/totp.GenerateCode
+    arity: 2
+    return: { type: string, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/pquerna/otp/totp.GenerateCodeCustom
+    arity: 3
+    return: { type: string, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 2, name: opts, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: github.com/pquerna/otp/totp.Validate
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: passcode, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+      - { index: 1, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/pquerna/otp/totp.ValidateCustom
+    arity: 4
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: passcode, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+      - { index: 1, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 3, name: opts, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: github.com/pquerna/otp/totp.Generate
+    arity: 1
+    return: { type: "*github.com/pquerna/otp.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: opts, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+
+  # HOTP (RFC 4226). GenerateCode/Validate default to DigitsSix + SHA-1.
+  - method: github.com/pquerna/otp/hotp.GenerateCode
+    arity: 2
+    return: { type: string, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/pquerna/otp/hotp.GenerateCodeCustom
+    arity: 3
+    return: { type: string, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 2, name: opts, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: github.com/pquerna/otp/hotp.Validate
+    arity: 3
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: passcode, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+      - { index: 2, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/pquerna/otp/hotp.ValidateCustom
+    arity: 4
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: passcode, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+      - { index: 2, name: secret, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 3, name: opts, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: github.com/pquerna/otp/hotp.Generate
+    arity: 1
+    return: { type: "*github.com/pquerna/otp.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: opts, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_pquerna_otp_test.go
+++ b/internal/callgraph/contracts/go_pquerna_otp_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesPquernaOTPContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{"github.com/pquerna/otp.NewKeyFromURL", "factory", "*github.com/pquerna/otp.Key", "keyMaterial", 1},
+		{"github.com/pquerna/otp.(*Key).Secret", "output", "string", "", 0},
+		{"github.com/pquerna/otp.(*Key).URL", "output", "string", "", 0},
+		{"github.com/pquerna/otp.(*Key).Image", "output", "image.Image", "", 2},
+		{"github.com/pquerna/otp/totp.GenerateCode", "operation", "string", "keyMaterial", 2},
+		{"github.com/pquerna/otp/totp.ValidateCustom", "operation", "bool", "options", 4},
+		{"github.com/pquerna/otp/totp.Generate", "factory", "*github.com/pquerna/otp.Key", "options", 1},
+		{"github.com/pquerna/otp/hotp.Validate", "operation", "bool", "input", 3},
+		{"github.com/pquerna/otp/hotp.GenerateCodeCustom", "operation", "string", "keyMaterial", 3},
+		{"github.com/pquerna/otp/hotp.Generate", "factory", "*github.com/pquerna/otp.Key", "options", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "pquerna-otp" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want pquerna-otp %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}

--- a/internal/callgraph/go_nested_module_test.go
+++ b/internal/callgraph/go_nested_module_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A mining workspace unpacks a module proxy zip one or more directories below
+// the scan root (<workspace>/<host>/<path>@<version>/go.mod). The subtree must
+// be named by the declared module path so that cross-package calls inside the
+// module — which resolve to the declared import path — land on functions the
+// graph actually contains.
+func TestGoBuilder_NestedModuleReRootsImportPath(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "example.com", "otplib@v1.0.0")
+	subPkgDir := filepath.Join(moduleDir, "totp")
+	if err := os.MkdirAll(subPkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		filepath.Join(moduleDir, "go.mod"): "module example.com/otplib\n\ngo 1.21\n",
+		filepath.Join(moduleDir, "otp.go"): `package otplib
+
+func NewKey(secret string) string { return secret }
+`,
+		filepath.Join(subPkgDir, "totp.go"): `package totp
+
+import "example.com/otplib"
+
+func Generate(secret string) string {
+	return otplib.NewKey(secret)
+}
+`,
+	}
+	for path, content := range files {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	graph, err := NewBuilder(NewGoParser()).BuildFromDirectories([]PackageDir{{
+		Dir:        root,
+		ImportPath: "pkg_golang_example.com_otplib-v1.0.0-12345",
+	}}, nil)
+	if err != nil {
+		t.Fatalf("BuildFromDirectories: %v", err)
+	}
+
+	var newKey, generate string
+	for id := range graph.Functions {
+		switch {
+		case strings.HasSuffix(id, "otplib.NewKey"):
+			newKey = id
+		case strings.HasSuffix(id, "totp.Generate"):
+			generate = id
+		}
+	}
+	if !strings.HasPrefix(newKey, "example.com/otplib.") {
+		t.Fatalf("NewKey id = %q, want rooted at the declared module path", newKey)
+	}
+	if !strings.HasPrefix(generate, "example.com/otplib/totp.") {
+		t.Fatalf("Generate id = %q, want rooted below the declared module path", generate)
+	}
+
+	callers := graph.Callers[newKey]
+	found := false
+	for _, caller := range callers {
+		if caller == generate {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cross-package call totp.Generate -> otplib.NewKey missing: Callers[%q] = %v", newKey, callers)
+	}
+}

--- a/internal/callgraph/go_parser.go
+++ b/internal/callgraph/go_parser.go
@@ -1,6 +1,7 @@
 package callgraph
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -140,6 +141,34 @@ func (p *GoParser) SkipsDirNamed(name string) bool {
 // SubPackagePath constructs a child import path by appending the dir name with "/".
 func (p *GoParser) SubPackagePath(parentPath, dirName string) string {
 	return parentPath + "/" + dirName
+}
+
+// NestedModulePath implements NestedModuleNamer: when dir carries its own
+// go.mod, the subtree is that module and its packages must be named by the
+// declared module path, not by the directory chain from the scan root. This
+// is how an unpacked module proxy zip (<workspace>/<host>/<path>@<version>/)
+// gets github.com/owner/repo identities that its own cross-package call sites
+// resolve to.
+func (p *GoParser) NestedModulePath(dir string) string {
+	file, err := os.Open(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			log.Debug().Err(closeErr).Msg("Failed to close go.mod")
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		}
+	}
+
+	return ""
 }
 
 // PackageSeparator returns "/" — Go uses forward slashes in import paths.


### PR DESCRIPTION
Tier 0 family `golang-github-com-pquerna-otp` (tracker: scanoss/crypto-mining-service#225). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/pquerna-otp.yaml`

20 schema-v2 contracts for `github.com/pquerna/otp` v1.0.0–v1.5.0, inventoried from all six module sources:

- **factory**: `NewKeyFromURL`, `totp.Generate`, `hotp.Generate` (option-struct parameter roles).
- **operation**: totp/hotp `GenerateCode`, `GenerateCodeCustom`, `Validate`, `ValidateCustom` with parameter roles for secrets (`keyMaterial`), passcodes (`input`), and option structs (`options`).
- **output**: `(*Key).Secret/URL/String/Image/Period/Digits/Algorithm/Encoder` (per-version availability noted in the header; declaring later-added methods across the range is safe).
- Dispositions for the rest of the surface in the file header — including `Algorithm.Hash`, whose concrete return is selected by the receiver **value** and is therefore not statically contractable.
- Embedded-KB test asserts 10 representative entries.

## 2. `fix(callgraph): re-root Go identities at a nested go.mod`

Surfaced by this family's E2E gate. A mining workspace unpacks a module proxy zip below the scan root (`<workspace>/<host>/<path>@<version>/go.mod`), so package identities were named after the workspace directory while the module's own cross-package call sites resolved to the declared import path — the halves never matched, every intra-module cross-package call was stored as **external**, and Forward Expand emitted no edges for any multi-package Go module (gotp, the previous family, is single-package and masked this).

The builder now asks the parser (new optional `NestedModuleNamer` interface, implemented only by `GoParser`) to re-root the import path when traversal enters a directory that declares its own module. Consumer scans with go.mod at the scan root are unchanged. Unit test builds the mining-workspace layout and asserts module-path-rooted identities plus a resolved cross-package edge.

Measured on the family stack (same rules, same mines): stored fragment internal edges went 7 → 16/19 across pquerna/otp v1.0.0–v1.5.0, and the tier0 stitch integration test went from "Forward Expand emitted no edges" to PASS with forward_edges=5–7 per version.

## Checks

`go test ./...` green, `make lint` 0 issues.

Family PR set: scanoss/crypto_rules#247 → this → scanoss/crypto-mining-service (closes #225 there).