### PR TITLE
feat(callgraph): add sigstore/sigstore contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/sigstore.yaml
+++ b/internal/callgraph/contracts/go/sigstore.yaml
@@ -1,0 +1,137 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: sigstore
+  coordinates:
+    - "github.com/sigstore/sigstore"
+  version_range: ">=1.0.0,<2.0.0"
+  description: "sigstore/sigstore signing library (signature facade and key utilities)"
+
+# Inventory source: github.com/sigstore/sigstore v1.9.5 module source from the
+# Go module proxy. Contracted boundary per the family audit: the pkg/signature
+# signer/verifier facade (family-explicit loaders, generic key-type loaders,
+# the Signer/Verifier interface operations) and the pkg/cryptoutils PEM key
+# helpers. Remote/keyless integrations (fulcioroots, oauth/oauthflow, tuf, the
+# kms subpackages) are service clients, not local cryptography
+# (skipped-non-crypto per the audit's local/remote split); DSSE and payload
+# wrappers delegate to the declared signers (skipped-non-crypto);
+# certificate marshalling helpers are container plumbing
+# (skipped-non-crypto).
+contracts:
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadECDSASigner
+    arity: 2
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.ECDSASigner", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: priv, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+      - { index: 1, name: hf, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadECDSAVerifier
+    arity: 2
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.ECDSAVerifier", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pub, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/sigstore/sigstore/pkg/signature.NewECDSASignerVerifier
+    arity: 3
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.ECDSASignerVerifier", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: curve, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadED25519Signer
+    arity: 1
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.ED25519Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: priv, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadED25519Verifier
+    arity: 1
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.ED25519Verifier", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/signature.NewED25519SignerVerifier
+    arity: 1
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.ED25519SignerVerifier", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadRSAPKCS1v15Signer
+    arity: 2
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.RSAPKCS1v15Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 1, name: hf, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadRSAPKCS1v15Verifier
+    arity: 2
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.RSAPKCS1v15Verifier", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/signature.NewRSAPKCS1v15SignerVerifier
+    arity: 3
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.RSAPKCS1v15SignerVerifier", confidence: high }
+    role: factory
+    parameters:
+      - { index: 1, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadRSAPSSSigner
+    arity: 3
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.RSAPSSSigner", confidence: high }
+    role: factory
+    parameters:
+      - { index: 1, name: hf, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadRSAPSSVerifier
+    arity: 3
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.RSAPSSVerifier", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/signature.NewRSAPSSSignerVerifier
+    arity: 3
+    return: { type: "*github.com/sigstore/sigstore/pkg/signature.RSAPSSSignerVerifier", confidence: high }
+    role: factory
+    parameters:
+      - { index: 1, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadSigner
+    arity: 2
+    return: { type: "github.com/sigstore/sigstore/pkg/signature.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: privateKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+      - { index: 1, name: hashFunc, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadVerifier
+    arity: 2
+    return: { type: "github.com/sigstore/sigstore/pkg/signature.Verifier", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: publicKey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadSignerFromPEMFile
+    arity: 3
+    return: { type: "github.com/sigstore/sigstore/pkg/signature.Signer", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/signature.LoadVerifierFromPEMFile
+    arity: 2
+    return: { type: "github.com/sigstore/sigstore/pkg/signature.Verifier", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/signature.(Signer).SignMessage
+    arity: 2
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/sigstore/sigstore/pkg/signature.(Verifier).VerifySignature
+    arity: 3
+    varargs: true
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/sigstore/sigstore/pkg/cryptoutils.UnmarshalPEMToPublicKey
+    arity: 1
+    return: { type: "crypto.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pemBytes, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/cryptoutils.UnmarshalPEMToPrivateKey
+    arity: 2
+    return: { type: "crypto.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pemBytes, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/sigstore/sigstore/pkg/cryptoutils.GeneratePEMEncodedECDSAKeyPair
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: factory
+  - method: github.com/sigstore/sigstore/pkg/cryptoutils.GeneratePEMEncodedRSAKeyPair
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go_sigstore_test.go
+++ b/internal/callgraph/contracts/go_sigstore_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesSigstoreContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/sigstore/sigstore/pkg/signature.LoadECDSASigner", "factory", "algorithm", 2},
+		{"github.com/sigstore/sigstore/pkg/signature.NewRSAPSSSignerVerifier", "factory", "keySize", 3},
+		{"github.com/sigstore/sigstore/pkg/signature.LoadSigner", "factory", "keyMaterial", 2},
+		{"github.com/sigstore/sigstore/pkg/signature.(Signer).SignMessage", "operation", "", 2},
+		{"github.com/sigstore/sigstore/pkg/cryptoutils.UnmarshalPEMToPublicKey", "factory", "keyMaterial", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "sigstore" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want sigstore %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-sigstore-sigstore` (scanoss/crypto-mining-service#229).

## What

- `internal/callgraph/contracts/go/sigstore.yaml` (23 contracts, `>=1.0.0,<2.0.0`): family-explicit and generic signer/verifier factories with hash/keySize/curve parameter roles, the `(Signer).SignMessage` / `(Verifier).VerifySignature` interface operations, and the cryptoutils PEM helpers. Remote/keyless clients recorded as out of scope per the audit. Dispositions in the header.
- `go_sigstore_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (60 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#229.

Refs scanoss/crypto-mining-service#229