### PR TITLE
feat(callgraph): add lestrrat-go/jwx contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/jwx-v2.yaml
+++ b/internal/callgraph/contracts/go/jwx-v2.yaml
@@ -1,0 +1,118 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: jwx-v2
+  coordinates:
+    - "github.com/lestrrat-go/jwx/v2"
+  version_range: ">=2.0.0-alpha1,<3.0.0"
+  description: "lestrrat-go/jwx v2 JOSE implementation (JWA/JWE/JWK/JWS/JWT)"
+
+# Inventory source: github.com/lestrrat-go/jwx/v2 v2.1.7 module source from
+# the Go module proxy. The v0/v1 major lives at github.com/lestrrat-go/jwx and
+# is contracted separately in jwx.yaml; the majors must never cross-attribute.
+# v2 moved the algorithm/key pair out of the operation signatures into the
+# WithKey options, so the option constructors are the metadata anchors and the
+# operations themselves are algorithm-free.
+#
+# Dispositions for the remaining public surface: jwa constant registries are
+# values, not callables (not contractable); jwt.ParseRequest/ParseHeader and
+# ParseCookie are HTTP extraction wrappers over Parse (skipped-non-crypto);
+# jwk.NewSet/NewCache and the jwk.Import alias landscape post-2.1 stay on the
+# declared FromRaw identity (older spelling never matches); jws/jwe message
+# and header builders are serialization plumbing (skipped-non-crypto).
+contracts:
+  - method: github.com/lestrrat-go/jwx/v2/jws.Sign
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jws.Verify
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jws.WithKey
+    arity: 3
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jws.SignVerifyOption", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/v2/jwe.Encrypt
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jwe.Decrypt
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jwe.WithKey
+    arity: 3
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwe.EncryptDecryptOption", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/v2/jwt.Sign
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jwt.Parse
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwt.Token", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jwt.ParseString
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwt.Token", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/v2/jwt.WithKey
+    arity: 3
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwt.SignEncryptParseOption", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/v2/jwk.FromRaw
+    arity: 1
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwk.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/v2/jwk.Parse
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwk.Set", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: src, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/v2/jwk.ParseKey
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwk.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: data, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/v2/jwk.Fetch
+    arity: 3
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwk.Set", confidence: high }
+    role: factory
+    parameters:
+      - { index: 1, name: u, role: metadata-contributing, contributes: { property: context, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/v2/jwk.PublicKeyOf
+    arity: 1
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwk.Key", confidence: high }
+    role: output
+  - method: github.com/lestrrat-go/jwx/v2/jwk.PublicSetOf
+    arity: 1
+    return: { type: "github.com/lestrrat-go/jwx/v2/jwk.Set", confidence: high }
+    role: output
+hierarchy: {}

--- a/internal/callgraph/contracts/go/jwx.yaml
+++ b/internal/callgraph/contracts/go/jwx.yaml
@@ -1,0 +1,150 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: jwx
+  coordinates:
+    - "github.com/lestrrat-go/jwx"
+  version_range: ">=0.9.0,<2.0.0"
+  description: "lestrrat-go/jwx v0/v1 JOSE implementation (JWA/JWE/JWK/JWS/JWT)"
+
+# Inventory source: github.com/lestrrat-go/jwx v1.2.31 module source from the
+# Go module proxy. The v2 major lives at github.com/lestrrat-go/jwx/v2 and is
+# contracted separately in jwx-v2.yaml; the majors must never cross-attribute.
+# The JOSE algorithm is a jwa constant argument (operation-determining
+# parameter); rules capture its name, contracts carry lifecycle structure.
+# Early v0.9/v1.0 minors expose narrower option sets; identities declared here
+# that a tag lacks simply never match.
+#
+# Dispositions for the remaining public surface: jwa constant registries are
+# values, not callables (not contractable); jws.SignLiteral and the
+# header/message builders are serialization plumbing (skipped-non-crypto);
+# jwt.ParseRequest/ParseHeader/ParseForm are HTTP extraction wrappers over
+# Parse (skipped-non-crypto); jwk.NewSet/AutoRefresh and the typed New*Key
+# constructors build empty containers (skipped-non-crypto); x25519 and the
+# internal subpackages are implementation detail (skipped-non-crypto).
+contracts:
+  - method: github.com/lestrrat-go/jwx/jws.Sign
+    arity: 4
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jws.SignMulti
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/jws.Verify
+    arity: 4
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jws.VerifySet
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: set, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jws.VerifyAuto
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/jwe.Encrypt
+    arity: 6
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: keyalg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+      - { index: 3, name: contentalg, role: metadata-contributing, contributes: { property: contentEncryption, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/jwe.Decrypt
+    arity: 4
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jwt.Sign
+    arity: 4
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jwt.Parse
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwt.Token", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/jwt.ParseString
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwt.Token", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/jwt.ParseReader
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwt.Token", confidence: high }
+    role: operation
+  - method: github.com/lestrrat-go/jwx/jwt.WithVerify
+    arity: 2
+    return: { type: "github.com/lestrrat-go/jwx/jwt.ParseOption", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: alg, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jwk.New
+    arity: 1
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/lestrrat-go/jwx/jwk.Parse
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Set", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: src, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/jwk.ParseKey
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: data, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/jwk.ParseString
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Set", confidence: high }
+    role: factory
+  - method: github.com/lestrrat-go/jwx/jwk.ParseReader
+    arity: 2
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Set", confidence: high }
+    role: factory
+  - method: github.com/lestrrat-go/jwx/jwk.Fetch
+    arity: 3
+    varargs: true
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Set", confidence: high }
+    role: factory
+    parameters:
+      - { index: 1, name: urlstring, role: metadata-contributing, contributes: { property: context, derivation: argument_value } }
+  - method: github.com/lestrrat-go/jwx/jwk.PublicKeyOf
+    arity: 1
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Key", confidence: high }
+    role: output
+  - method: github.com/lestrrat-go/jwx/jwk.PublicSetOf
+    arity: 1
+    return: { type: "github.com/lestrrat-go/jwx/jwk.Set", confidence: high }
+    role: output
+hierarchy: {}

--- a/internal/callgraph/contracts/go_jwx_test.go
+++ b/internal/callgraph/contracts/go_jwx_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// TestLoadEmbeddedGoIncludesJWXContracts asserts representative entries from
+// both jwx major-version KBs (github.com/lestrrat-go/jwx and its /v2 path).
+// The majors are separate libraries and must resolve independently.
+func TestLoadEmbeddedGoIncludesJWXContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, library, role, property string
+		arity                           int
+	}{
+		{"github.com/lestrrat-go/jwx/jws.Sign", "jwx", "operation", "algorithm", 4},
+		{"github.com/lestrrat-go/jwx/jwe.Encrypt", "jwx", "operation", "contentEncryption", 6},
+		{"github.com/lestrrat-go/jwx/jwt.WithVerify", "jwx", "config", "algorithm", 2},
+		{"github.com/lestrrat-go/jwx/jwk.New", "jwx", "factory", "keyMaterial", 1},
+		{"github.com/lestrrat-go/jwx/jwk.PublicKeyOf", "jwx", "output", "", 1},
+		{"github.com/lestrrat-go/jwx/v2/jws.Sign", "jwx-v2", "operation", "", 2},
+		{"github.com/lestrrat-go/jwx/v2/jws.WithKey", "jwx-v2", "config", "algorithm", 3},
+		{"github.com/lestrrat-go/jwx/v2/jwt.Parse", "jwx-v2", "operation", "", 2},
+		{"github.com/lestrrat-go/jwx/v2/jwk.FromRaw", "jwx-v2", "factory", "keyMaterial", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != tt.library || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want %s %s/high", contract, tt.library, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `lestrrat-go-jwx` (scanoss/crypto-mining-service#238).

## What

- `internal/callgraph/contracts/go/jwx.yaml` (21 contracts, `>=0.9.0,<2.0.0`) and `internal/callgraph/contracts/go/jwx-v2.yaml` (16 contracts, `>=2.0.0-alpha1,<3.0.0`): JWS/JWE/JWT sign/verify/encrypt/decrypt operations with operation-determining `jwa` parameters (positional in v1; via the `WithKey` option constructors in v2, which are `config` anchors), JWT parse operations, and JWK key-material factories/outputs (`New`/`FromRaw`, `Parse*`, `Fetch`, `PublicKeyOf`/`PublicSetOf`).
- Full API inventories with dispositions in each YAML header; the majors are separate libraries and never share a KB entry.
- `go_jwx_test.go` asserts representative entries from both KBs.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (88 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#238.

Refs scanoss/crypto-mining-service#238