### PR TITLE
feat(callgraph): add decred secp256k1 contracts for the Go KB (Tier 0)

### DIFF
--- a/internal/callgraph/contracts/go/decred-secp256k1.yaml
+++ b/internal/callgraph/contracts/go/decred-secp256k1.yaml
@@ -1,0 +1,180 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: decred-secp256k1
+  coordinates:
+    - "github.com/decred/dcrd/dcrec/secp256k1/v4"
+  version_range: ">=4.0.0,<5.0.0"
+  description: "decred secp256k1 curve, ECDSA, and EC-Schnorr-DCRv0 implementation"
+
+# Inventory source: github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0 through
+# v4.4.1 module sources from the Go module proxy (root package plus the ecdsa
+# and schnorr subpackages). GeneratePrivateKeyFromRand first appears at
+# v4.1.0; declaring it across the range is safe (a call that does not exist in
+# an older release cannot appear at a call site compiled against it).
+#
+# Dispositions for the remaining public surface:
+# - The low-level arithmetic types (FieldVal, ModNScalar, JacobianPoint) and
+#   the KoblitzCurve elliptic.Curve adaptor are deliberately uncontracted: the
+#   committed family audit scopes key factories, shared-secret generation,
+#   ECDSA/Schnorr operations, parsing, and serialization; the arithmetic
+#   surface carries no role the operands do not already have.
+# - NonceRFC6979 is contracted (deterministic-nonce derivation feeds signing).
+# - PublicKey.IsEqual/IsOnCurve/AsJacobian and PrivateKey/PublicKey.ToECDSA
+#   interop conversions are informative-return accessors; ToECDSA is
+#   contracted as output because it hands the key material to stdlib types.
+contracts:
+  # Root package: key material.
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.GeneratePrivateKey
+    arity: 0
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.GeneratePrivateKeyFromRand
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.NewPrivateKey
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.PrivKeyFromBytes
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: privKeyBytes, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.NewPublicKey
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.ParsePubKey
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: serialized, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.GenerateSharedSecret
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privkey, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: pubkey, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.NonceRFC6979
+    arity: 5
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.ModNScalar", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(*PrivateKey).PubKey
+    arity: 0
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: output
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(*PrivateKey).Zero
+    arity: 0
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(PrivateKey).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(PublicKey).SerializeCompressed
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(PublicKey).SerializeUncompressed
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(*PrivateKey).ToECDSA
+    arity: 0
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: output
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4.(*PublicKey).ToECDSA
+    arity: 0
+    return: { type: "*crypto/ecdsa.PublicKey", confidence: high }
+    role: output
+
+  # ECDSA subpackage.
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Sign
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.SignCompact
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.RecoverCompact
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: signature, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.NewSignature
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.ParseDERSignature
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.(*Signature).Verify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+      - { index: 1, name: pubKey, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.(*Signature).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+
+  # Schnorr subpackage (EC-Schnorr-DCRv0).
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.Sign
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privKey, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.NewSignature
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.Signature", confidence: high }
+    role: factory
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.ParseSignature
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.ParsePubKey
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pubKeyStr, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.(*Signature).Verify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+      - { index: 1, name: pubKey, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/decred/dcrd/dcrec/secp256k1/v4/schnorr.(Signature).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_decred_secp256k1_test.go
+++ b/internal/callgraph/contracts/go_decred_secp256k1_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesDecredSecp256k1Contracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	const m = "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{m + ".GeneratePrivateKey", "factory", "*" + m + ".PrivateKey", "", 0},
+		{m + ".PrivKeyFromBytes", "factory", "*" + m + ".PrivateKey", "keyMaterial", 1},
+		{m + ".GenerateSharedSecret", "operation", "[]byte", "privateKey", 2},
+		{m + ".NonceRFC6979", "operation", "*" + m + ".ModNScalar", "keyMaterial", 5},
+		{m + ".(PublicKey).SerializeCompressed", "output", "[]byte", "", 0},
+		{m + "/ecdsa.Sign", "operation", "*" + m + "/ecdsa.Signature", "digest", 2},
+		{m + "/ecdsa.RecoverCompact", "operation", "*" + m + ".PublicKey", "signature", 2},
+		{m + "/ecdsa.(*Signature).Verify", "operation", "bool", "publicKey", 2},
+		{m + "/schnorr.Sign", "operation", "*" + m + "/schnorr.Signature", "privateKey", 2},
+		{m + "/schnorr.ParsePubKey", "factory", "*" + m + ".PublicKey", "publicKey", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "decred-secp256k1" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want decred-secp256k1 %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-github-com-decred-dcrd-dcrec-secp256k1-v4` (tracker: scanoss/crypto-mining-service#214). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/decred-secp256k1.yaml`

28 schema-v2 contracts for `github.com/decred/dcrd/dcrec/secp256k1/v4` v4.0.0–v4.4.1 across the root, `ecdsa`, and `schnorr` packages: key factories/parsers with keyMaterial/publicKey roles, ECDH `GenerateSharedSecret`, RFC 6979 nonce derivation, ECDSA sign/compact-sign/recover/verify, EC-Schnorr-DCRv0 sign/verify, signature parsing, and serialization outputs (value receivers declared in `(Type)` form). The low-level `FieldVal`/`ModNScalar`/`JacobianPoint` arithmetic and the `elliptic.Curve` adaptor stay uncontracted per the committed family audit scope — dispositioned in the header. Embedded-KB test asserts 10 representative entries.

## 2. Nested-go.mod re-rooting fix (same commit as #346)

Needed here for real: this is a **multi-package** module, and with the fix the family fragments carry 670–711 internal edges with module-path-rooted identities; the tier0 stitch test passes with `forward_edges=17`. Merge #346 first; this branch then rebases to the contract commit alone.

## Checks

`go test ./...` green, `make lint` 0 issues.

Family PR set: scanoss/crypto_rules#252 → this → scanoss/crypto-mining-service (closes #214 there).