### PR TITLE
feat(callgraph): add JWT lineage contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/golang-jwt.yaml
+++ b/internal/callgraph/contracts/go/golang-jwt.yaml
@@ -1,0 +1,170 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: golang-jwt
+  coordinates:
+    - "github.com/golang-jwt/jwt/v5"
+  version_range: ">=5.0.0-rc.1,<6.0.0"
+  description: "golang-jwt/jwt v5 JWT implementation (maintained lineage)"
+
+# Inventory source: github.com/golang-jwt/jwt/v5 v5.3.1 module source from the
+# Go module proxy. Maintained successor of the archived
+# github.com/dgrijalva/jwt-go lineage, contracted separately in jwt-go.yaml;
+# the two must never cross-attribute. The JWS algorithm is selected by the
+# SigningMethod argument at token creation (rule-side parameterCondition);
+# contracts carry lifecycle structure only. v5 signing-method terminals return
+# []byte where the legacy lineage returned string.
+#
+# Dispositions for the remaining public surface: (*Token).SigningString,
+# (*Parser).ParseUnverified, and (*Parser).DecodeSegment never touch a key or
+# signature (skipped-non-crypto); GetAlgorithms returns registered names only
+# (skipped-informative-return); NewNumericDate and the claims/error helpers are
+# data plumbing (skipped-non-crypto); the ParserOption/TokenOption With*
+# functions configure validation policy, not cryptography, and WithValidMethods
+# is negative-tested at the rule layer (skipped-non-crypto); the SigningMethod
+# package variables are values, not callables (not contractable).
+contracts:
+  # New and NewWithClaims take a trailing ...TokenOption list, which occupies
+  # one slot under the KB varargs convention.
+  - method: github.com/golang-jwt/jwt/v5.New
+    arity: 2
+    varargs: true
+    return: { type: "*github.com/golang-jwt/jwt/v5.Token", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: method, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.NewWithClaims
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/golang-jwt/jwt/v5.Token", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: method, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.(*Token).SignedString
+    arity: 1
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/golang-jwt/jwt/v5.Parse
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/golang-jwt/jwt/v5.Token", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.ParseWithClaims
+    arity: 4
+    varargs: true
+    return: { type: "*github.com/golang-jwt/jwt/v5.Token", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.NewParser
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/golang-jwt/jwt/v5.Parser", confidence: high }
+    role: factory
+  - method: github.com/golang-jwt/jwt/v5.(*Parser).Parse
+    arity: 2
+    return: { type: "*github.com/golang-jwt/jwt/v5.Token", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*Parser).ParseWithClaims
+    arity: 3
+    return: { type: "*github.com/golang-jwt/jwt/v5.Token", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.GetSigningMethod
+    arity: 1
+    return: { type: "github.com/golang-jwt/jwt/v5.SigningMethod", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.RegisterSigningMethod
+    arity: 2
+    return: { type: "()", confidence: high }
+    role: config
+
+  # Signing-method terminals: the concrete Sign/Verify implementations that
+  # perform the HMAC, RSA, RSA-PSS, ECDSA, and Ed25519 work behind
+  # SignedString/Parse.
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodHMAC).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodHMAC).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodRSA).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodRSA).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodRSAPSS).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodRSAPSS).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodECDSA).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodECDSA).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodEd25519).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/golang-jwt/jwt/v5.(*SigningMethodEd25519).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+
+  # PEM key-material parsing.
+  - method: github.com/golang-jwt/jwt/v5.ParseRSAPrivateKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/rsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.ParseRSAPrivateKeyFromPEMWithPassword
+    arity: 2
+    return: { type: "*crypto/rsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.ParseRSAPublicKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/rsa.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.ParseECPrivateKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.ParseECPublicKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/ecdsa.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.ParseEdPrivateKeyFromPEM
+    arity: 1
+    return: { type: "crypto.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/golang-jwt/jwt/v5.ParseEdPublicKeyFromPEM
+    arity: 1
+    return: { type: "crypto.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+hierarchy: {}

--- a/internal/callgraph/contracts/go/jwt-go.yaml
+++ b/internal/callgraph/contracts/go/jwt-go.yaml
@@ -1,0 +1,137 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: jwt-go
+  coordinates:
+    - "github.com/dgrijalva/jwt-go"
+  version_range: ">=1.0.0,<4.0.0"
+  description: "dgrijalva/jwt-go JWT implementation (legacy lineage)"
+
+# Inventory source: github.com/dgrijalva/jwt-go v3.2.0+incompatible module
+# source from the Go module proxy. The archived legacy lineage; its maintained
+# successor github.com/golang-jwt/jwt/v5 is contracted separately in
+# golang-jwt.yaml and the two must never cross-attribute. The JWS algorithm is
+# selected by the SigningMethod argument at token creation (rule-side
+# parameterCondition); contracts carry lifecycle structure only.
+#
+# Dispositions for the remaining public surface: EncodeSegment/DecodeSegment
+# are base64 plumbing (skipped-non-crypto); (*Token).SigningString and
+# (*Parser).ParseUnverified never touch a key or signature
+# (skipped-non-crypto); NewValidationError and the error types are diagnostics
+# (skipped-non-crypto); the SigningMethod package variables are values, not
+# callables (not contractable); the request subpackage extractors delegate to
+# Parse (skipped-non-crypto). Identities added after v1.0.0 (ECDSA at v2.7.0,
+# RSA-PSS at v3.0.0) simply never match older tags.
+contracts:
+  - method: github.com/dgrijalva/jwt-go.New
+    arity: 1
+    return: { type: "*github.com/dgrijalva/jwt-go.Token", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: method, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.NewWithClaims
+    arity: 2
+    return: { type: "*github.com/dgrijalva/jwt-go.Token", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: method, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.(*Token).SignedString
+    arity: 1
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/dgrijalva/jwt-go.Parse
+    arity: 2
+    return: { type: "*github.com/dgrijalva/jwt-go.Token", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.ParseWithClaims
+    arity: 3
+    return: { type: "*github.com/dgrijalva/jwt-go.Token", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*Parser).Parse
+    arity: 2
+    return: { type: "*github.com/dgrijalva/jwt-go.Token", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*Parser).ParseWithClaims
+    arity: 3
+    return: { type: "*github.com/dgrijalva/jwt-go.Token", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.GetSigningMethod
+    arity: 1
+    return: { type: "github.com/dgrijalva/jwt-go.SigningMethod", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.RegisterSigningMethod
+    arity: 2
+    return: { type: "()", confidence: high }
+    role: config
+
+  # Signing-method terminals: the concrete Sign/Verify implementations that
+  # perform the HMAC, RSA, RSA-PSS, and ECDSA work behind SignedString/Parse.
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodHMAC).Sign
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodHMAC).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodRSA).Sign
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodRSA).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodRSAPSS).Sign
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodRSAPSS).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodECDSA).Sign
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+  - method: github.com/dgrijalva/jwt-go.(*SigningMethodECDSA).Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+
+  # PEM key-material parsing.
+  - method: github.com/dgrijalva/jwt-go.ParseRSAPrivateKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/rsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.ParseRSAPrivateKeyFromPEMWithPassword
+    arity: 2
+    return: { type: "*crypto/rsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.ParseRSAPublicKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/rsa.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.ParseECPrivateKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/dgrijalva/jwt-go.ParseECPublicKeyFromPEM
+    arity: 1
+    return: { type: "*crypto/ecdsa.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+hierarchy: {}

--- a/internal/callgraph/contracts/go_jwt_lineage_test.go
+++ b/internal/callgraph/contracts/go_jwt_lineage_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// TestLoadEmbeddedGoIncludesJWTLineageContracts asserts representative entries
+// from both JWT lineage KBs: the archived github.com/dgrijalva/jwt-go and its
+// maintained successor github.com/golang-jwt/jwt/v5. The two are separate
+// libraries and must resolve independently.
+func TestLoadEmbeddedGoIncludesJWTLineageContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, library, role, property string
+		arity                           int
+	}{
+		{"github.com/dgrijalva/jwt-go.NewWithClaims", "jwt-go", "factory", "algorithm", 2},
+		{"github.com/dgrijalva/jwt-go.(*Token).SignedString", "jwt-go", "operation", "keyMaterial", 1},
+		{"github.com/dgrijalva/jwt-go.Parse", "jwt-go", "operation", "", 2},
+		{"github.com/dgrijalva/jwt-go.(*SigningMethodHMAC).Sign", "jwt-go", "operation", "", 2},
+		{"github.com/dgrijalva/jwt-go.ParseECPrivateKeyFromPEM", "jwt-go", "factory", "keyMaterial", 1},
+		{"github.com/golang-jwt/jwt/v5.NewWithClaims", "golang-jwt", "factory", "algorithm", 3},
+		{"github.com/golang-jwt/jwt/v5.Parse", "golang-jwt", "operation", "", 3},
+		{"github.com/golang-jwt/jwt/v5.NewParser", "golang-jwt", "factory", "", 1},
+		{"github.com/golang-jwt/jwt/v5.(*SigningMethodEd25519).Verify", "golang-jwt", "operation", "", 3},
+		{"github.com/golang-jwt/jwt/v5.ParseEdPublicKeyFromPEM", "golang-jwt", "factory", "keyMaterial", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != tt.library || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want %s %s/high", contract, tt.library, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `jwt-go-lineage` (scanoss/crypto-mining-service#237).

## What

- `internal/callgraph/contracts/go/jwt-go.yaml` (21 contracts, `>=1.0.0,<4.0.0`) and `internal/callgraph/contracts/go/golang-jwt.yaml` (27 contracts, `>=5.0.0-rc.1,<6.0.0`): token factories with operation-determining SigningMethod parameters, `Parse`/`ParseWithClaims`/`SignedString` operations, the concrete signing-method `Sign`/`Verify` terminals (HMAC/RSA/RSA-PSS/ECDSA, plus Ed25519 on v5 where terminals return `[]byte` instead of `string`), `NewParser`/`GetSigningMethod` lifecycle entries, and PEM key-material factories returning stdlib key types.
- Full API inventories with dispositions are in each YAML header; the two lineages are separate libraries and never share a KB entry.
- `go_jwt_lineage_test.go` asserts representative entries from both KBs.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (24 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#237.

Refs scanoss/crypto-mining-service#237