### PR TITLE
feat(callgraph): add edwards25519 contracts for the Go KB (Tier 0)

### DIFF
--- a/internal/callgraph/contracts/go/edwards25519.yaml
+++ b/internal/callgraph/contracts/go/edwards25519.yaml
@@ -1,0 +1,163 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: edwards25519
+  coordinates:
+    - "filippo.io/edwards25519"
+  version_range: ">=1.0.0-alpha.1,<2.0.0"
+  description: "filippo.io/edwards25519 Edwards25519 group arithmetic"
+
+# Inventory source: filippo.io/edwards25519 v1.0.0-alpha.1 through v1.2.0
+# module sources from the Go module proxy (edwards25519.go, scalar.go,
+# scalarmult.go, extra.go). Version notes: the Set*Bytes scalar decoders
+# changed shape at v1.0.0-beta.1 (alpha returned *Scalar or bare error; every
+# release from beta on returns (*Scalar, error)) — the contracts declare the
+# stable first result, which holds across the whole range. Point.Double,
+# Point.Select, and Point.ScalarMultSlow first appear by v1.2.0;
+# Point.MultByCofactor, Point.BytesMontgomery, Point.ExtendedCoordinates, and
+# Point.SetExtendedCoordinates at v1.0.0. Declaring later-added methods across
+# the range is safe: a call that does not exist in an older release cannot
+# appear at a call site compiled against it.
+#
+# Dispositions for the remaining public surface:
+# - Point.Set and Scalar.Set are plain copies; Point.Equal and Scalar.Equal
+#   are constant-time comparisons returning int; Point.Select is a
+#   constant-time conditional assignment. All are skipped-non-crypto for
+#   contract purposes (no material or algorithm state crosses them that the
+#   operands do not already carry).
+# - ExtendedCoordinates/SetExtendedCoordinates expose internal field elements
+#   (filippo.io/edwards25519/field types) — skipped-informative-return.
+contracts:
+  # Factories.
+  - method: filippo.io/edwards25519.NewScalar
+    arity: 0
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: factory
+  - method: filippo.io/edwards25519.NewIdentityPoint
+    arity: 0
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: factory
+  - method: filippo.io/edwards25519.NewGeneratorPoint
+    arity: 0
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: factory
+
+  # Decoders: material entering the curve domain.
+  - method: filippo.io/edwards25519.(*Point).SetBytes
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: filippo.io/edwards25519.(*Scalar).SetCanonicalBytes
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: filippo.io/edwards25519.(*Scalar).SetUniformBytes
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: filippo.io/edwards25519.(*Scalar).SetBytesWithClamping
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+
+  # Scalar multiplication and group operations.
+  - method: filippo.io/edwards25519.(*Point).ScalarBaseMult
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: filippo.io/edwards25519.(*Point).ScalarMult
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: filippo.io/edwards25519.(*Point).ScalarMultSlow
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: filippo.io/edwards25519.(*Point).VarTimeDoubleScalarBaseMult
+    arity: 3
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).MultiScalarMult
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).VarTimeMultiScalarMult
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).Add
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).Subtract
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).Negate
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).Double
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Point).MultByCofactor
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Point", confidence: high }
+    role: operation
+
+  # Scalar arithmetic.
+  - method: filippo.io/edwards25519.(*Scalar).Add
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Scalar).Subtract
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Scalar).Negate
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Scalar).Multiply
+    arity: 2
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Scalar).MultiplyAdd
+    arity: 3
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: operation
+  - method: filippo.io/edwards25519.(*Scalar).Invert
+    arity: 1
+    return: { type: "*filippo.io/edwards25519.Scalar", confidence: high }
+    role: operation
+
+  # Serialization outputs.
+  - method: filippo.io/edwards25519.(*Point).Bytes
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: filippo.io/edwards25519.(*Point).BytesMontgomery
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: filippo.io/edwards25519.(*Scalar).Bytes
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_edwards25519_test.go
+++ b/internal/callgraph/contracts/go_edwards25519_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesEdwards25519Contracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{"filippo.io/edwards25519.NewGeneratorPoint", "factory", "*filippo.io/edwards25519.Point", "", 0},
+		{"filippo.io/edwards25519.(*Point).SetBytes", "factory", "*filippo.io/edwards25519.Point", "input", 1},
+		{"filippo.io/edwards25519.(*Scalar).SetBytesWithClamping", "factory", "*filippo.io/edwards25519.Scalar", "keyMaterial", 1},
+		{"filippo.io/edwards25519.(*Point).ScalarBaseMult", "operation", "*filippo.io/edwards25519.Point", "keyMaterial", 1},
+		{"filippo.io/edwards25519.(*Point).ScalarMult", "operation", "*filippo.io/edwards25519.Point", "keyMaterial", 2},
+		{"filippo.io/edwards25519.(*Point).VarTimeDoubleScalarBaseMult", "operation", "*filippo.io/edwards25519.Point", "", 3},
+		{"filippo.io/edwards25519.(*Scalar).Invert", "operation", "*filippo.io/edwards25519.Scalar", "", 1},
+		{"filippo.io/edwards25519.(*Point).BytesMontgomery", "output", "[]byte", "", 0},
+		{"filippo.io/edwards25519.(*Scalar).Bytes", "output", "[]byte", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "edwards25519" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want edwards25519 %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-filippo-io-edwards25519` (tracker: scanoss/crypto-mining-service#207). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/edwards25519.yaml`

27 schema-v2 contracts for `filippo.io/edwards25519` v1.0.0-alpha.1 – v1.2.0:

- **factory**: `NewScalar`, `NewIdentityPoint`, `NewGeneratorPoint`, plus the byte decoders (`Point.SetBytes`, `Scalar.SetCanonicalBytes/SetUniformBytes/SetBytesWithClamping`) with keyMaterial/input parameter roles.
- **operation**: the scalar-multiplication surface with its variable-time variants, point group arithmetic (`Add/Subtract/Negate/Double/MultByCofactor`), and scalar arithmetic (`Add/Subtract/Negate/Multiply/MultiplyAdd/Invert`).
- **output**: `Point.Bytes`, `Point.BytesMontgomery`, `Scalar.Bytes`.
- Header notes the alpha-era decoder signature changes (stable first result declared across the range), later-added methods, and dispositions for copies, constant-time comparisons, and field-element accessors.
- Embedded-KB test asserts 9 representative entries.

## 2. Nested-go.mod re-rooting fix (same commit as #346)

Carried so the family gate mines module-path-rooted identities. Merge #346 first; this branch then rebases to the contract commit alone.

## Checks

`go test ./...` green, `make lint` 0 issues.

Family PR set: scanoss/crypto_rules#251 → this → scanoss/crypto-mining-service (closes #207 there).