### PR TITLE
feat(callgraph): add x509-parser contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/x509-parser.yaml
+++ b/internal/callgraph/contracts/rust/x509-parser.yaml
@@ -1,0 +1,75 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: x509-parser
+  coordinates:
+    - x509-parser
+    - x509_parser
+  version_range: ">=0.6.5,<0.19.0"
+  description: "X.509 certificate, CSR and CRL parser"
+
+# API read at x509-parser 0.18.1 (src/lib.rs, src/certificate.rs,
+# src/revocation_list.rs, src/pem.rs) and cross-checked at 0.6.5, 0.9.2 and
+# 0.13.2.
+#
+# WHY A CONTRACT EXISTS HERE AT ALL. The family row carried finder n/a /
+# not_applicable while the matrix reported contract_gap=Y. Settled against an
+# exported call graph rather than by precedence: a consumer calling
+# parse_x509_certificate produced `x509_parser.parse_x509_certificate(?)` with
+# empty parameter_types, which is what an absent contract looks like. The matrix
+# is right and the tracker row was wrong; it is corrected in this family's PR.
+#
+# KEY SHAPE: these are FREE FUNCTIONS at the crate root, so the emitted
+# call-site FQN carries ONE dot and the Rust key normalisation returns it
+# unchanged. Authored in exactly that shape, read off the exported graph rather
+# than assumed. `parse_x509_pem` lives in the `pem` module and is authored with
+# the module segment.
+#
+# VERSION RANGE STARTS AT 0.6.5, NOT AT THE MATRIX'S OLDEST ROW. 0.1.0 has no
+# top-level certificate parse at all -- its public surface is
+# parse_tbs_certificate, parse_algorithm_identifier, parse_signature_value and
+# parse_version, low-level DER pieces. Nothing here can resolve against it.
+# 0.6.5 introduces parse_x509_der and parse_crl_der; 0.9.2 adds
+# parse_x509_certificate, parse_x509_crl and parse_x509_pem and keeps the older
+# names, so both eras are contracted.
+#
+# ARITIES READ FROM THE DECLARATIONS: every parse entry point takes exactly one
+# argument, the input byte slice.
+#
+# skipped-non-crypto: the nom combinators, the extension and OID registries,
+#   the Display/Debug impls, and the ASN.1 plumbing.
+#
+# DELIBERATELY ABSENT: verify_signature. It exists on X509Certificate,
+# CertificationRequest and CertificateRevocationList from 0.9.2, but it is gated
+# behind a non-default feature (`default = []`, `verify = ["ring"]`,
+# `verify-aws = ["aws-lc-rs"]`) and the cryptography is performed by ring or
+# aws-lc-rs, which carry their own contracts. Typing it here would route another
+# crate's work through this one.
+contracts:
+  - method: x509_parser.parse_x509_certificate
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: x509_parser.parse_x509_der
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: x509_parser.parse_x509_crl
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: x509_parser.parse_crl_der
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: x509_parser::pem.parse_x509_pem
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_x509_parser_test.go
+++ b/internal/callgraph/contracts/rust_x509_parser_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// x509-parser's parse entry points are free functions at the crate root, so the
+// emitted call-site FQN carries ONE dot and the Rust key normalisation returns
+// it unchanged. These are the keys observed in an exported call graph, verbatim:
+// authoring them in the method shape (`x509_parser::parse_x509_certificate`)
+// would load fine, pass a lookup on the authored spelling, and still export
+// "parse_x509_certificate(?)" -- indistinguishable from having no contract.
+func TestLoadEmbeddedRustIncludesX509ParserContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+	}{
+		// 0.9.2 and later.
+		{"x509_parser.parse_x509_certificate", 1},
+		{"x509_parser.parse_x509_crl", 1},
+		{"x509_parser::pem.parse_x509_pem", 1},
+		// 0.6.5-era names, kept as aliases of the same functions.
+		{"x509_parser.parse_x509_der", 1},
+		{"x509_parser.parse_crl_der", 1},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		c := got[0]
+		if c.SourceLibrary != "x509-parser" {
+			t.Errorf("%s: library = %q, want x509-parser", tc.method, c.SourceLibrary)
+		}
+		if c.Role != "factory" {
+			t.Errorf("%s: role = %q, want factory", tc.method, c.Role)
+		}
+		if len(c.ParameterTypes) != 1 || c.ParameterTypes[0] != "&[u8]" {
+			t.Errorf("%s: parameter_types = %v, want [\"&[u8]\"]", tc.method, c.ParameterTypes)
+		}
+	}
+
+	// Resolution must also work when the caller cannot derive an arity.
+	if got := kb.ContractsFor("x509_parser.parse_x509_certificate", -1); len(got) == 0 {
+		t.Error("ContractsFor(parse_x509_certificate, -1): no contract at unknown arity")
+	}
+}
+
+// verify_signature is deliberately NOT contracted. It is gated behind a
+// non-default feature (`verify = ["ring"]`, `verify-aws = ["aws-lc-rs"]`) and
+// the cryptography is performed by ring or aws-lc-rs, which carry their own
+// contracts. Typing it here would route another crate's work through this one.
+func TestX509ParserDoesNotContractVerification(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, m := range []string{
+		"x509_parser.verify_signature",
+		"x509_parser::certificate::X509Certificate.verify_signature",
+		"x509_parser::revocation_list::CertificateRevocationList.verify_signature",
+	} {
+		for _, a := range []int{0, 1, -1} {
+			if got := kb.ContractsFor(m, a); len(got) > 0 {
+				t.Errorf("ContractsFor(%q, %d) resolved to %q: verification belongs to ring/aws-lc-rs",
+					m, a, got[0].SourceLibrary)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds five Rust knowledge-base contracts for `x509-parser`'s parse entry points.

## Why a contract exists here at all

The family row carried `finder: n/a / not_applicable` while the matrix reported
`contract_gap=Y`. Settled against an exported call graph rather than by
precedence — a consumer calling `parse_x509_certificate` produced

```
x509_parser.parse_x509_certificate(?)   parameter_types = [""]
```

which is what an absent contract looks like. The matrix is right; the tracker row
is corrected in this family's tracker PR. With the contracts loaded the same scan
exports `x509_parser.parse_x509_certificate(&[u8])`.

## Key shape

These are **free functions at the crate root**, so the emitted call-site FQN
carries **one dot** and the Rust key normalisation returns it unchanged. Authored
in exactly that shape, read off the exported graph rather than assumed.
`parse_x509_pem` lives in the `pem` module and is authored with the module
segment. A test resolves every key from the emitted spelling verbatim.

## Version range starts at 0.6.5, not the matrix's oldest row

`0.1.0` has no top-level certificate parse — its public surface is
`parse_tbs_certificate`, `parse_algorithm_identifier`, `parse_signature_value`
and `parse_version`. Nothing here can resolve against it, and saying so is more
useful than a range implying coverage it cannot have. `0.6.5` introduces
`parse_x509_der` / `parse_crl_der`; `0.9.2` adds the three current names and
keeps the older ones, so both eras are contracted.

Every parse entry point takes exactly one argument, the input byte slice — read
from the declarations.

## verify_signature is deliberately not contracted

It exists from 0.9.2 but is gated behind a non-default feature
(`verify = ["ring"]`, `verify-aws = ["aws-lc-rs"]`), and the cryptography is
performed by ring or aws-lc-rs, which carry their own contracts. Typing it here
would route another crate's work through this one. A test asserts it does not
resolve.

## Tests

Full suite green (0 failures), `make lint` 0 issues at the pinned golangci-lint
version, re-verified after rebasing onto 13 newer commits. Additive only.