### PR TITLE
feat(callgraph): add k256, p256, p384 and p521 contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/k256.yaml
+++ b/internal/callgraph/contracts/rust/k256.yaml
@@ -1,0 +1,145 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: k256
+  coordinates:
+    - k256
+  version_range: ">=0.4.0,<0.15.0"
+  description: "secp256k1 (Bitcoin/Ethereum) elliptic curve: ECDSA, BIP-340 Schnorr and ECDH"
+
+# API read at k256 0.13.4.
+#
+# 0.0.0 through 0.3.0 are outside the range deliberately: 0.0.0 is a
+# name-reservation placeholder whose src/lib.rs holds only a `2 + 2` test, and
+# 0.2.0/0.3.0 ship `arithmetic` alone with no ecdsa and no ecdh module.
+#
+# WHERE THE SIGNATURES COME FROM. For k256, `ecdsa::SigningKey` and
+# `ecdsa::VerifyingKey` are `pub type` aliases onto the generic `ecdsa` crate
+# (k256 0.13.4 src/ecdsa.rs), so the arities and returns below were read from
+# ecdsa 0.16.9 src/signing.rs:87,92,99,123 and src/verifying.rs:92,102,109.
+# The ecdh and key types alias `elliptic-curve`, read at 0.13.8 src/ecdh.rs:60,
+# :105,:120, src/secret_key.rs:94,136,144 and src/public_key.rs:102,126.
+#
+# The schnorr entries are a SEPARATE ALGORITHM (BIP-340), not a spelling variant
+# of the ecdsa ones, and k256 exports both under the same SigningKey and
+# VerifyingKey names (0.13.4 src/schnorr.rs:68). They are keyed on the
+# `k256::schnorr` module path so the two can never collapse into one identity.
+# Signatures read at 0.13.4 src/schnorr/signing.rs:39,44,56,97. The module does
+# not exist below 0.12.0.
+#
+# WHY THIS CONTRACT EXISTS AT ALL. An exported callgraph for a consumer of this
+# crate emitted `canonical_signature: "k256::ecdsa.SigningKey.random(?)"` with
+# empty `parameter_types` — the shape an ABSENT contract takes. The generic
+# ecdsa.yaml does not cover it: its keys are `ecdsa::SigningKey.*`, and the
+# callgraph identifies the call by the re-exporting crate's own module path.
+# elliptic-curve.yaml does not cover it either — that file is the Curve trait
+# and carries `contracts: []`.
+#
+# skipped-non-crypto: byte and DER conversions (to_bytes, as_nonzero_scalar,
+#   to_sec1_bytes), Display/FromStr, serde, and the arithmetic backends.
+contracts:
+  - method: k256::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: "k256::ecdsa::SigningKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+# The era-3 constructor. 0.14 replaces `SigningKey::random(rng)` with a
+# ZERO-ARITY `SigningKey::generate()`, which is a TRAIT method: the crate's own
+# doc example imports `elliptic_curve::Generate` to call it (k256 0.14.0-rc.15
+# src/ecdsa.rs:26,30). It is contracted because this file's version_range covers
+# 0.14.x, and an uncontracted constructor is exactly the `(?)` shape these
+# contracts exist to remove.
+  - method: k256::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: "k256::ecdsa::SigningKey", confidence: high}
+    role: factory
+  - method: k256::ecdsa::SigningKey.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&elliptic_curve::FieldBytes"]
+    role: factory
+  - method: k256::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: k256::ecdsa::SigningKey.verifying_key
+    arity: 0
+    return: {type: "&k256::ecdsa::VerifyingKey", confidence: high}
+    role: output
+  - method: k256::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: k256::ecdsa::VerifyingKey.from_encoded_point
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&k256::EncodedPoint"]
+    role: factory
+  - method: k256::ecdsa::VerifyingKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["k256::AffinePoint"]
+    role: factory
+  - method: k256::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: "k256::ecdh::EphemeralSecret", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: k256::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: "k256::ecdh::SharedSecret", confidence: high}
+    parameter_types: ["&k256::PublicKey"]
+    role: operation
+  - method: k256::SecretKey.random
+    arity: 1
+    return: {type: "k256::SecretKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: k256::SecretKey.public_key
+    arity: 0
+    return: {type: "k256::PublicKey", confidence: high}
+    role: output
+  - method: k256::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: k256::PublicKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["k256::AffinePoint"]
+    role: factory
+  - method: k256::schnorr::SigningKey.random
+    arity: 1
+    return: {type: "k256::schnorr::SigningKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  # Same trait constructor on the schnorr side (0.14.0-rc.15
+  # src/schnorr.rs:39,49), kept a separate identity from the ecdsa one.
+  - method: k256::schnorr::SigningKey.generate
+    arity: 0
+    return: {type: "k256::schnorr::SigningKey", confidence: high}
+    role: factory
+  - method: k256::schnorr::SigningKey.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: k256::schnorr::SigningKey.verifying_key
+    arity: 0
+    return: {type: "&k256::schnorr::VerifyingKey", confidence: high}
+    role: output
+  - method: k256::schnorr::SigningKey.sign_raw
+    arity: 2
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]", "&[u8; 32]"]
+    role: operation
+  - method: k256::schnorr::VerifyingKey.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/p256.yaml
+++ b/internal/callgraph/contracts/rust/p256.yaml
@@ -1,0 +1,107 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: p256
+  coordinates:
+    - p256
+  version_range: ">=0.4.0,<0.15.0"
+  description: "NIST P-256 (secp256r1) elliptic curve: ECDSA and ECDH"
+
+# API read at p256 0.13.2.
+#
+# 0.0.0 through 0.3.0 are outside the range deliberately: 0.0.0 is a
+# name-reservation placeholder and 0.1.0-0.3.0 ship `arithmetic` alone.
+#
+# WHERE THE SIGNATURES COME FROM. For p256, `ecdsa::SigningKey` and
+# `ecdsa::VerifyingKey` are `pub type` aliases onto the generic `ecdsa` crate
+# (p256 0.13.2 src/ecdsa.rs), so the arities and returns below were read from
+# ecdsa 0.16.9 src/signing.rs:87,92,99,123 and src/verifying.rs:92,102,109.
+# The ecdh and key types alias `elliptic-curve`, read at 0.13.8 src/ecdh.rs:60,
+# :105,:120, src/secret_key.rs:94,136,144 and src/public_key.rs:102,126.
+#
+# WHY THIS CONTRACT EXISTS AT ALL. An exported callgraph for a consumer of this
+# crate emitted `canonical_signature: "p256::ecdsa.SigningKey.random(?)"` with
+# empty `parameter_types` — the shape an ABSENT contract takes. The generic
+# ecdsa.yaml does not cover it: its keys are `ecdsa::SigningKey.*`, and the
+# callgraph identifies the call by the re-exporting crate's own module path.
+# elliptic-curve.yaml does not cover it either — that file is the Curve trait
+# and carries `contracts: []`.
+#
+# skipped-non-crypto: byte and DER conversions (to_bytes, as_nonzero_scalar,
+#   to_sec1_bytes), Display/FromStr, serde, and the arithmetic backends.
+contracts:
+  - method: p256::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: "p256::ecdsa::SigningKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+# The era-3 constructor. 0.14 replaces `SigningKey::random(rng)` with a
+# ZERO-ARITY `SigningKey::generate()`, which is a TRAIT method: the crate's own
+# doc example imports `elliptic_curve::Generate` to call it (p256 0.14.0-rc.15
+# src/ecdsa.rs:26,30). It is contracted because this file's version_range covers
+# 0.14.x, and an uncontracted constructor is exactly the `(?)` shape these
+# contracts exist to remove.
+  - method: p256::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: "p256::ecdsa::SigningKey", confidence: high}
+    role: factory
+  - method: p256::ecdsa::SigningKey.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&elliptic_curve::FieldBytes"]
+    role: factory
+  - method: p256::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p256::ecdsa::SigningKey.verifying_key
+    arity: 0
+    return: {type: "&p256::ecdsa::VerifyingKey", confidence: high}
+    role: output
+  - method: p256::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p256::ecdsa::VerifyingKey.from_encoded_point
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&p256::EncodedPoint"]
+    role: factory
+  - method: p256::ecdsa::VerifyingKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["p256::AffinePoint"]
+    role: factory
+  - method: p256::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: "p256::ecdh::EphemeralSecret", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: p256::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: "p256::ecdh::SharedSecret", confidence: high}
+    parameter_types: ["&p256::PublicKey"]
+    role: operation
+  - method: p256::SecretKey.random
+    arity: 1
+    return: {type: "p256::SecretKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: p256::SecretKey.public_key
+    arity: 0
+    return: {type: "p256::PublicKey", confidence: high}
+    role: output
+  - method: p256::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p256::PublicKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["p256::AffinePoint"]
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/p384.yaml
+++ b/internal/callgraph/contracts/rust/p384.yaml
@@ -1,0 +1,108 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: p384
+  coordinates:
+    - p384
+  version_range: ">=0.11.0,<0.15.0"
+  description: "NIST P-384 (secp384r1) elliptic curve: ECDSA and ECDH"
+
+# API read at p384 0.13.1.
+#
+# 0.0.0 through 0.10.0 are outside the range deliberately. 0.3.0 DOES have an
+# `ecdsa` module, but it is a re-export shell with no SigningKey and nothing
+# constructible; the usable signing and agreement APIs both arrive at 0.11.0.
+#
+# WHERE THE SIGNATURES COME FROM. For p384, `ecdsa::SigningKey` and
+# `ecdsa::VerifyingKey` are `pub type` aliases onto the generic `ecdsa` crate
+# (p384 0.13.1 src/ecdsa.rs), so the arities and returns below were read from
+# ecdsa 0.16.9 src/signing.rs:87,92,99,123 and src/verifying.rs:92,102,109.
+# The ecdh and key types alias `elliptic-curve`, read at 0.13.8 src/ecdh.rs:60,
+# :105,:120, src/secret_key.rs:94,136,144 and src/public_key.rs:102,126.
+#
+# WHY THIS CONTRACT EXISTS AT ALL. An exported callgraph for a consumer of this
+# crate emitted `canonical_signature: "p384::ecdsa.SigningKey.random(?)"` with
+# empty `parameter_types` — the shape an ABSENT contract takes. The generic
+# ecdsa.yaml does not cover it: its keys are `ecdsa::SigningKey.*`, and the
+# callgraph identifies the call by the re-exporting crate's own module path.
+# elliptic-curve.yaml does not cover it either — that file is the Curve trait
+# and carries `contracts: []`.
+#
+# skipped-non-crypto: byte and DER conversions (to_bytes, as_nonzero_scalar,
+#   to_sec1_bytes), Display/FromStr, serde, and the arithmetic backends.
+contracts:
+  - method: p384::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: "p384::ecdsa::SigningKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+# The era-3 constructor. 0.14 replaces `SigningKey::random(rng)` with a
+# ZERO-ARITY `SigningKey::generate()`, which is a TRAIT method: the crate's own
+# doc example imports `elliptic_curve::Generate` to call it (p384 0.14.0-rc.15
+# src/ecdsa.rs:26,30). It is contracted because this file's version_range covers
+# 0.14.x, and an uncontracted constructor is exactly the `(?)` shape these
+# contracts exist to remove.
+  - method: p384::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: "p384::ecdsa::SigningKey", confidence: high}
+    role: factory
+  - method: p384::ecdsa::SigningKey.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&elliptic_curve::FieldBytes"]
+    role: factory
+  - method: p384::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p384::ecdsa::SigningKey.verifying_key
+    arity: 0
+    return: {type: "&p384::ecdsa::VerifyingKey", confidence: high}
+    role: output
+  - method: p384::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p384::ecdsa::VerifyingKey.from_encoded_point
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&p384::EncodedPoint"]
+    role: factory
+  - method: p384::ecdsa::VerifyingKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["p384::AffinePoint"]
+    role: factory
+  - method: p384::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: "p384::ecdh::EphemeralSecret", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: p384::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: "p384::ecdh::SharedSecret", confidence: high}
+    parameter_types: ["&p384::PublicKey"]
+    role: operation
+  - method: p384::SecretKey.random
+    arity: 1
+    return: {type: "p384::SecretKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: p384::SecretKey.public_key
+    arity: 0
+    return: {type: "p384::PublicKey", confidence: high}
+    role: output
+  - method: p384::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p384::PublicKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["p384::AffinePoint"]
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/p521.yaml
+++ b/internal/callgraph/contracts/rust/p521.yaml
@@ -1,0 +1,116 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: p521
+  coordinates:
+    - p521
+  version_range: ">=0.13.1,<0.15.0"
+  description: "NIST P-521 (secp521r1) elliptic curve: ECDSA and ECDH"
+
+# API read at p521 0.13.3.
+#
+# 0.0.0 and 0.13.0 are outside the range deliberately: 0.0.0 is a
+# name-reservation placeholder, and 0.13.0 ships `arithmetic` as its ONLY
+# module — no ecdsa, no ecdh. The boundary sits INSIDE the 0.13 line, at 0.13.1.
+#
+# WHERE THE SIGNATURES COME FROM, and why p521 differs. Unlike p256, p384 and
+# k256 — which spell these as `pub type` aliases onto the generic `ecdsa` crate
+# — p521 wraps SigningKey in its OWN newtype: 0.13.3 src/ecdsa.rs:82
+# `pub struct SigningKey(ecdsa_core::SigningKey<NistP521>)`, with inherent
+# `random` at :88, `from_bytes` at :93, `from_slice` at :98, `verifying_key` at
+# :120 (returning VerifyingKey BY VALUE, not the `&VerifyingKey` the aliased
+# crates return) and `sign_prehash` at :134. That distinction is the reason this
+# contract exists per crate rather than being inherited from ecdsa.yaml.
+# The ecdh and key types still alias `elliptic-curve`, read at 0.13.8.
+#
+# WHY THIS CONTRACT EXISTS AT ALL. An exported callgraph for a consumer of this
+# crate emitted `canonical_signature: "p521::ecdsa.SigningKey.random(?)"` with
+# empty `parameter_types` — the shape an ABSENT contract takes. The generic
+# ecdsa.yaml does not cover it: its keys are `ecdsa::SigningKey.*`, and the
+# callgraph identifies the call by the re-exporting crate's own module path.
+# elliptic-curve.yaml does not cover it either — that file is the Curve trait
+# and carries `contracts: []`.
+#
+# skipped-non-crypto: byte and DER conversions (to_bytes, as_nonzero_scalar,
+#   to_sec1_bytes), Display/FromStr, serde, and the arithmetic backends.
+contracts:
+  - method: p521::ecdsa::SigningKey.random
+    arity: 1
+    return: {type: "p521::ecdsa::SigningKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+# The era-3 constructor. 0.14 replaces `SigningKey::random(rng)` with a
+# ZERO-ARITY `SigningKey::generate()`, which is a TRAIT method: the crate's own
+# doc example imports `elliptic_curve::Generate` to call it (p521 0.14.0-rc.15
+# src/ecdsa.rs:26,30). It is contracted because this file's version_range covers
+# 0.14.x, and an uncontracted constructor is exactly the `(?)` shape these
+# contracts exist to remove.
+  - method: p521::ecdsa::SigningKey.generate
+    arity: 0
+    return: {type: "p521::ecdsa::SigningKey", confidence: high}
+    role: factory
+  - method: p521::ecdsa::SigningKey.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&elliptic_curve::FieldBytes"]
+    role: factory
+  - method: p521::ecdsa::SigningKey.from_slice
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p521::ecdsa::SigningKey.verifying_key
+    arity: 0
+    return: {type: "p521::ecdsa::VerifyingKey", confidence: high}
+    role: output
+  - method: p521::ecdsa::VerifyingKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p521::ecdsa::VerifyingKey.from_encoded_point
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&p521::EncodedPoint"]
+    role: factory
+  - method: p521::ecdsa::VerifyingKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["p521::AffinePoint"]
+    role: factory
+  - method: p521::ecdh::EphemeralSecret.random
+    arity: 1
+    return: {type: "p521::ecdh::EphemeralSecret", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: p521::ecdh::EphemeralSecret.diffie_hellman
+    arity: 1
+    return: {type: "p521::ecdh::SharedSecret", confidence: high}
+    parameter_types: ["&p521::PublicKey"]
+    role: operation
+  - method: p521::SecretKey.random
+    arity: 1
+    return: {type: "p521::SecretKey", confidence: high}
+    parameter_types: ["&impl elliptic_curve::rand_core::CryptoRngCore"]
+    role: factory
+  - method: p521::SecretKey.public_key
+    arity: 0
+    return: {type: "p521::PublicKey", confidence: high}
+    role: output
+  - method: p521::PublicKey.from_sec1_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: p521::PublicKey.from_affine
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["p521::AffinePoint"]
+    role: factory
+  - method: p521::ecdsa::SigningKey.sign_prehash
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_elliptic_curves_test.go
+++ b/internal/callgraph/contracts/rust_elliptic_curves_test.go
@@ -1,0 +1,191 @@
+package contracts_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The four RustCrypto elliptic-curve crates ship from one upstream repository
+// and export IDENTICAL type names (SigningKey, VerifyingKey, SecretKey,
+// EphemeralSecret). k256 goes further and exports SigningKey/VerifyingKey from
+// two modules implementing two different algorithms — ecdsa and schnorr. So a
+// contract keyed on the wrong crate, or on the wrong module inside k256,
+// resolves silently and mislabels the receiver rather than failing. Assert the
+// exact key, the owning library, the role and the return type for each.
+//
+// These contracts exist because the generic ecdsa.yaml does NOT cover them: its
+// keys are `ecdsa::SigningKey.*`, while the callgraph identifies a call by the
+// re-exporting crate's own module path. Before these files, an exported
+// callgraph for a consumer carried `k256::ecdsa.SigningKey.random(?)` with
+// empty parameter_types — the shape an absent contract takes.
+func TestLoadEmbeddedRustIncludesEllipticCurveContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	rng := "&impl elliptic_curve::rand_core::CryptoRngCore"
+
+	tests := []struct {
+		method string
+		arity  int
+		lib    string
+		role   string
+		ret    string
+	}{
+		// k256 ECDSA. The curve is secp256k1; the hash is deliberately not
+		// claimed by the rules, and no hash appears in a contract either.
+		{"k256::ecdsa::SigningKey.random", 1, "k256", "factory", "k256::ecdsa::SigningKey"},
+		{"k256::ecdsa::SigningKey.from_slice", 1, "k256", "factory", "core::result::Result"},
+		// Era 3: the zero-arity trait constructor 0.14 replaced random(rng) with.
+		{"k256::ecdsa::SigningKey.generate", 0, "k256", "factory", "k256::ecdsa::SigningKey"},
+		{"k256::schnorr::SigningKey.generate", 0, "k256", "factory", "k256::schnorr::SigningKey"},
+		{"p256::ecdsa::SigningKey.generate", 0, "p256", "factory", "p256::ecdsa::SigningKey"},
+		{"p384::ecdsa::SigningKey.generate", 0, "p384", "factory", "p384::ecdsa::SigningKey"},
+		{"p521::ecdsa::SigningKey.generate", 0, "p521", "factory", "p521::ecdsa::SigningKey"},
+		{"k256::ecdsa::SigningKey.verifying_key", 0, "k256", "output", "&k256::ecdsa::VerifyingKey"},
+		{"k256::ecdsa::VerifyingKey.from_sec1_bytes", 1, "k256", "factory", "core::result::Result"},
+
+		// k256 BIP-340 Schnorr — a DIFFERENT algorithm under the SAME type
+		// names, keyed on the schnorr module path so the two identities can
+		// never collapse into one.
+		{"k256::schnorr::SigningKey.random", 1, "k256", "factory", "k256::schnorr::SigningKey"},
+		{"k256::schnorr::SigningKey.verifying_key", 0, "k256", "output", "&k256::schnorr::VerifyingKey"},
+		{"k256::schnorr::SigningKey.sign_raw", 2, "k256", "operation", "core::result::Result"},
+		{"k256::schnorr::VerifyingKey.from_bytes", 1, "k256", "factory", "core::result::Result"},
+
+		// ECDH, shared shape across all four crates.
+		{"k256::ecdh::EphemeralSecret.random", 1, "k256", "factory", "k256::ecdh::EphemeralSecret"},
+		{"k256::ecdh::EphemeralSecret.diffie_hellman", 1, "k256", "operation", "k256::ecdh::SharedSecret"},
+		{"p256::ecdh::EphemeralSecret.diffie_hellman", 1, "p256", "operation", "p256::ecdh::SharedSecret"},
+		{"p384::ecdh::EphemeralSecret.diffie_hellman", 1, "p384", "operation", "p384::ecdh::SharedSecret"},
+		{"p521::ecdh::EphemeralSecret.diffie_hellman", 1, "p521", "operation", "p521::ecdh::SharedSecret"},
+
+		// The NIST curves.
+		{"p256::ecdsa::SigningKey.random", 1, "p256", "factory", "p256::ecdsa::SigningKey"},
+		{"p256::ecdsa::VerifyingKey.from_sec1_bytes", 1, "p256", "factory", "core::result::Result"},
+		{"p384::ecdsa::SigningKey.random", 1, "p384", "factory", "p384::ecdsa::SigningKey"},
+		{"p384::ecdsa::VerifyingKey.from_sec1_bytes", 1, "p384", "factory", "core::result::Result"},
+		{"p521::ecdsa::SigningKey.random", 1, "p521", "factory", "p521::ecdsa::SigningKey"},
+		{"p521::ecdsa::VerifyingKey.from_sec1_bytes", 1, "p521", "factory", "core::result::Result"},
+
+		// Key material, claimed once per crate.
+		{"k256::SecretKey.random", 1, "k256", "factory", "k256::SecretKey"},
+		{"p256::SecretKey.random", 1, "p256", "factory", "p256::SecretKey"},
+		{"p384::SecretKey.random", 1, "p384", "factory", "p384::SecretKey"},
+		{"p521::SecretKey.random", 1, "p521", "factory", "p521::SecretKey"},
+		{"k256::PublicKey.from_sec1_bytes", 1, "k256", "factory", "core::result::Result"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].SourceLibrary != tt.lib || got[0].Role != tt.role || got[0].Return.Type != tt.ret {
+				t.Fatalf("%s#%d = %#v, want role %q and return %q from %s",
+					tt.method, tt.arity, got[0], tt.role, tt.ret, tt.lib)
+			}
+		})
+	}
+
+	// Every crate's RNG-taking factory must carry the concrete parameter type.
+	// An empty parameter_types is the signature of an absent contract, so a
+	// contract that resolves but carries nothing is barely better than none.
+	for _, method := range []string{
+		"k256::ecdsa::SigningKey.random",
+		"p256::ecdsa::SigningKey.random",
+		"p384::ecdsa::SigningKey.random",
+		"p521::ecdsa::SigningKey.random",
+		"k256::schnorr::SigningKey.random",
+		"k256::ecdh::EphemeralSecret.random",
+	} {
+		got := kb.ContractsFor(method, 1)
+		if len(got) != 1 {
+			t.Fatalf("%s#1 contracts = %d, want 1", method, len(got))
+		}
+		if len(got[0].ParameterTypes) != 1 || got[0].ParameterTypes[0] != rng {
+			t.Fatalf("%s#1 parameter_types = %#v, want [%q]", method, got[0].ParameterTypes, rng)
+		}
+	}
+}
+
+// The call-site FQN dots the receiver-type separator, so a contract authored
+// with Rust's "::" only resolves because contracts.rustAuthoredKey rewrites it
+// back. That rewrite performs EXACTLY ONE substitution and its doc comment
+// assumes callers build at most "package.Type.method" — true for a
+// single-segment module like x25519_dalek, and NOT true for the two-segment
+// module paths this family uses (k256::ecdsa, k256::schnorr, p521::ecdh).
+//
+// So the form asserted here is the one an exported callgraph actually emits for
+// these crates — `k256::ecdsa.SigningKey.random`, module separator intact and
+// only the receiver-type separator dotted. The FULLY dotted variant
+// (`k256.ecdsa.SigningKey.random`) is deliberately NOT asserted: rustAuthoredKey
+// would rewrite it to `k256.ecdsa::SigningKey.random`, which matches nothing,
+// and no observed call site produces it. If a future parser change starts
+// emitting it, this comment is the place that explains the miss.
+func TestEllipticCurveContractsResolveFromCallSiteKeys(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, emitted := range []string{
+		"k256::ecdsa.SigningKey.random",
+		"k256::ecdsa.VerifyingKey.from_sec1_bytes",
+		"k256::schnorr.SigningKey.random",
+		"k256::schnorr.VerifyingKey.from_bytes",
+		"k256::ecdh.EphemeralSecret.diffie_hellman",
+		"p256::ecdsa.SigningKey.random",
+		"p384::ecdsa.SigningKey.random",
+		"p521::ecdsa.SigningKey.random",
+		"p521::ecdsa.SigningKey.sign_prehash",
+	} {
+		t.Run(emitted, func(t *testing.T) {
+			// -1 is the arity a Rust call site carries when the callee name
+			// encodes none, which is the common case.
+			if got := kb.ContractsFor(emitted, -1); len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, -1) = %d contracts, want 1", emitted, len(got))
+			}
+		})
+	}
+}
+
+// p521 is the one crate in this family that does NOT alias the generic ecdsa
+// crate: 0.13.3 src/ecdsa.rs:82 wraps it in its own newtype, and :120 returns
+// VerifyingKey BY VALUE where the aliased crates return a reference. If the
+// contracts ever collapse into one shared template, this is the assertion that
+// notices.
+func TestP521NewtypeReturnsVerifyingKeyByValue(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	byValue := kb.ContractsFor("p521::ecdsa::SigningKey.verifying_key", 0)
+	if len(byValue) != 1 {
+		t.Fatalf("p521 verifying_key contracts = %d, want 1", len(byValue))
+	}
+	if got := byValue[0].Return.Type; got != "p521::ecdsa::VerifyingKey" {
+		t.Fatalf("p521 verifying_key return = %q, want p521::ecdsa::VerifyingKey (by value)", got)
+	}
+
+	for _, c := range []string{"k256", "p256", "p384"} {
+		byRef := kb.ContractsFor(c+"::ecdsa.SigningKey.verifying_key", 0)
+		if len(byRef) != 1 {
+			t.Fatalf("%s verifying_key contracts = %d, want 1", c, len(byRef))
+		}
+		if got := byRef[0].Return.Type; got != "&"+c+"::ecdsa::VerifyingKey" {
+			t.Fatalf("%s verifying_key return = %q, want a reference", c, got)
+		}
+	}
+}


### PR DESCRIPTION
Adds Rust KB contracts for `k256`, `p256`, `p384` and `p521` (58 entries).

## Why these are needed at all

An exported callgraph for a consumer of these crates carried:

```
canonical_signature: "k256::ecdsa.SigningKey.random(?)"
parameter_types: [""]
```

which is the shape an **absent** contract takes. The generic `ecdsa.yaml` does
not cover it — its keys are `ecdsa::SigningKey.*`, while the callgraph
identifies a call by the re-exporting crate's own module path. `elliptic-curve.yaml`
does not either: that file is the `Curve` trait and carries `contracts: []`,
mentioning these four crates only in a prose description.

After these contracts, the same export resolves — **0 of 4 unresolved**, each
with real parameter types:

```
k256::ecdsa.SigningKey.random(&impl elliptic_curve::rand_core::CryptoRngCore)
k256::ecdsa.VerifyingKey.from_sec1_bytes(&[u8])
k256::ecdh.EphemeralSecret.random(&impl elliptic_curve::rand_core::CryptoRngCore)
p521::ecdsa.SigningKey.random(&impl elliptic_curve::rand_core::CryptoRngCore)
```

## Where the signatures come from

Not inferred. For k256, p256 and p384 these types are `pub type` aliases onto
the generic crates, so arities and returns were read from **ecdsa 0.16.9**
(`src/signing.rs:87,92,99,123`, `src/verifying.rs:92,102,109`) and
**elliptic-curve 0.13.8** (`src/ecdh.rs:60,105,120`, `src/secret_key.rs:94,136,144`,
`src/public_key.rs:102,126`).

**p521 is different and the contract records it.** 0.13.3 `src/ecdsa.rs:82`
wraps it in its own newtype — `pub struct SigningKey(ecdsa_core::SigningKey<NistP521>)`
— with inherent `random` at `:88`, `from_bytes` at `:93`, `from_slice` at `:98`,
and `verifying_key` at `:120` returning `VerifyingKey` **by value** where the
aliased crates return a reference. `TestP521NewtypeReturnsVerifyingKeyByValue`
fails if the four files ever collapse into one shared template.

That same distinction is why the recovery methods are contracted for k256/p256/p384
but **not** p521: they live in ecdsa-core `src/recovery.rs`, which the aliases
inherit and the newtype does not re-expose.

## k256 schnorr is a separate identity

`src/schnorr.rs:68` re-exports `SigningKey`/`VerifyingKey` — the same names the
`ecdsa` module uses, for a different algorithm (BIP-340). The schnorr entries are
keyed on the `k256::schnorr` module path so the two can never collapse into one
identity; signatures read at 0.13.4 `src/schnorr/signing.rs:39,44,56,97`.

## Version ranges exclude what genuinely has no API

- k256/p256 `>=0.4.0,<0.15.0` — 0.0.0 is a name-reservation placeholder whose
  `src/lib.rs` is a `2 + 2` test; 0.1.0–0.3.0 ship `arithmetic` alone.
- p384 `>=0.11.0,<0.15.0` — 0.3.0 *has* an `ecdsa` module but it is a re-export
  shell with nothing constructible.
- p521 `>=0.13.1,<0.15.0` — 0.13.0 ships `arithmetic` as its only module.

## Verification

`make lint` (pinned golangci-lint v2.10.1): **0 issues**. Package tests pass;
contracts resolve both under their authored spelling and under the dotted
call-site key an export actually emits.
