### PR TITLE
feat(callgraph): add Cloudflare CIRCL contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/circl.yaml
+++ b/internal/callgraph/contracts/go/circl.yaml
@@ -1,0 +1,157 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: circl
+  coordinates:
+    - "github.com/cloudflare/circl"
+  version_range: ">=1.0.0,<2.0.0"
+  description: "Cloudflare CIRCL cryptographic library (KEM/signature registries, HPKE, DH, EdDSA)"
+
+# Inventory source: github.com/cloudflare/circl v1.6.4 module source from the
+# Go module proxy. CIRCL is broad; per the family audit the contracted
+# boundary is the stable consumer surface: the kem/sign scheme registries and
+# their scheme interfaces (interface-declared per the shared-declaration
+# rule), HPKE suite/sender/receiver, dh/x25519 and dh/x448, and the
+# sign/ed25519 and sign/ed448 packages.
+#
+# Dispositions for the remaining public surface: the concrete scheme packages
+# (kyber, mlkem, dilithium, mldsa, eddilithium, frodo, hybrid schemes) are
+# reached through the registry interfaces (covered-existing via the interface
+# contracts); group, ecc, math, simd, xof, and expander are low-level
+# arithmetic (skipped-non-crypto at this boundary); abe, blindsign, oprf, ot,
+# pke, pki, secretsharing, tss, vdaf, and zk are experimental or
+# protocol-research APIs (needs-follow-up per the audit's stable/experimental
+# split); cipher/ascon has its own primitive shape (needs-follow-up).
+contracts:
+  # KEM registry and scheme interface
+  - method: github.com/cloudflare/circl/kem/schemes.ByName
+    arity: 1
+    return: { type: "github.com/cloudflare/circl/kem.Scheme", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: name, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/cloudflare/circl/kem.(Scheme).GenerateKeyPair
+    arity: 0
+    return: { type: "github.com/cloudflare/circl/kem.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/kem.(Scheme).DeriveKeyPair
+    arity: 1
+    return: { type: "github.com/cloudflare/circl/kem.PublicKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: seed, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/cloudflare/circl/kem.(Scheme).Encapsulate
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/cloudflare/circl/kem.(Scheme).Decapsulate
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: sk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+
+  # Signature registry and scheme interface
+  - method: github.com/cloudflare/circl/sign/schemes.ByName
+    arity: 1
+    return: { type: "github.com/cloudflare/circl/sign.Scheme", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: name, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/cloudflare/circl/sign.(Scheme).GenerateKey
+    arity: 0
+    return: { type: "github.com/cloudflare/circl/sign.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/sign.(Scheme).DeriveKey
+    arity: 1
+    return: { type: "github.com/cloudflare/circl/sign.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/sign.(Scheme).Sign
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: sk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/cloudflare/circl/sign.(Scheme).Verify
+    arity: 4
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+
+  # HPKE
+  - method: github.com/cloudflare/circl/hpke.NewSuite
+    arity: 3
+    return: { type: "github.com/cloudflare/circl/hpke.Suite", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: kemID, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: kdfID, role: metadata-contributing, contributes: { property: kdf, derivation: argument_value } }
+      - { index: 2, name: aeadID, role: metadata-contributing, contributes: { property: contentEncryption, derivation: argument_value } }
+  - method: github.com/cloudflare/circl/hpke.(Suite).NewSender
+    arity: 2
+    return: { type: "*github.com/cloudflare/circl/hpke.Sender", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pkR, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/cloudflare/circl/hpke.(Suite).NewReceiver
+    arity: 2
+    return: { type: "*github.com/cloudflare/circl/hpke.Receiver", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: skR, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+
+  # DH
+  - method: github.com/cloudflare/circl/dh/x25519.KeyGen
+    arity: 2
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/dh/x25519.Shared
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/dh/x448.KeyGen
+    arity: 2
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/dh/x448.Shared
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+
+  # EdDSA packages
+  - method: github.com/cloudflare/circl/sign/ed25519.GenerateKey
+    arity: 1
+    return: { type: "github.com/cloudflare/circl/sign/ed25519.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/sign/ed25519.Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: privateKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/cloudflare/circl/sign/ed25519.Verify
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: public, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/cloudflare/circl/sign/ed448.GenerateKey
+    arity: 1
+    return: { type: "github.com/cloudflare/circl/sign/ed448.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/cloudflare/circl/sign/ed448.Sign
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: priv, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/cloudflare/circl/sign/ed448.Verify
+    arity: 4
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: public, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+hierarchy: {}

--- a/internal/callgraph/contracts/go_circl_test.go
+++ b/internal/callgraph/contracts/go_circl_test.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesCIRCLContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/cloudflare/circl/kem/schemes.ByName", "factory", "algorithm", 1},
+		{"github.com/cloudflare/circl/kem.(Scheme).Encapsulate", "operation", "keyMaterial", 1},
+		{"github.com/cloudflare/circl/sign/schemes.ByName", "factory", "algorithm", 1},
+		{"github.com/cloudflare/circl/sign.(Scheme).Verify", "operation", "keyMaterial", 4},
+		{"github.com/cloudflare/circl/hpke.NewSuite", "factory", "kdf", 3},
+		{"github.com/cloudflare/circl/dh/x25519.Shared", "operation", "", 3},
+		{"github.com/cloudflare/circl/sign/ed448.Sign", "operation", "keyMaterial", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "circl" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want circl %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-cloudflare-circl` (scanoss/crypto-mining-service#211).

## What

- `internal/callgraph/contracts/go/circl.yaml` (24 contracts, `>=1.0.0,<2.0.0`): the kem/sign scheme registries with operation-determining name parameters, the `kem.Scheme` and `sign.Scheme` interfaces declared once per the shared-declaration rule (`(Scheme).Method` form), HPKE suite/sender/receiver with kdf/contentEncryption parameter roles, dh/x25519 and dh/x448, and the ed25519/ed448 packages. The audit's stable/experimental split is recorded in the header (abe, blindsign, oprf, ot, pke, pki, secretsharing, tss, vdaf, zk, and cipher/ascon as needs-follow-up; concrete scheme packages covered through the registry interfaces).
- `go_circl_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (20 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#211.

Refs scanoss/crypto-mining-service#211