### PR TITLE
feat(callgraph): add ThalesIgnite/crypto11 contracts for the Go KB (Tier 0)

### DIFF
--- a/internal/callgraph/contracts/go/crypto11.yaml
+++ b/internal/callgraph/contracts/go/crypto11.yaml
@@ -1,0 +1,166 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: crypto11
+  coordinates:
+    - "github.com/ThalesIgnite/crypto11"
+  version_range: ">=0.1.0,<1.3.0"
+  description: "ThalesIgnite crypto11 high-level PKCS#11 facade"
+
+# Inventory source: github.com/ThalesIgnite/crypto11 v1.2.5 and v1.6.1 module
+# sources from the Go module proxy (the contracted surface is identical), with
+# the pre-v1.1.0 package-level generator era noted on the detection side.
+#
+# The range ends at v1.3.0 deliberately: from that release the repository was
+# renamed and go.mod declares module github.com/ThalesGroup/crypto11, so a
+# consumer literally cannot import the ThalesIgnite path against those
+# releases (Go rejects the module-path mismatch). Call sites compiled against
+# v1.3.0+ carry ThalesGroup identities that belong to that coordinate, not to
+# this one — out of range rather than unsupported, following the age
+# precedent.
+#
+# Dispositions: the crypto.Signer/crypto.Decrypter method calls on the
+# returned Signer/SignerDecrypter values resolve through stdlib interfaces
+# (interface-typed receivers; the stdlib contracts own crypto.Signer.Sign);
+# attribute plumbing (NewAttributeSet*, GetAttribute*, AttributeSet methods)
+# and the WithAttributes DSA/label variants beyond those declared are
+# structural lookups; SecretKey Encrypt/Decrypt low-level padding helpers are
+# unexported.
+contracts:
+  - method: github.com/ThalesIgnite/crypto11.Configure
+    arity: 1
+    return: { type: "*github.com/ThalesIgnite/crypto11.Context", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: config, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.ConfigureFromFile
+    arity: 1
+    return: { type: "*github.com/ThalesIgnite/crypto11.Context", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateRSAKeyPair
+    arity: 2
+    return: { type: "github.com/ThalesIgnite/crypto11.SignerDecrypter", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateRSAKeyPairWithLabel
+    arity: 3
+    return: { type: "github.com/ThalesIgnite/crypto11.SignerDecrypter", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateRSAKeyPairWithAttributes
+    arity: 3
+    return: { type: "github.com/ThalesIgnite/crypto11.SignerDecrypter", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateECDSAKeyPair
+    arity: 2
+    return: { type: "github.com/ThalesIgnite/crypto11.Signer", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: curve, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateECDSAKeyPairWithLabel
+    arity: 3
+    return: { type: "github.com/ThalesIgnite/crypto11.Signer", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: curve, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateECDSAKeyPairWithAttributes
+    arity: 3
+    return: { type: "github.com/ThalesIgnite/crypto11.Signer", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: curve, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateDSAKeyPair
+    arity: 2
+    return: { type: "github.com/ThalesIgnite/crypto11.Signer", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: params, role: metadata-contributing, contributes: { property: parameters, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateSecretKey
+    arity: 3
+    return: { type: "*github.com/ThalesIgnite/crypto11.SecretKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+      - { index: 2, name: cipher, role: metadata-contributing, contributes: { property: cipher, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).GenerateSecretKeyWithLabel
+    arity: 4
+    return: { type: "*github.com/ThalesIgnite/crypto11.SecretKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+      - { index: 3, name: cipher, role: metadata-contributing, contributes: { property: cipher, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*Context).FindKeyPair
+    arity: 2
+    return: { type: "github.com/ThalesIgnite/crypto11.Signer", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*Context).FindKey
+    arity: 2
+    return: { type: "*github.com/ThalesIgnite/crypto11.SecretKey", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*Context).FindPrivateKey
+    arity: 2
+    return: { type: "github.com/ThalesIgnite/crypto11.PrivateKey", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*Context).NewRandomReader
+    arity: 0
+    return: { type: "io.Reader", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*Context).FindCertificate
+    arity: 3
+    return: { type: "*crypto/x509.Certificate", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*Context).ImportCertificate
+    arity: 2
+    return: { type: "error", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: certificate, role: metadata-contributing, contributes: { property: certificate, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).NewCBCEncrypter
+    arity: 1
+    return: { type: "crypto/cipher.BlockMode", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: iv, role: metadata-contributing, contributes: { property: iv, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).NewCBCDecrypter
+    arity: 1
+    return: { type: "crypto/cipher.BlockMode", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: iv, role: metadata-contributing, contributes: { property: iv, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).NewCBCEncrypterCloser
+    arity: 1
+    return: { type: "github.com/ThalesIgnite/crypto11.BlockModeCloser", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: iv, role: metadata-contributing, contributes: { property: iv, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).NewCBCDecrypterCloser
+    arity: 1
+    return: { type: "github.com/ThalesIgnite/crypto11.BlockModeCloser", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: iv, role: metadata-contributing, contributes: { property: iv, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).NewGCM
+    arity: 0
+    return: { type: "crypto/cipher.AEAD", confidence: high }
+    role: factory
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).NewHMAC
+    arity: 2
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: mech, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: length, role: metadata-contributing, contributes: { property: outputLength, derivation: argument_value } }
+  - method: github.com/ThalesIgnite/crypto11.(*SecretKey).Delete
+    arity: 0
+    return: { type: "error", confidence: high }
+    role: operation
+  - method: github.com/ThalesIgnite/crypto11.(*Context).Close
+    arity: 0
+    return: { type: "error", confidence: high }
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/go_crypto11_test.go
+++ b/internal/callgraph/contracts/go_crypto11_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesCrypto11Contracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	const m = "github.com/ThalesIgnite/crypto11"
+	tests := []struct {
+		method, role, returnType, property string
+		arity                              int
+	}{
+		{m + ".Configure", "factory", "*" + m + ".Context", "options", 1},
+		{m + ".(*Context).GenerateRSAKeyPair", "operation", m + ".SignerDecrypter", "keySize", 2},
+		{m + ".(*Context).GenerateECDSAKeyPair", "operation", m + ".Signer", "curve", 2},
+		{m + ".(*Context).GenerateSecretKey", "operation", "*" + m + ".SecretKey", "cipher", 3},
+		{m + ".(*Context).FindKeyPair", "factory", m + ".Signer", "", 2},
+		{m + ".(*Context).NewRandomReader", "factory", "io.Reader", "", 0},
+		{m + ".(*SecretKey).NewCBCEncrypter", "factory", "crypto/cipher.BlockMode", "iv", 1},
+		{m + ".(*SecretKey).NewGCM", "factory", "crypto/cipher.AEAD", "", 0},
+		{m + ".(*SecretKey).NewHMAC", "factory", "hash.Hash", "algorithm", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "crypto11" || contract.Role != tt.role ||
+				contract.Return.Type != tt.returnType || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want crypto11 %s -> %s/high", contract, tt.role, tt.returnType)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Tier 0 family `golang-github-com-thalesignite-crypto11` (tracker: scanoss/crypto-mining-service#231). Finder phase — two commits.

## 1. `internal/callgraph/contracts/go/crypto11.yaml`

25 schema-v2 contracts: `Configure` factories, RSA/ECDSA/DSA/secret keypair generation with keySize/curve/cipher parameter roles, token key/certificate lookup factories, the token CSPRNG reader, and the `SecretKey` block-mode/AEAD/HMAC constructors with iv/algorithm roles.

**The range ends at v1.3.0 deliberately:** the repository rename makes go.mod declare `github.com/ThalesGroup/crypto11` from that release, so a consumer cannot import the ThalesIgnite path against it — call sites compiled against v1.3.0+ carry ThalesGroup identities that belong to that coordinate (out of range rather than unsupported, following the age precedent; noted in the header).

## 2. Nested-go.mod re-rooting fix (same commit as #346)

Merge #346 first; this branch then rebases to the contract commit alone.

## Checks

`go test ./...` green, `make lint` 0 issues; embedded-KB test asserts 9 representative entries.

Family PR set: scanoss/crypto_rules#257 → this → scanoss/crypto-mining-service (closes #231 there).