### PR TITLE
feat(callgraph): add wireguard-go contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/wireguard.yaml
+++ b/internal/callgraph/contracts/go/wireguard.yaml
@@ -1,0 +1,65 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: wireguard
+  coordinates:
+    - "golang.zx2c4.com/wireguard"
+  version_range: ">=0.0.20190409,<0.1.0"
+  description: "wireguard-go WireGuard secure-channel implementation"
+
+# Inventory source: golang.zx2c4.com/wireguard v0.0.20200320 and v0.0.20201118
+# module sources from the Go module proxy. The declared range starts at
+# v0.0.20190409 deliberately: the 2018 tags ship a flat package-main
+# application with no importable device package, so no consumer can write the
+# identities below against them (age beta precedent), and v0.0.20201121 is a
+# retraction-only stub module. The suite is fixed by the protocol (Noise
+# IKpsk2 over Curve25519, ChaCha20-Poly1305 transport, BLAKE2s); no parameter
+# selects an algorithm.
+#
+# Dispositions for the remaining public surface: tun/, conn/, ipc/,
+# ratelimiter/, and rwcancel/ are transport and platform plumbing
+# (skipped-non-crypto); pool/buffer accessors, Up/Down/Close/Wait lifecycle,
+# peer lookup/removal, and the Bind* socket helpers carry no crypto semantics
+# (skipped-non-crypto); IpcGetOperation/IpcHandle expose UAPI configuration
+# streams whose key material is already anchored on SetPrivateKey/NewPeer
+# (skipped-non-crypto); the internal Routine* workers and SendHandshake*
+# helpers are goroutine plumbing behind the message operations
+# (skipped-non-crypto).
+contracts:
+  - method: golang.zx2c4.com/wireguard/device.NewDevice
+    arity: 2
+    return: { type: "*golang.zx2c4.com/wireguard/device.Device", confidence: high }
+    role: factory
+  - method: golang.zx2c4.com/wireguard/device.(*Device).SetPrivateKey
+    arity: 1
+    return: { type: "()", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: sk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: golang.zx2c4.com/wireguard/device.(*Device).NewPeer
+    arity: 1
+    return: { type: "*golang.zx2c4.com/wireguard/device.Peer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: golang.zx2c4.com/wireguard/device.(*Device).IpcSetOperation
+    arity: 1
+    return: { type: "*golang.zx2c4.com/wireguard/device.IPCError", confidence: high }
+    role: config
+  - method: golang.zx2c4.com/wireguard/device.(*Device).CreateMessageInitiation
+    arity: 1
+    return: { type: "*golang.zx2c4.com/wireguard/device.MessageInitiation", confidence: high }
+    role: operation
+  - method: golang.zx2c4.com/wireguard/device.(*Device).ConsumeMessageInitiation
+    arity: 1
+    return: { type: "*golang.zx2c4.com/wireguard/device.Peer", confidence: high }
+    role: operation
+  - method: golang.zx2c4.com/wireguard/device.(*Device).CreateMessageResponse
+    arity: 1
+    return: { type: "*golang.zx2c4.com/wireguard/device.MessageResponse", confidence: high }
+    role: operation
+  - method: golang.zx2c4.com/wireguard/device.(*Device).ConsumeMessageResponse
+    arity: 1
+    return: { type: "*golang.zx2c4.com/wireguard/device.Peer", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go_wireguard_test.go
+++ b/internal/callgraph/contracts/go_wireguard_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesWireGuardContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"golang.zx2c4.com/wireguard/device.NewDevice", "factory", "", 2},
+		{"golang.zx2c4.com/wireguard/device.(*Device).SetPrivateKey", "config", "keyMaterial", 1},
+		{"golang.zx2c4.com/wireguard/device.(*Device).NewPeer", "factory", "keyMaterial", 1},
+		{"golang.zx2c4.com/wireguard/device.(*Device).CreateMessageInitiation", "operation", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "wireguard" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want wireguard %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-golang-zx2c4-com-wireguard` (scanoss/crypto-mining-service#234).

## What

- `internal/callgraph/contracts/go/wireguard.yaml` (8 contracts, `>=0.0.20190409,<0.1.0`): device factory, key-material config (`SetPrivateKey`/`NewPeer`), UAPI config, and the four Noise handshake message operations. The range starts at v0.0.20190409 because the 2018 tags ship a flat package-main application with no importable device package, and v0.0.20201120/21 are retraction-only stub modules. Full inventory dispositions in the YAML header.
- `go_wireguard_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#234.

Refs scanoss/crypto-mining-service#234