### PR TITLE
feat(callgraph): add ProtonMail gopenpgp v2 contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/gopenpgp.yaml
+++ b/internal/callgraph/contracts/go/gopenpgp.yaml
@@ -1,0 +1,143 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: gopenpgp
+  coordinates:
+    - "github.com/ProtonMail/gopenpgp/v2"
+  version_range: ">=2.0.0,<3.0.0"
+  description: "ProtonMail gopenpgp v2 high-level OpenPGP facade"
+
+# Inventory source: github.com/ProtonMail/gopenpgp/v2 v2.9.0 module source
+# from the Go module proxy. The facade delegates the primitives to
+# ProtonMail/go-crypto (contracted separately when that family lands); only
+# the gopenpgp-level identities a consumer calls are declared here.
+#
+# Dispositions for the remaining public surface: armor/ and subtle/ are
+# encoding and constant-time helpers (skipped-non-crypto); the Mobile-suffixed
+# helper variants and Go2Android/Go2IOS readers are gomobile plumbing over the
+# declared identities (skipped-non-crypto); PlainMessage/PGPMessage/
+# PGPSignature constructors and Get* accessors are data containers
+# (skipped-non-crypto); the stream/split/context method variants on KeyRing
+# share the declared base identities' semantics and are matched by the
+# detection rules' regexes, so only the base arities are contracted
+# (needs-follow-up for full per-variant arity coverage); fingerprint helpers
+# return display digests (skipped-informative-return).
+contracts:
+  # helper facade
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.EncryptMessageArmored
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.DecryptMessageArmored
+    arity: 3
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privateKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.EncryptMessageWithPassword
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: password, role: metadata-contributing, contributes: { property: password, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.DecryptMessageWithPassword
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: password, role: metadata-contributing, contributes: { property: password, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.SignCleartextMessageArmored
+    arity: 3
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privateKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.VerifyCleartextMessageArmored
+    arity: 3
+    return: { type: "string", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: publicKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.GenerateKey
+    arity: 5
+    return: { type: "string", confidence: high }
+    role: factory
+    parameters:
+      - { index: 3, name: keyType, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 4, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/helper.UpdatePrivateKeyPassphrase
+    arity: 3
+    return: { type: "string", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: privateKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+
+  # crypto package key lifecycle
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.GenerateKey
+    arity: 4
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 2, name: keyType, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 3, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.GenerateSessionKey
+    arity: 0
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.SessionKey", confidence: high }
+    role: factory
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.GenerateSessionKeyAlgo
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.SessionKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: algo, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.NewKey
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: binKeys, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.NewKeyFromArmored
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.Key", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: armored, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.NewKeyRing
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.KeyRing", confidence: high }
+    role: factory
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.NewKeyRingFromBinary
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.KeyRing", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: binKeys, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+
+  # KeyRing operations (base arities; stream/context variants share semantics)
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).Encrypt
+    arity: 2
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.PGPMessage", confidence: high }
+    role: operation
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).Decrypt
+    arity: 3
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.PlainMessage", confidence: high }
+    role: operation
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).SignDetached
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.PGPSignature", confidence: high }
+    role: operation
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).VerifyDetached
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).EncryptSessionKey
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).DecryptSessionKey
+    arity: 1
+    return: { type: "*github.com/ProtonMail/gopenpgp/v2/crypto.SessionKey", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go_gopenpgp_test.go
+++ b/internal/callgraph/contracts/go_gopenpgp_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGopenpgpContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/ProtonMail/gopenpgp/v2/helper.EncryptMessageArmored", "operation", "keyMaterial", 2},
+		{"github.com/ProtonMail/gopenpgp/v2/helper.GenerateKey", "factory", "algorithm", 5},
+		{"github.com/ProtonMail/gopenpgp/v2/crypto.GenerateKey", "factory", "keySize", 4},
+		{"github.com/ProtonMail/gopenpgp/v2/crypto.NewKeyRing", "factory", "", 1},
+		{"github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).SignDetached", "operation", "", 1},
+		{"github.com/ProtonMail/gopenpgp/v2/crypto.(*KeyRing).DecryptSessionKey", "operation", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "gopenpgp" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want gopenpgp %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-protonmail-gopenpgp-v2` (scanoss/crypto-mining-service#227).

## What

- `internal/callgraph/contracts/go/gopenpgp.yaml` (22 contracts, `>=2.0.0,<3.0.0`): helper facade operations with key/password parameter roles, key and session-key factories with operation-determining `keyType`/`algo` parameters, key parsing and key ring factories, and the KeyRing base operations (Encrypt/Decrypt/SignDetached/VerifyDetached/EncryptSessionKey/DecryptSessionKey). Full inventory dispositions in the YAML header (gomobile plumbing, armor/subtle helpers, and stream-variant arities recorded as needs-follow-up).
- `go_gopenpgp_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (71 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#227.

Refs scanoss/crypto-mining-service#227