### PR TITLE
feat(callgraph): add btcec/v2 contracts for the Go KB (Tier 0)

### DIFF
--- a/internal/callgraph/contracts/go/btcec.yaml
+++ b/internal/callgraph/contracts/go/btcec.yaml
@@ -1,0 +1,186 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: btcec
+  coordinates:
+    - "github.com/btcsuite/btcd/btcec/v2"
+  version_range: ">=2.0.0,<3.0.0"
+  description: "btcsuite btcec/v2 Bitcoin secp256k1 facade"
+
+# Inventory source: github.com/btcsuite/btcd/btcec/v2 v2.0.0 and v2.5.0 module
+# sources from the Go module proxy. Layout notes: v2.0.0 ships the ECDSA
+# surface at the package root; the ecdsa and schnorr (BIP-340) subpackages
+# appear at v2.1.0 and ellswift at v2.4.0. Declaring later-added identities
+# across the range is safe (a call that does not exist in an older release
+# cannot appear at a call site compiled against it).
+#
+# Aliasing without duplication: PrivateKey, PublicKey, Signature, FieldVal,
+# ModNScalar, JacobianPoint, and KoblitzCurve are type ALIASES of the Decred
+# secp256k1 module's types, so method calls on them (PubKey, Serialize,
+# Verify, ...) resolve to the Decred identities covered by
+# decred-secp256k1.yaml — only the functions declared in btcec's own
+# namespaces are contracted here. The low-level Jacobian/field arithmetic and
+# schnorr/musig2 stay out per the family scope; IsCompressedPubKey and
+# ToSerialized are format helpers (skipped-non-crypto).
+contracts:
+  - method: github.com/btcsuite/btcd/btcec/v2.NewPrivateKey
+    arity: 0
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+  - method: github.com/btcsuite/btcd/btcec/v2.PrivKeyFromBytes
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2.PrivKeyFromScalar
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2.ParsePubKey
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pubKeyStr, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2.NewPublicKey
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+  - method: github.com/btcsuite/btcd/btcec/v2.Generator
+    arity: 0
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+  - method: github.com/btcsuite/btcd/btcec/v2.GenerateSharedSecret
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privkey, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: pubkey, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+
+  # v2.0.0 root-layout ECDSA surface.
+  - method: github.com/btcsuite/btcd/btcec/v2.Sign
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2.SignCompact
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2.RecoverCompact
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/btcsuite/btcd/btcec/v2.ParseSignature
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigStr, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2.ParseDERSignature
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigStr, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+
+  # v2.1.0+ ecdsa subpackage.
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.Sign
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.SignCompact
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.RecoverCompact
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.NewSignature
+    arity: 2
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.ParseSignature
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigStr, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.ParseDERSignature
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigStr, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/ecdsa.VerifyLowS
+    arity: 1
+    return: { type: error, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: sigStr, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+
+  # v2.1.0+ schnorr subpackage (BIP-340). Sign's SignOption variadic occupies
+  # one slot under the KB varargs convention.
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.Sign
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/btcsuite/btcd/btcec/v2/schnorr.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privKey, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.NewSignature
+    arity: 2
+    return: { type: "*github.com/btcsuite/btcd/btcec/v2/schnorr.Signature", confidence: high }
+    role: factory
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.ParseSignature
+    arity: 1
+    return: { type: "*github.com/btcsuite/btcd/btcec/v2/schnorr.Signature", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.ParsePubKey
+    arity: 1
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pubKeyStr, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.SerializePubKey
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.(*Signature).Verify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+      - { index: 1, name: pubKey, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/btcsuite/btcd/btcec/v2/schnorr.(*Signature).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+
+  # v2.4.0+ ellswift: uniform-random-looking public key encoding.
+  - method: github.com/btcsuite/btcd/btcec/v2/ellswift.EllswiftCreate
+    arity: 0
+    return: { type: "*github.com/decred/dcrd/dcrec/secp256k1/v4.PrivateKey", confidence: high }
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_btcec_test.go
+++ b/internal/callgraph/contracts/go_btcec_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesBtcecContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	const m = "github.com/btcsuite/btcd/btcec/v2"
+	const dec = "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{m + ".NewPrivateKey", "factory", "*" + dec + ".PrivateKey", "", 0},
+		{m + ".PrivKeyFromBytes", "factory", "*" + dec + ".PrivateKey", "keyMaterial", 1},
+		{m + ".GenerateSharedSecret", "operation", "[]byte", "privateKey", 2},
+		{m + ".SignCompact", "operation", "[]byte", "digest", 3},
+		{m + "/ecdsa.Sign", "operation", "*" + dec + "/ecdsa.Signature", "privateKey", 2},
+		{m + "/ecdsa.VerifyLowS", "operation", "error", "signature", 1},
+		{m + "/schnorr.Sign", "operation", "*" + m + "/schnorr.Signature", "digest", 3},
+		{m + "/schnorr.(*Signature).Verify", "operation", "bool", "publicKey", 2},
+		{m + "/ellswift.EllswiftCreate", "factory", "*" + dec + ".PrivateKey", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "btcec" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want btcec %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-github-com-btcsuite-btcd-btcec-v2` (tracker: scanoss/crypto-mining-service#210). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/btcec.yaml`

26 schema-v2 contracts for `github.com/btcsuite/btcd/btcec/v2` v2.0.0–v2.5.0: key factories/parsers, ECDH, the v2.0.0 root-layout ECDSA surface plus the v2.1.0+ `ecdsa` subpackage (incl. `VerifyLowS`), the BIP-340 `schnorr` subpackage (variadic `Sign` under the KB varargs convention), and the v2.4.0+ `ellswift` keygen.

**Aliasing without duplication** (the committed family audit's requirement): btcec's key/signature types are type aliases of the Decred secp256k1 module's types, so method calls on them resolve to the Decred identities covered by `decred-secp256k1.yaml` (#350) — only btcec's own namespaces are declared here, with return types pointing at the aliased identities. `schnorr/musig2` and the low-level arithmetic are dispositioned in the header.

## 2. Nested-go.mod re-rooting fix (same commit as #346)

Merge #346 first; this branch then rebases to the contract commit alone.

## Checks

`go test ./...` green, `make lint` 0 issues; embedded-KB test asserts 9 representative entries.

Family PR set: scanoss/crypto_rules#253 → #350 (Decred contracts, alias targets) → this → scanoss/crypto-mining-service (closes #210 there).