### PR TITLE
feat(callgraph): add webpki contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/webpki.yaml
+++ b/internal/callgraph/contracts/rust/webpki.yaml
@@ -1,0 +1,76 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: webpki
+  coordinates:
+    - webpki
+  version_range: ">=0.1.1,<0.23.0"
+  description: "TLS certificate path validation (WebPKI)"
+
+# API read at webpki 0.22.4 (src/end_entity.rs) and cross-checked at 0.1.1,
+# 0.18.1 and 0.21.4.
+#
+# WHY A CONTRACT EXISTS HERE. The matrix reported contract_gap=Y and an exported
+# call graph agreed: a consumer calling verify_is_valid_tls_server_cert produced
+# `webpki.EndEntityCert.verify_is_valid_tls_server_cert(?, ?, ?, ?)` with empty
+# parameter_types, which is what an absent contract looks like.
+#
+# KEY SHAPE: methods on EndEntityCert, so the emitted call-site FQN is
+# `webpki.EndEntityCert.<method>` -- two dots, which the Rust key normalisation
+# rewrites to the authored `webpki::EndEntityCert.<method>`. Read off the
+# exported graph rather than assumed.
+#
+# ARITIES READ FROM THE DECLARATIONS (self excluded), end_entity.rs at 0.22.4:
+#   verify_is_valid_tls_server_cert(supported_sig_algs, trust_anchors,
+#                                   intermediate_certs, time)   -> 4
+#   verify_is_valid_tls_client_cert(same shape)                 -> 4
+#   the _ext variants of both                                   -> 4
+#   verify_signature(signature_alg, msg, signature)             -> 3
+#   TryFrom::try_from(cert_der)                                 -> 1
+#
+# THE 0.22 RENAME AFFECTS TYPES, NOT METHODS. 0.22.0 renames the public types --
+# `DNSName` to `DnsName`, `TLSServerTrustAnchors` to `TlsServerTrustAnchors` --
+# and adds the `_ext` variants. The method names are stable across the whole
+# committed 0.1.1-0.22.4 range, so one set of keys covers it; the parameter
+# types below use the post-0.22 spelling, which is the range's newest.
+#
+# THE NAME-MATCHING API IS DELIBERATELY ABSENT, for the same reason it is
+# unmatched by the rules: verify_is_valid_for_dns_name,
+# verify_is_valid_for_at_least_one_dns_name, verify_cert_dns_name,
+# check_name_constraints and DnsNameRef::try_from_ascii compare strings against
+# the certificate's SANs. `verify_is_valid_for_dns_name` reads as a verification
+# and delegates straight to `name::verify_cert_dns_name` (end_entity.rs:179).
+# Typing them here would route hostname matching through the crypto call graph.
+contracts:
+  - method: webpki::EndEntityCert.try_from
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: webpki::EndEntityCert.verify_is_valid_tls_server_cert
+    arity: 4
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[&webpki::SignatureAlgorithm]", "&webpki::TlsServerTrustAnchors", "&[&[u8]]", "webpki::Time"]
+    role: operation
+  - method: webpki::EndEntityCert.verify_is_valid_tls_server_cert_ext
+    arity: 4
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[&webpki::SignatureAlgorithm]", "&webpki::TlsServerTrustAnchors", "&[&[u8]]", "webpki::Time"]
+    role: operation
+  - method: webpki::EndEntityCert.verify_is_valid_tls_client_cert
+    arity: 4
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[&webpki::SignatureAlgorithm]", "&webpki::TlsClientTrustAnchors", "&[&[u8]]", "webpki::Time"]
+    role: operation
+  - method: webpki::EndEntityCert.verify_is_valid_tls_client_cert_ext
+    arity: 4
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&[&webpki::SignatureAlgorithm]", "&webpki::TlsClientTrustAnchors", "&[&[u8]]", "webpki::Time"]
+    role: operation
+  - method: webpki::EndEntityCert.verify_signature
+    arity: 3
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&webpki::SignatureAlgorithm", "&[u8]", "&[u8]"]
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_webpki_test.go
+++ b/internal/callgraph/contracts/rust_webpki_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// webpki's verification methods live on EndEntityCert, so the emitted call-site
+// FQN is `webpki.EndEntityCert.<method>` -- two dots, which the Rust key
+// normalisation rewrites to the authored `webpki::EndEntityCert.<method>`.
+// These are the keys read off an exported call graph.
+func TestLoadEmbeddedRustIncludesWebpkiContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		role   string
+	}{
+		{"webpki::EndEntityCert.try_from", 1, "factory"},
+		{"webpki::EndEntityCert.verify_is_valid_tls_server_cert", 4, "operation"},
+		{"webpki::EndEntityCert.verify_is_valid_tls_server_cert_ext", 4, "operation"},
+		{"webpki::EndEntityCert.verify_is_valid_tls_client_cert", 4, "operation"},
+		{"webpki::EndEntityCert.verify_is_valid_tls_client_cert_ext", 4, "operation"},
+		{"webpki::EndEntityCert.verify_signature", 3, "operation"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		if got[0].SourceLibrary != "webpki" {
+			t.Errorf("%s: library = %q, want webpki", tc.method, got[0].SourceLibrary)
+		}
+		if got[0].Role != tc.role {
+			t.Errorf("%s: role = %q, want %q", tc.method, got[0].Role, tc.role)
+		}
+		if len(got[0].ParameterTypes) != tc.arity {
+			t.Errorf("%s: %d parameter_types, want %d", tc.method, len(got[0].ParameterTypes), tc.arity)
+		}
+	}
+
+	// The dot-joined call-site shape and unknown arity must both resolve.
+	for _, m := range []string{
+		"webpki.EndEntityCert.verify_is_valid_tls_server_cert",
+		"webpki.EndEntityCert.verify_signature",
+	} {
+		if got := kb.ContractsFor(m, -1); len(got) == 0 {
+			t.Errorf("ContractsFor(%q, -1): no contract for the emitted key", m)
+		}
+	}
+}
+
+// The name-matching API is deliberately not contracted. Five entry points begin
+// with `verify_` and carry no cryptography -- they compare strings against the
+// certificate's SANs. `verify_is_valid_for_dns_name` reads as a verification and
+// delegates straight to `name::verify_cert_dns_name` (end_entity.rs:179).
+// Typing them would route hostname matching through the crypto call graph.
+func TestWebpkiDoesNotContractNameMatching(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, m := range []string{
+		"webpki::EndEntityCert.verify_is_valid_for_dns_name",
+		"webpki::EndEntityCert.verify_is_valid_for_at_least_one_dns_name",
+		"webpki::DnsNameRef.try_from_ascii",
+		"webpki::DnsNameRef.try_from_ascii_str",
+		"webpki.verify_cert_dns_name",
+	} {
+		for _, a := range []int{0, 1, 2, -1} {
+			if got := kb.ContractsFor(m, a); len(got) > 0 {
+				t.Errorf("ContractsFor(%q, %d) resolved to %q: this is hostname matching, not cryptography",
+					m, a, got[0].SourceLibrary)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds six Rust knowledge-base contracts for `webpki`: the `EndEntityCert`
constructor and the five verification methods.

## Why

The matrix reported `contract_gap=Y` and an exported call graph agreed — a
consumer calling `verify_is_valid_tls_server_cert` produced

```
webpki.EndEntityCert.verify_is_valid_tls_server_cert(?, ?, ?, ?)
```

with empty `parameter_types`, which is what an absent contract looks like. With
the contracts loaded the same scan exports the fully typed signature.

## Key shape and arities

Methods on `EndEntityCert`, so the emitted FQN is
`webpki.EndEntityCert.<method>` — two dots, which the Rust key normalisation
rewrites to the authored `webpki::EndEntityCert.<method>`. Read off the exported
graph rather than assumed; a test resolves from both spellings and at unknown
arity.

Arities from `end_entity.rs` at 0.22.4, self excluded: the four chain-validation
methods take 4 (`supported_sig_algs`, `trust_anchors`, `intermediate_certs`,
`time`), `verify_signature` takes 3, `TryFrom::try_from` takes 1.

## The 0.22 rename affects types, not methods

0.22.0 renames the public types — `DNSName` → `DnsName`,
`TLSServerTrustAnchors` → `TlsServerTrustAnchors` — and adds the `_ext`
variants. The method names are stable across the whole committed 0.1.1–0.22.4
range, so one set of keys covers it; the parameter types use the post-0.22
spelling, which is the range's newest.

## The name-matching API is deliberately absent

`verify_is_valid_for_dns_name`, `verify_is_valid_for_at_least_one_dns_name`,
`verify_cert_dns_name`, `check_name_constraints` and `DnsNameRef::try_from_ascii`
compare hostnames against the certificate's SANs.
`verify_is_valid_for_dns_name` reads as a verification and delegates straight to
`name::verify_cert_dns_name` (`end_entity.rs:179`). Typing them here would route
hostname matching through the crypto call graph. A test asserts none of them
resolve.

## Tests

Full suite green (0 failures), `make lint` 0 issues at the pinned golangci-lint
version, re-verified after rebasing onto 9 newer commits. Additive only.