### PR TITLE
feat(callgraph): add go-jose contracts for all four lineages

### DIFF
--- a/internal/callgraph/contracts/go/go-jose-v2.yaml
+++ b/internal/callgraph/contracts/go/go-jose-v2.yaml
@@ -1,0 +1,89 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: go-jose-v2
+  coordinates:
+    - "gopkg.in/square/go-jose.v2"
+  version_range: ">=2.0.0,<3.0.0"
+  description: "go-jose v2 on the gopkg.in path"
+
+# Inventory source: the newest committed CSV tag of this lineage from the Go
+# module proxy. The four go-jose lineages (square original, gopkg.in v2, org
+# v3, org v4) are contracted separately, one exact import path each, and never
+# share an FQN. Dispositions: the jose.JSONWebKey/JSONWebKeySet types are data
+# containers with JSON marshalling (skipped-non-crypto at this boundary);
+# cryptosigner and jwt.Builder claim/serialization methods are plumbing behind
+# the declared factories (skipped-non-crypto); OpaqueSigner/OpaqueKeyEncrypter
+# adapters are integration points, not algorithm selectors
+# (skipped-non-crypto).
+contracts:
+  - method: gopkg.in/square/go-jose.v2.NewEncrypter
+    arity: 3
+    return: { type: "gopkg.in/square/go-jose.v2.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: rcpt, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: gopkg.in/square/go-jose.v2.NewMultiEncrypter
+    arity: 3
+    return: { type: "gopkg.in/square/go-jose.v2.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: gopkg.in/square/go-jose.v2.NewSigner
+    arity: 2
+    return: { type: "gopkg.in/square/go-jose.v2.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: gopkg.in/square/go-jose.v2.NewMultiSigner
+    arity: 2
+    return: { type: "gopkg.in/square/go-jose.v2.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigs, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: gopkg.in/square/go-jose.v2.ParseSigned
+    arity: 1
+    return: { type: "*gopkg.in/square/go-jose.v2.JSONWebSignature", confidence: high }
+    role: operation
+  - method: gopkg.in/square/go-jose.v2.ParseEncrypted
+    arity: 1
+    return: { type: "*gopkg.in/square/go-jose.v2.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: gopkg.in/square/go-jose.v2.(Encrypter).Encrypt
+    arity: 1
+    return: { type: "*gopkg.in/square/go-jose.v2.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: gopkg.in/square/go-jose.v2.(JSONWebEncryption).Decrypt
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: decryptionKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: gopkg.in/square/go-jose.v2.(Signer).Sign
+    arity: 1
+    return: { type: "*gopkg.in/square/go-jose.v2.JSONWebSignature", confidence: high }
+    role: operation
+  - method: gopkg.in/square/go-jose.v2.(JSONWebSignature).Verify
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: verificationKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: gopkg.in/square/go-jose.v2/jwt.Signed
+    arity: 1
+    return: { type: "gopkg.in/square/go-jose.v2/jwt.Builder", confidence: high }
+    role: factory
+  - method: gopkg.in/square/go-jose.v2/jwt.Encrypted
+    arity: 1
+    return: { type: "gopkg.in/square/go-jose.v2/jwt.Builder", confidence: high }
+    role: factory
+  - method: gopkg.in/square/go-jose.v2/jwt.ParseSigned
+    arity: 1
+    return: { type: "*gopkg.in/square/go-jose.v2/jwt.JSONWebToken", confidence: high }
+    role: operation
+  - method: gopkg.in/square/go-jose.v2/jwt.ParseEncrypted
+    arity: 1
+    return: { type: "*gopkg.in/square/go-jose.v2/jwt.JSONWebToken", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go/go-jose-v3.yaml
+++ b/internal/callgraph/contracts/go/go-jose-v3.yaml
@@ -1,0 +1,89 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: go-jose-v3
+  coordinates:
+    - "github.com/go-jose/go-jose/v3"
+  version_range: ">=3.0.0,<4.0.0"
+  description: "go-jose v3 (maintained org path)"
+
+# Inventory source: the newest committed CSV tag of this lineage from the Go
+# module proxy. The four go-jose lineages (square original, gopkg.in v2, org
+# v3, org v4) are contracted separately, one exact import path each, and never
+# share an FQN. Dispositions: the jose.JSONWebKey/JSONWebKeySet types are data
+# containers with JSON marshalling (skipped-non-crypto at this boundary);
+# cryptosigner and jwt.Builder claim/serialization methods are plumbing behind
+# the declared factories (skipped-non-crypto); OpaqueSigner/OpaqueKeyEncrypter
+# adapters are integration points, not algorithm selectors
+# (skipped-non-crypto).
+contracts:
+  - method: github.com/go-jose/go-jose/v3.NewEncrypter
+    arity: 3
+    return: { type: "github.com/go-jose/go-jose/v3.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: rcpt, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v3.NewMultiEncrypter
+    arity: 3
+    return: { type: "github.com/go-jose/go-jose/v3.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v3.NewSigner
+    arity: 2
+    return: { type: "github.com/go-jose/go-jose/v3.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v3.NewMultiSigner
+    arity: 2
+    return: { type: "github.com/go-jose/go-jose/v3.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigs, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v3.ParseSigned
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v3.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v3.ParseEncrypted
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v3.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v3.(Encrypter).Encrypt
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v3.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v3.(JSONWebEncryption).Decrypt
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: decryptionKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/go-jose/go-jose/v3.(Signer).Sign
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v3.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v3.(JSONWebSignature).Verify
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: verificationKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/go-jose/go-jose/v3/jwt.Signed
+    arity: 1
+    return: { type: "github.com/go-jose/go-jose/v3/jwt.Builder", confidence: high }
+    role: factory
+  - method: github.com/go-jose/go-jose/v3/jwt.Encrypted
+    arity: 1
+    return: { type: "github.com/go-jose/go-jose/v3/jwt.Builder", confidence: high }
+    role: factory
+  - method: github.com/go-jose/go-jose/v3/jwt.ParseSigned
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v3/jwt.JSONWebToken", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v3/jwt.ParseEncrypted
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v3/jwt.JSONWebToken", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go/go-jose-v4.yaml
+++ b/internal/callgraph/contracts/go/go-jose-v4.yaml
@@ -1,0 +1,105 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: go-jose-v4
+  coordinates:
+    - "github.com/go-jose/go-jose/v4"
+  version_range: ">=4.0.0,<5.0.0"
+  description: "go-jose v4 (algorithm-allowlist parse APIs)"
+
+# Inventory source: the newest committed CSV tag of this lineage from the Go
+# module proxy. The four go-jose lineages (square original, gopkg.in v2, org
+# v3, org v4) are contracted separately, one exact import path each, and never
+# share an FQN. Dispositions: the jose.JSONWebKey/JSONWebKeySet types are data
+# containers with JSON marshalling (skipped-non-crypto at this boundary);
+# cryptosigner and jwt.Builder claim/serialization methods are plumbing behind
+# the declared factories (skipped-non-crypto); OpaqueSigner/OpaqueKeyEncrypter
+# adapters are integration points, not algorithm selectors
+# (skipped-non-crypto).
+contracts:
+  - method: github.com/go-jose/go-jose/v4.NewEncrypter
+    arity: 3
+    return: { type: "github.com/go-jose/go-jose/v4.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: rcpt, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v4.NewMultiEncrypter
+    arity: 3
+    return: { type: "github.com/go-jose/go-jose/v4.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v4.NewSigner
+    arity: 2
+    return: { type: "github.com/go-jose/go-jose/v4.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v4.NewMultiSigner
+    arity: 2
+    return: { type: "github.com/go-jose/go-jose/v4.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigs, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/go-jose/go-jose/v4.ParseSigned
+    arity: 2
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.ParseEncrypted
+    arity: 3
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.ParseSignedCompact
+    arity: 2
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.ParseSignedJSON
+    arity: 2
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.ParseEncryptedCompact
+    arity: 3
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.ParseEncryptedJSON
+    arity: 3
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.(Encrypter).Encrypt
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.(JSONWebEncryption).Decrypt
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: decryptionKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/go-jose/go-jose/v4.(Signer).Sign
+    arity: 1
+    return: { type: "*github.com/go-jose/go-jose/v4.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4.(JSONWebSignature).Verify
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: verificationKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/go-jose/go-jose/v4/jwt.Signed
+    arity: 1
+    return: { type: "github.com/go-jose/go-jose/v4/jwt.Builder", confidence: high }
+    role: factory
+  - method: github.com/go-jose/go-jose/v4/jwt.Encrypted
+    arity: 1
+    return: { type: "github.com/go-jose/go-jose/v4/jwt.Builder", confidence: high }
+    role: factory
+  - method: github.com/go-jose/go-jose/v4/jwt.ParseSigned
+    arity: 2
+    return: { type: "*github.com/go-jose/go-jose/v4/jwt.JSONWebToken", confidence: high }
+    role: operation
+  - method: github.com/go-jose/go-jose/v4/jwt.ParseEncrypted
+    arity: 3
+    return: { type: "*github.com/go-jose/go-jose/v4/jwt.JSONWebToken", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go/square-go-jose.yaml
+++ b/internal/callgraph/contracts/go/square-go-jose.yaml
@@ -1,0 +1,89 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: square-go-jose
+  coordinates:
+    - "github.com/square/go-jose"
+  version_range: ">=1.0.0,<3.0.0"
+  description: "square/go-jose legacy lineage (v1/v2 tags on the original path)"
+
+# Inventory source: the newest committed CSV tag of this lineage from the Go
+# module proxy. The four go-jose lineages (square original, gopkg.in v2, org
+# v3, org v4) are contracted separately, one exact import path each, and never
+# share an FQN. Dispositions: the jose.JSONWebKey/JSONWebKeySet types are data
+# containers with JSON marshalling (skipped-non-crypto at this boundary);
+# cryptosigner and jwt.Builder claim/serialization methods are plumbing behind
+# the declared factories (skipped-non-crypto); OpaqueSigner/OpaqueKeyEncrypter
+# adapters are integration points, not algorithm selectors
+# (skipped-non-crypto).
+contracts:
+  - method: github.com/square/go-jose.NewEncrypter
+    arity: 3
+    return: { type: "github.com/square/go-jose.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: rcpt, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/square/go-jose.NewMultiEncrypter
+    arity: 3
+    return: { type: "github.com/square/go-jose.Encrypter", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: enc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/square/go-jose.NewSigner
+    arity: 2
+    return: { type: "github.com/square/go-jose.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sig, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/square/go-jose.NewMultiSigner
+    arity: 2
+    return: { type: "github.com/square/go-jose.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: sigs, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/square/go-jose.ParseSigned
+    arity: 1
+    return: { type: "*github.com/square/go-jose.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/square/go-jose.ParseEncrypted
+    arity: 1
+    return: { type: "*github.com/square/go-jose.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/square/go-jose.(Encrypter).Encrypt
+    arity: 1
+    return: { type: "*github.com/square/go-jose.JSONWebEncryption", confidence: high }
+    role: operation
+  - method: github.com/square/go-jose.(JSONWebEncryption).Decrypt
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: decryptionKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/square/go-jose.(Signer).Sign
+    arity: 1
+    return: { type: "*github.com/square/go-jose.JSONWebSignature", confidence: high }
+    role: operation
+  - method: github.com/square/go-jose.(JSONWebSignature).Verify
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: verificationKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/square/go-jose/jwt.Signed
+    arity: 1
+    return: { type: "github.com/square/go-jose/jwt.Builder", confidence: high }
+    role: factory
+  - method: github.com/square/go-jose/jwt.Encrypted
+    arity: 1
+    return: { type: "github.com/square/go-jose/jwt.Builder", confidence: high }
+    role: factory
+  - method: github.com/square/go-jose/jwt.ParseSigned
+    arity: 1
+    return: { type: "*github.com/square/go-jose/jwt.JSONWebToken", confidence: high }
+    role: operation
+  - method: github.com/square/go-jose/jwt.ParseEncrypted
+    arity: 1
+    return: { type: "*github.com/square/go-jose/jwt.JSONWebToken", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go_go_jose_test.go
+++ b/internal/callgraph/contracts/go_go_jose_test.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// TestLoadEmbeddedGoIncludesGoJoseContracts asserts representative entries
+// from all four go-jose lineage KBs.
+func TestLoadEmbeddedGoIncludesGoJoseContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, library, role, property string
+		arity                           int
+	}{
+		{"github.com/square/go-jose.NewSigner", "square-go-jose", "factory", "algorithm", 2},
+		{"gopkg.in/square/go-jose.v2.NewEncrypter", "go-jose-v2", "factory", "algorithm", 3},
+		{"gopkg.in/square/go-jose.v2/jwt.Signed", "go-jose-v2", "factory", "", 1},
+		{"github.com/go-jose/go-jose/v3.(JSONWebSignature).Verify", "go-jose-v3", "operation", "keyMaterial", 1},
+		{"github.com/go-jose/go-jose/v3.ParseSigned", "go-jose-v3", "operation", "", 1},
+		{"github.com/go-jose/go-jose/v4.ParseSigned", "go-jose-v4", "operation", "", 2},
+		{"github.com/go-jose/go-jose/v4.ParseEncrypted", "go-jose-v4", "operation", "", 3},
+		{"github.com/go-jose/go-jose/v4/jwt.ParseSigned", "go-jose-v4", "operation", "", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != tt.library || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want %s %s/high", contract, tt.library, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `go-jose` (scanoss/crypto-mining-service#204).

## What

- Four schema-v2 KBs (`square-go-jose.yaml`, `go-jose-v2.yaml`, `go-jose-v3.yaml`, `go-jose-v4.yaml`), one exact import path each: encrypter/signer factories with operation-determining algorithm parameters, parse operations (v4 carries the allowlist arities: `ParseSigned` arity 2, `ParseEncrypted` arity 3, plus the Compact/JSON variants), the `(Encrypter).Encrypt` / `(JSONWebEncryption).Decrypt` / `(Signer).Sign` / `(JSONWebSignature).Verify` terminals with keyMaterial parameter roles, and the `jwt` subpackage builders/parsers. Dispositions in each header.
- `go_go_jose_test.go` asserts representative entries from all four KBs.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (71 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#204.

Refs scanoss/crypto-mining-service#204