### PR TITLE
feat(callgraph): add Google Cloud KMS contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/google-cloud-kms.yaml
+++ b/internal/callgraph/contracts/go/google-cloud-kms.yaml
@@ -1,0 +1,90 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: google-cloud-kms
+  coordinates:
+    - "cloud.google.com/go/kms"
+  version_range: ">=0.1.0,<2.0.0"
+  description: "Google Cloud KMS client (apiv1 KeyManagementClient)"
+
+# Inventory source: cloud.google.com/go/kms v1.9.0 module source from the Go
+# module proxy. Every operation runs remotely inside Cloud KMS; algorithm, key
+# purpose, and protection level live in the protobuf request/key resources and
+# are exposed as capture-side state, never as inferred provider capabilities
+# (azkeys precedent). Pagers, IAM helpers, key-ring/version listing and
+# lifecycle plumbing, the EKM and Autokey admin clients, and the kmspb/
+# aliasshim generated types are structural and stay uncontracted
+# (skipped-non-crypto).
+contracts:
+  - method: cloud.google.com/go/kms/apiv1.NewKeyManagementClient
+    arity: 2
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1.KeyManagementClient", confidence: high }
+    role: factory
+  - method: cloud.google.com/go/kms/apiv1.NewKeyManagementRESTClient
+    arity: 2
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1.KeyManagementClient", confidence: high }
+    role: factory
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).CreateCryptoKey
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.CryptoKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: req, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).CreateCryptoKeyVersion
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.CryptoKeyVersion", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).ImportCryptoKeyVersion
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.CryptoKeyVersion", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: req, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).Encrypt
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.EncryptResponse", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: req, role: metadata-contributing, contributes: { property: options, derivation: argument_value } }
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).Decrypt
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.DecryptResponse", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).AsymmetricSign
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.AsymmetricSignResponse", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).AsymmetricDecrypt
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.AsymmetricDecryptResponse", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).MacSign
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.MacSignResponse", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).MacVerify
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.MacVerifyResponse", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).GenerateRandomBytes
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.GenerateRandomBytesResponse", confidence: high }
+    role: operation
+  - method: cloud.google.com/go/kms/apiv1.(*KeyManagementClient).GetPublicKey
+    arity: 3
+    varargs: true
+    return: { type: "*cloud.google.com/go/kms/apiv1/kmspb.PublicKey", confidence: high }
+    role: output
+hierarchy: {}

--- a/internal/callgraph/contracts/go_google_cloud_kms_test.go
+++ b/internal/callgraph/contracts/go_google_cloud_kms_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGoogleCloudKMSContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role string
+		arity        int
+	}{
+		{"cloud.google.com/go/kms/apiv1.NewKeyManagementClient", "factory", 2},
+		{"cloud.google.com/go/kms/apiv1.(*KeyManagementClient).Encrypt", "operation", 3},
+		{"cloud.google.com/go/kms/apiv1.(*KeyManagementClient).AsymmetricSign", "operation", 3},
+		{"cloud.google.com/go/kms/apiv1.(*KeyManagementClient).GetPublicKey", "output", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "google-cloud-kms" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want google-cloud-kms %s/high", contract, tt.role)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-cloud-google-com-go-kms` (scanoss/crypto-mining-service#205).

## What

- `internal/callgraph/contracts/go/google-cloud-kms.yaml` (13 contracts, `>=0.1.0,<2.0.0`): KeyManagementClient factories and the remote operation terminals (Encrypt/Decrypt, AsymmetricSign/Decrypt, MacSign/Verify, GenerateRandomBytes, CreateCryptoKey/Version, ImportCryptoKeyVersion, GetPublicKey output). Dispositions in the header (pagers, IAM, EKM/Autokey admin clients, generated kmspb types).
- `go_google_cloud_kms_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (62 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#205.

Refs scanoss/crypto-mining-service#205