### PR TITLE
feat(callgraph): add jamesruan/sodium contracts for the Go KB (Tier 0)

### DIFF
--- a/internal/callgraph/contracts/go/jamesruan-sodium.yaml
+++ b/internal/callgraph/contracts/go/jamesruan-sodium.yaml
@@ -1,0 +1,377 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: jamesruan-sodium
+  coordinates:
+    - "github.com/jamesruan/sodium"
+  version_range: ">=1.0.13,<2.0.0"
+  description: "jamesruan/sodium libsodium facade"
+
+# Inventory source: github.com/jamesruan/sodium v1.0.14 module source from the
+# Go module proxy (the v1.0.13/v1.0.14 exported API is identical). The package
+# is a cgo facade over libsodium: crypto_box (X25519-XSalsa20-Poly1305),
+# crypto_secretbox (XSalsa20-Poly1305), crypto_aead (ChaCha20/XChaCha20-
+# Poly1305 IETF), crypto_sign (Ed25519), crypto_auth (HMAC-SHA512-256),
+# crypto_generichash (BLAKE2b), crypto_shorthash (SipHash-2-4), crypto_pwhash
+# (Argon2id), crypto_kdf, crypto_kx, and crypto_scalarmult (X25519).
+#
+# Dispositions for the remaining public surface: Size/Length getters,
+# MemZero/MemCmp, the SecretStream encoder/decoder streaming methods
+# (io.Writer/io.Reader contracts on interface-typed state), the ToBox
+# key-conversion helpers, and BoxNonce.Next are structural or non-crypto and
+# stay uncontracted; typed key/nonce structs are composite literals.
+contracts:
+  - method: github.com/jamesruan/sodium.MakeBoxKP
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.BoxKP", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeSignKP
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.SignKP", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeKXKP
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.KXKP", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeAEADCPKey
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.AEADCPKey", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeAEADXCPKey
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.AEADXCPKey", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeSecretStreamXCPKey
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.SecretStreamXCPKey", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeMasterKey
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.MasterKey", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.SeedBoxKP
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.BoxKP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: seed, role: metadata-contributing, contributes: { property: seed, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.SeedSignKP
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.SignKP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: seed, role: metadata-contributing, contributes: { property: seed, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.SeedKXKP
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.KXKP", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: seed, role: metadata-contributing, contributes: { property: seed, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.NewSignState
+    arity: 0
+    return: { type: "*github.com/jamesruan/sodium.SignState", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.MakeSecretStreamXCPEncoder
+    arity: 2
+    return: { type: "github.com/jamesruan/sodium.SecretStreamEncoder", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.MakeSecretStreamXCPDecoder
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.SecretStreamDecoder", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.LoadPWHashStr
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.PWHashStr", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: b, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.PWHashStore
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.PWHashStr", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pw, role: metadata-contributing, contributes: { property: password, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.PWHashStoreSensitive
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.PWHashStr", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pw, role: metadata-contributing, contributes: { property: password, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.PWHashStoreInteractive
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.PWHashStr", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pw, role: metadata-contributing, contributes: { property: password, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.Randomize
+    arity: 1
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.CryptoScalarmult
+    arity: 2
+    return: { type: "github.com/jamesruan/sodium.ScalarMult", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: n, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: p, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.CryptoScalarmultBase
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Scalar", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: n, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.MakeKeyContext
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.KeyContext", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.(Bytes).Box
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 2, name: sk, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).BoxOpen
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 2, name: sk, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).BoxDetached
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).BoxOpenDetached
+    arity: 4
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).SealedBox
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pk, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).SealedBoxOpen
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).SecretBox
+    arity: 2
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 1, name: k, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).SecretBoxOpen
+    arity: 2
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 1, name: k, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).SecretBoxDetached
+    arity: 2
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).SecretBoxOpenDetached
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADCPEncrypt
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: ad, role: metadata-contributing, contributes: { property: associatedData, derivation: argument_value } }
+      - { index: 1, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 2, name: k, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).AEADCPDecrypt
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: ad, role: metadata-contributing, contributes: { property: associatedData, derivation: argument_value } }
+      - { index: 1, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 2, name: k, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).AEADCPEncryptDetached
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADCPDecryptDetached
+    arity: 4
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADCPVerify
+    arity: 3
+    return: { type: "error", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADCPVerifyDetached
+    arity: 4
+    return: { type: "error", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADXCPEncrypt
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: ad, role: metadata-contributing, contributes: { property: associatedData, derivation: argument_value } }
+      - { index: 1, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 2, name: k, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).AEADXCPDecrypt
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: ad, role: metadata-contributing, contributes: { property: associatedData, derivation: argument_value } }
+      - { index: 1, name: n, role: metadata-contributing, contributes: { property: nonce, derivation: argument_value } }
+      - { index: 2, name: k, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).AEADXCPEncryptDetached
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADXCPDecryptDetached
+    arity: 4
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADXCPVerify
+    arity: 3
+    return: { type: "error", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).AEADXCPVerifyDetached
+    arity: 4
+    return: { type: "error", confidence: high }
+    role: operation
+  - method: github.com/jamesruan/sodium.(Bytes).Sign
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).SignDetached
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).SignVerifyDetached
+    arity: 2
+    return: { type: "error", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: sig, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).SignOpen
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).Auth
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.MAC", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).AuthVerify
+    arity: 2
+    return: { type: "error", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: mac, role: metadata-contributing, contributes: { property: authenticationTag, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(Bytes).Shorthash
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(*SignState).Update
+    arity: 1
+    return: { type: "()", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: b, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(*SignState).Sign
+    arity: 1
+    return: { type: "github.com/jamesruan/sodium.Signature", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(*SignState).Verify
+    arity: 2
+    return: { type: "error", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: sig, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(PWHashStr).PWHashVerify
+    arity: 1
+    return: { type: "error", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pw, role: metadata-contributing, contributes: { property: password, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(MasterKey).Derive
+    arity: 3
+    return: { type: "github.com/jamesruan/sodium.SubKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: length, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+      - { index: 2, name: context, role: metadata-contributing, contributes: { property: context, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(KXKP).ClientSessionKeys
+    arity: 1
+    return: { type: "*github.com/jamesruan/sodium.KXSessionKeys", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: server_pk, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(KXKP).ServerSessionKeys
+    arity: 1
+    return: { type: "*github.com/jamesruan/sodium.KXSessionKeys", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: client_pk, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.(BoxSecretKey).PublicKey
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.BoxPublicKey", confidence: high }
+    role: output
+  - method: github.com/jamesruan/sodium.(SignSecretKey).PublicKey
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.SignPublicKey", confidence: high }
+    role: output
+  - method: github.com/jamesruan/sodium.(SignSecretKey).Seed
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.SignSeed", confidence: high }
+    role: output
+  - method: github.com/jamesruan/sodium.(PWHashStr).Value
+    arity: 0
+    return: { type: "github.com/jamesruan/sodium.Bytes", confidence: high }
+    role: output
+  - method: github.com/jamesruan/sodium.NewGenericHash
+    arity: 1
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: outlen, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.NewGenericHashKeyed
+    arity: 2
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: outlen, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/jamesruan/sodium.NewGenericHashDefault
+    arity: 0
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+  - method: github.com/jamesruan/sodium.NewGenericHashDefaultKeyed
+    arity: 1
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_jamesruan_sodium_test.go
+++ b/internal/callgraph/contracts/go_jamesruan_sodium_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesJamesruanSodiumContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	const m = "github.com/jamesruan/sodium"
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{m + ".MakeBoxKP", "factory", m + ".BoxKP", "", 0},
+		{m + ".SeedSignKP", "factory", m + ".SignKP", "seed", 1},
+		{m + ".PWHashStore", "operation", m + ".PWHashStr", "password", 1},
+		{m + ".CryptoScalarmult", "operation", m + ".ScalarMult", "privateKey", 2},
+		{m + ".(Bytes).Box", "operation", m + ".Bytes", "nonce", 3},
+		{m + ".(Bytes).SignDetached", "operation", m + ".Signature", "privateKey", 1},
+		{m + ".(Bytes).AEADXCPEncrypt", "operation", m + ".Bytes", "associatedData", 3},
+		{m + ".(Bytes).Auth", "operation", m + ".MAC", "keyMaterial", 1},
+		{m + ".(PWHashStr).PWHashVerify", "operation", "error", "password", 1},
+		{m + ".(MasterKey).Derive", "operation", m + ".SubKey", "outputLength", 3},
+		{m + ".(KXKP).ClientSessionKeys", "operation", "*" + m + ".KXSessionKeys", "publicKey", 1},
+		{m + ".NewGenericHashKeyed", "factory", "hash.Hash", "keyMaterial", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "jamesruan-sodium" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want jamesruan-sodium %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-github-com-jamesruan-sodium` (tracker: scanoss/crypto-mining-service#220). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/jamesruan-sodium.yaml`

65 schema-v2 contracts for `github.com/jamesruan/sodium` v1.0.13–v1.0.14: keypair/key factories (Make*/Seed*), the full `Bytes` operation surface (box, secretbox, both IETF AEADs with detached/verify variants, Ed25519 sign/verify, crypto_auth, shorthash), the multi-part `SignState`, Argon2id password hashing/verification, BLAKE2b generichash constructors, crypto_kdf `MasterKey.Derive`, crypto_kx session keys, and X25519 scalarmult — with parameter roles for keys, nonces, seeds, associated data, and passwords. Structural getters, memory helpers, streaming io methods on interface-typed state, and key-conversion helpers are dispositioned in the header. Embedded-KB test asserts 12 representative entries.

## 2. Nested-go.mod re-rooting fix (same commit as #346)

Merge #346 first; this branch then rebases to the contract commit alone.

## Checks

`go test ./...` green, `make lint` 0 issues.

Family PR set: scanoss/crypto_rules#254 → this → scanoss/crypto-mining-service (closes #220 there).