### PR TITLE
feat(callgraph): add herumi bls-eth-go-binary contracts for the Go KB (Tier 0)

### DIFF
--- a/internal/callgraph/contracts/go/herumi-bls-eth.yaml
+++ b/internal/callgraph/contracts/go/herumi-bls-eth.yaml
@@ -1,0 +1,147 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: herumi-bls-eth
+  coordinates:
+    - "github.com/herumi/bls-eth-go-binary"
+  version_range: ">=1.28.1,<2.0.0"
+  description: "herumi bls-eth-go-binary BLS12-381 facade"
+
+# Inventory source: github.com/herumi/bls-eth-go-binary v1.28.1 and v1.37.0
+# module sources from the Go module proxy (the exported bls facade is
+# identical across the committed range). The implementation is a bundled
+# native binary behind cgo; only the Go facade boundary is contracted, per the
+# committed family audit ("do not claim inspection of native implementation
+# code from a Go-only scan").
+#
+# Dispositions: the ID/Fr/G1/G2/GT low-level field and group types, the
+# hex/dec string getters/setters, IsEqual/IsZero/IsValidOrder checks, and the
+# master-key sharing helpers (GetMasterSecretKey, Recover, Set over ID vectors)
+# are structural or secret-sharing plumbing left to the rule layer's
+# operations; serialization is contracted as output on the three main types.
+contracts:
+  - method: github.com/herumi/bls-eth-go-binary/bls.Init
+    arity: 1
+    return: { type: error, confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: curve, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).SetByCSPRNG
+    arity: 0
+    return: { type: "()", confidence: high }
+    role: factory
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).GetPublicKey
+    arity: 0
+    return: { type: "*github.com/herumi/bls-eth-go-binary/bls.PublicKey", confidence: high }
+    role: output
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).Sign
+    arity: 1
+    return: { type: "*github.com/herumi/bls-eth-go-binary/bls.Sign", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: m, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).SignByte
+    arity: 1
+    return: { type: "*github.com/herumi/bls-eth-go-binary/bls.Sign", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: msg, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).SignHash
+    arity: 1
+    return: { type: "*github.com/herumi/bls-eth-go-binary/bls.Sign", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: hash, role: metadata-contributing, contributes: { property: digest, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).GetPop
+    arity: 0
+    return: { type: "*github.com/herumi/bls-eth-go-binary/bls.Sign", confidence: high }
+    role: operation
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).Verify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pub, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).VerifyByte
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pub, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).VerifyHash
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pub, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).VerifyPop
+    arity: 1
+    return: { type: bool, confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pub, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).Aggregate
+    arity: 1
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).AggregateVerify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).AggregateVerifyNoCheck
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).FastAggregateVerify
+    arity: 2
+    return: { type: bool, confidence: high }
+    role: operation
+  - method: github.com/herumi/bls-eth-go-binary/bls.MultiVerify
+    arity: 3
+    return: { type: bool, confidence: high }
+    role: operation
+  - method: github.com/herumi/bls-eth-go-binary/bls.DHKeyExchange
+    arity: 2
+    return: { type: "github.com/herumi/bls-eth-go-binary/bls.PublicKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: sec, role: metadata-contributing, contributes: { property: privateKey, derivation: argument_value } }
+      - { index: 1, name: pub, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.HashAndMapToSignature
+    arity: 1
+    return: { type: "*github.com/herumi/bls-eth-go-binary/bls.Sign", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: buf, role: metadata-contributing, contributes: { property: input, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*PublicKey).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).Serialize
+    arity: 0
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*SecretKey).Deserialize
+    arity: 1
+    return: { type: error, confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: buf, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*PublicKey).Deserialize
+    arity: 1
+    return: { type: error, confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: buf, role: metadata-contributing, contributes: { property: publicKey, derivation: argument_value } }
+  - method: github.com/herumi/bls-eth-go-binary/bls.(*Sign).Deserialize
+    arity: 1
+    return: { type: error, confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: buf, role: metadata-contributing, contributes: { property: signature, derivation: argument_value } }
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_herumi_bls_eth_test.go
+++ b/internal/callgraph/contracts/go_herumi_bls_eth_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesHerumiBlsEthContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	const m = "github.com/herumi/bls-eth-go-binary/bls"
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{m + ".Init", "config", "error", "curve", 1},
+		{m + ".(*SecretKey).SetByCSPRNG", "factory", "()", "", 0},
+		{m + ".(*SecretKey).SignByte", "operation", "*" + m + ".Sign", "input", 1},
+		{m + ".(*Sign).VerifyByte", "operation", "bool", "publicKey", 2},
+		{m + ".(*Sign).FastAggregateVerify", "operation", "bool", "", 2},
+		{m + ".DHKeyExchange", "operation", m + ".PublicKey", "privateKey", 2},
+		{m + ".(*Sign).Serialize", "output", "[]byte", "", 0},
+		{m + ".(*SecretKey).Deserialize", "factory", "error", "keyMaterial", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "herumi-bls-eth" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want herumi-bls-eth %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-github-com-herumi-bls-eth-go-binary` (tracker: scanoss/crypto-mining-service#219). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/herumi-bls-eth.yaml`

25 schema-v2 contracts for the BLS12-381 Go facade (v1.28.1–v1.37.0): `Init` with a curve parameter role, CSPRNG keygen, public-key derivation, sign/verify in all three input forms, aggregation and pairing-backed aggregate verification, proof-of-possession, DH key exchange, hash-to-curve, and serialization/deserialization as outputs/factories. Only the Go facade boundary is contracted — the native implementation lives behind cgo per the committed family audit; field/group low-level types and secret-sharing plumbing dispositioned in the header. Embedded-KB test asserts 8 representative entries.

## 2. Nested-go.mod re-rooting fix (same commit as #346)

Merge #346 first; this branch then rebases to the contract commit alone.

## Checks

`go test ./...` green, `make lint` 0 issues.

Family PR set: scanoss/crypto_rules#256 → this → scanoss/crypto-mining-service (closes #219 there).