### PR TITLE
feat(callgraph): add RustCrypto hashes contracts for the Rust KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Callgraph contract KBs for the RustCrypto hash crates — blake2, md-5, ripemd, sha1, sha2, sha3 and whirlpool — so a consumer's hash call sites resolve to a declared signature instead of an empty one. Each covers both eras in its committed range, including sha2's `Sha512Trunc224`/`Sha512Trunc256` to `Sha512_224`/`Sha512_256` rename, blake2's 0.10 swap of the concrete and generic meanings of `Blake2b`, and the two unrelated upstream projects published under the `sha1` crate name.
+
 ### Changed
 - Live `--export-callgraph` and stitch keep a default `call_chains` sample of 128. Live scans that only need a composed route through dependencies should pass `--export-callgraph-max-chains 8` or `1`. `crypto_entry_points` stays the complete reverse-reach set at any N. The schema 6.x body still includes `call_chains`; `canonical_signature` spelling is unchanged.
 - Default scans skip vendored `shaded/` trees and compiler-generated protobuf stubs (`*_pb2.py`, `*.pb.go`, `*OuterClass.java`, protocol-buffer compiler headers, and the matching JS/TS/C/C++ globs). Authored sources in the same tree stay in the graph. `--no-default-exclusions` disables the new patterns. Protobuf runtimes scanned as the target artifact (`protobuf-java`, `google.protobuf`, `google.golang.org/protobuf`) stay in scope.
 - Call-graph construction uses the same directory exclusions as language detection (`--exclude`, `--no-default-exclusions`, and `--include-tests`). Per-language skip lists are gone, so Cargo `examples/` and `benches/` are inventoried unless `--exclude` says otherwise.
+
 ### Fixed
 - Gradle projects that omit a `group` now produce reachability verdicts from their application Java packages, matching the Maven equivalent for the same sources. Previously the Gradle project name was treated as the only user-code identity, so every finding was reported unreachable.
 - Directories named `example` or `examples` are no longer skipped by default. The old fingerprinting exclusions matched any path segment of those names, so Java `com.example` packages and shipped SDK samples produced no findings and no skip notice. Operators who still want them excluded can pass `--exclude example` / `--exclude examples`.

--- a/internal/callgraph/contracts/rust/blake2.yaml
+++ b/internal/callgraph/contracts/rust/blake2.yaml
@@ -1,0 +1,504 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: blake2
+  coordinates:
+    - blake2
+  version_range: ">=0.1.0,<0.12.0"
+  description: "RustCrypto BLAKE2b and BLAKE2s hashes, across the 0.10 rename"
+
+# Inventory sources: the blake2 crate's own source at 0.9.2 (src/lib.rs:5-47),
+# 0.10.6 (src/lib.rs:8-12,41-57,131) and 0.11.0-rc.6 (src/lib.rs:64,83-94,
+# 112,131-138), and the APIs selected by the scanoss/crypto_rules blake2 rules.
+#
+# THE CONCRETE AND GENERIC MEANINGS OF `Blake2b`/`Blake2s` SWAP AT 0.10.0, and
+# both are declared because both are in the matrix range:
+#
+#   0.1.0 - 0.9.x     `Blake2b`/`Blake2s` ARE the concrete full-width hashers;
+#                     variable output is `VarBlake2b`/`VarBlake2s`
+#   0.10.0 - 0.11.0   `Blake2b512`/`Blake2s256` are the concrete aliases,
+#                     `Blake2b<OutSize>` is generic, and the Var types are
+#                     renamed `Blake2bVar`/`Blake2sVar` (removed again at
+#                     0.11.0-rc.3)
+#
+# The generic `Blake2b<OutSize>` resolves to the same `blake2::Blake2b` key as
+# the pre-0.10 concrete type: the parser strips the type argument from the
+# callee identity, exactly as it does for the block-modes families' inner
+# cipher. The KB therefore gives that key the hasher's method surface and lets
+# the RULE decide what output size, if any, to report — which is why the
+# crypto_rules generic rules report no size while the concrete ones do.
+#
+# THE VARIABLE-OUTPUT CONSTRUCTORS TAKE THEIR LENGTH IN BYTES.
+# `Blake2bVar::new(10)` is an 80-bit digest (0.10.6 src/lib.rs:41-48), so the
+# parameter is declared with argument_byte_length rather than
+# argument_bit_length; the latter counts the length of key material a value
+# carries and would report 10 as if it were already bits.
+#
+# The range starts at 0.1.0 rather than the matrix's 0.0.0: that release is a
+# name reservation with an empty src/lib.rs.
+#
+# NOT DECLARED, deliberately: the keyed types `Blake2bMac512`, `Blake2sMac256`,
+# `Blake2bMac`, `Blake2sMac` and the 0.9-era `new_varkey` constructor. Those are
+# a MAC primitive rather than a digest and are out of this family's scope; the
+# gap is recorded on the family's issue rather than filled silently here.
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: blake2::Blake2b512.new
+    arity: 0
+    return: {type: blake2::Blake2b512, confidence: high}
+    role: factory
+  - method: blake2::Blake2b512.default
+    arity: 0
+    return: {type: blake2::Blake2b512, confidence: high}
+    role: factory
+  - method: blake2::Blake2b512.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2b512, confidence: high}
+    role: factory
+  - method: blake2::Blake2b512.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b512.chain_update
+    arity: 1
+    return: {type: blake2::Blake2b512, confidence: high}
+    role: operation
+  - method: blake2::Blake2b512.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b512.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2b512.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b512.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b512.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b512.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b512.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b256.new
+    arity: 0
+    return: {type: blake2::Blake2b256, confidence: high}
+    role: factory
+  - method: blake2::Blake2b256.default
+    arity: 0
+    return: {type: blake2::Blake2b256, confidence: high}
+    role: factory
+  - method: blake2::Blake2b256.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2b256, confidence: high}
+    role: factory
+  - method: blake2::Blake2b256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b256.chain_update
+    arity: 1
+    return: {type: blake2::Blake2b256, confidence: high}
+    role: operation
+  - method: blake2::Blake2b256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2b256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b256.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b128.new
+    arity: 0
+    return: {type: blake2::Blake2b128, confidence: high}
+    role: factory
+  - method: blake2::Blake2b128.default
+    arity: 0
+    return: {type: blake2::Blake2b128, confidence: high}
+    role: factory
+  - method: blake2::Blake2b128.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2b128, confidence: high}
+    role: factory
+  - method: blake2::Blake2b128.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b128.chain_update
+    arity: 1
+    return: {type: blake2::Blake2b128, confidence: high}
+    role: operation
+  - method: blake2::Blake2b128.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b128.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2b128.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b128.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b128.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b128.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b128.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s256.new
+    arity: 0
+    return: {type: blake2::Blake2s256, confidence: high}
+    role: factory
+  - method: blake2::Blake2s256.default
+    arity: 0
+    return: {type: blake2::Blake2s256, confidence: high}
+    role: factory
+  - method: blake2::Blake2s256.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2s256, confidence: high}
+    role: factory
+  - method: blake2::Blake2s256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s256.chain_update
+    arity: 1
+    return: {type: blake2::Blake2s256, confidence: high}
+    role: operation
+  - method: blake2::Blake2s256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2s256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s256.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s128.new
+    arity: 0
+    return: {type: blake2::Blake2s128, confidence: high}
+    role: factory
+  - method: blake2::Blake2s128.default
+    arity: 0
+    return: {type: blake2::Blake2s128, confidence: high}
+    role: factory
+  - method: blake2::Blake2s128.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2s128, confidence: high}
+    role: factory
+  - method: blake2::Blake2s128.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s128.chain_update
+    arity: 1
+    return: {type: blake2::Blake2s128, confidence: high}
+    role: operation
+  - method: blake2::Blake2s128.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s128.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2s128.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s128.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s128.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s128.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s128.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b.new
+    arity: 0
+    return: {type: blake2::Blake2b, confidence: high}
+    role: factory
+  - method: blake2::Blake2b.default
+    arity: 0
+    return: {type: blake2::Blake2b, confidence: high}
+    role: factory
+  - method: blake2::Blake2b.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2b, confidence: high}
+    role: factory
+  - method: blake2::Blake2b.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b.chain_update
+    arity: 1
+    return: {type: blake2::Blake2b, confidence: high}
+    role: operation
+  - method: blake2::Blake2b.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2b.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2b.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2b.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s.new
+    arity: 0
+    return: {type: blake2::Blake2s, confidence: high}
+    role: factory
+  - method: blake2::Blake2s.default
+    arity: 0
+    return: {type: blake2::Blake2s, confidence: high}
+    role: factory
+  - method: blake2::Blake2s.new_with_prefix
+    arity: 1
+    return: {type: blake2::Blake2s, confidence: high}
+    role: factory
+  - method: blake2::Blake2s.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s.chain_update
+    arity: 1
+    return: {type: blake2::Blake2s, confidence: high}
+    role: operation
+  - method: blake2::Blake2s.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2s.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2s.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2s.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: blake2::Blake2bVar.new
+    arity: 1
+    return: {type: blake2::Blake2bVar, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: output_size
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_byte_length}
+  - method: blake2::Blake2bVar.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2bVar.finalize_variable
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2bVar.finalize_variable_reset
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2bVar.finalize_boxed
+    arity: 0
+    return: {type: alloc::boxed::Box, confidence: high}
+    role: output
+  - method: blake2::Blake2bVar.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2sVar.new
+    arity: 1
+    return: {type: blake2::Blake2sVar, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: output_size
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_byte_length}
+  - method: blake2::Blake2sVar.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::Blake2sVar.finalize_variable
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2sVar.finalize_variable_reset
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::Blake2sVar.finalize_boxed
+    arity: 0
+    return: {type: alloc::boxed::Box, confidence: high}
+    role: output
+  - method: blake2::Blake2sVar.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::VarBlake2b.new
+    arity: 1
+    return: {type: blake2::VarBlake2b, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: output_size
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_byte_length}
+  - method: blake2::VarBlake2b.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::VarBlake2b.finalize_variable
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::VarBlake2b.finalize_variable_reset
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::VarBlake2b.finalize_boxed
+    arity: 0
+    return: {type: alloc::boxed::Box, confidence: high}
+    role: output
+  - method: blake2::VarBlake2b.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::VarBlake2s.new
+    arity: 1
+    return: {type: blake2::VarBlake2s, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: output_size
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_byte_length}
+  - method: blake2::VarBlake2s.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: blake2::VarBlake2s.finalize_variable
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::VarBlake2s.finalize_variable_reset
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: blake2::VarBlake2s.finalize_boxed
+    arity: 0
+    return: {type: alloc::boxed::Box, confidence: high}
+    role: output
+  - method: blake2::VarBlake2s.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/md-5.yaml
+++ b/internal/callgraph/contracts/rust/md-5.yaml
@@ -1,0 +1,79 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: md-5
+  coordinates:
+    - md-5
+  version_range: ">=0.4.0,<0.12.0"
+  description: "RustCrypto MD5 hash"
+
+# Inventory sources: the md-5 crate's own source at 0.4.0, 0.10.6 and 0.11.0,
+# and the APIs selected by the scanoss/crypto_rules md-5 rules.
+#
+# THE METHOD KEYS USE THE LIB NAME `md5`, NOT THE CRATE NAME `md-5`
+# (Cargo.toml `[lib] name = "md5"`, read at 0.10.6 and 0.11.0). The callgraph
+# sees the module path a consumer writes, which is `md5::Md5`. An unrelated
+# crate is published as `md5` and spells its API `md5::compute` and
+# `md5::Context`; neither appears below, so this KB cannot give identity to
+# that crate's calls.
+#
+# `input`/`result` are the pre-digest-0.9 spelling of `update`/`finalize`
+# (0.4.0 depends on digest 0.5). Both eras are in the matrix range, so both are
+# declared; method plus arity keeps them apart.
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: md5::Md5.new
+    arity: 0
+    return: {type: md5::Md5, confidence: high}
+    role: factory
+  - method: md5::Md5.default
+    arity: 0
+    return: {type: md5::Md5, confidence: high}
+    role: factory
+  - method: md5::Md5.new_with_prefix
+    arity: 1
+    return: {type: md5::Md5, confidence: high}
+    role: factory
+  - method: md5::Md5.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: md5::Md5.chain_update
+    arity: 1
+    return: {type: md5::Md5, confidence: high}
+    role: operation
+  - method: md5::Md5.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: md5::Md5.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: md5::Md5.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: md5::Md5.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: md5::Md5.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: md5::Md5.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: md5::Md5.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/ripemd.yaml
+++ b/internal/callgraph/contracts/rust/ripemd.yaml
@@ -1,0 +1,192 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: ripemd
+  coordinates:
+    - ripemd
+  version_range: ">=0.1.0,<0.3.0"
+  description: "RustCrypto RIPEMD hashes"
+
+# Inventory sources: the ripemd crate's own source at 0.1.0, 0.1.2 and 0.2.0,
+# and the APIs selected by the scanoss/crypto_rules ripemd rules.
+#
+# Four variants, each its own concrete type. `Ripemd128` does not exist before
+# 0.1.2 (0.1.0 src/lib.rs:157-159 declares only 160/256/320); declaring it for
+# the whole range is safe because a call that does not exist cannot be made,
+# and the alternative — two YAMLs split at 0.1.2 — would collide on the three
+# shared types.
+#
+# The range starts at 0.1.0 rather than the matrix's 0.0.0: that release is a
+# name reservation with an empty src/lib.rs and no API to contract.
+#
+# No `input`/`result` era here: the crate's first release already depends on
+# digest 0.10.
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: ripemd::Ripemd128.new
+    arity: 0
+    return: {type: ripemd::Ripemd128, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd128.default
+    arity: 0
+    return: {type: ripemd::Ripemd128, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd128.new_with_prefix
+    arity: 1
+    return: {type: ripemd::Ripemd128, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd128.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd128.chain_update
+    arity: 1
+    return: {type: ripemd::Ripemd128, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd128.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd128.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: ripemd::Ripemd128.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd128.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd128.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd160.new
+    arity: 0
+    return: {type: ripemd::Ripemd160, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd160.default
+    arity: 0
+    return: {type: ripemd::Ripemd160, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd160.new_with_prefix
+    arity: 1
+    return: {type: ripemd::Ripemd160, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd160.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd160.chain_update
+    arity: 1
+    return: {type: ripemd::Ripemd160, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd160.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd160.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: ripemd::Ripemd160.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd160.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd160.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd256.new
+    arity: 0
+    return: {type: ripemd::Ripemd256, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd256.default
+    arity: 0
+    return: {type: ripemd::Ripemd256, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd256.new_with_prefix
+    arity: 1
+    return: {type: ripemd::Ripemd256, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd256.chain_update
+    arity: 1
+    return: {type: ripemd::Ripemd256, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: ripemd::Ripemd256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd320.new
+    arity: 0
+    return: {type: ripemd::Ripemd320, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd320.default
+    arity: 0
+    return: {type: ripemd::Ripemd320, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd320.new_with_prefix
+    arity: 1
+    return: {type: ripemd::Ripemd320, confidence: high}
+    role: factory
+  - method: ripemd::Ripemd320.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd320.chain_update
+    arity: 1
+    return: {type: ripemd::Ripemd320, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd320.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd320.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: ripemd::Ripemd320.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: ripemd::Ripemd320.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: ripemd::Ripemd320.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/sha1.yaml
+++ b/internal/callgraph/contracts/rust/sha1.yaml
@@ -1,0 +1,104 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: sha1
+  coordinates:
+    - sha1
+  version_range: ">=0.0.1,<0.12.0"
+  description: "SHA-1 hash, both upstream lineages published under the sha1 crate name"
+
+# Inventory sources: the sha1 crate's own source at 0.0.1, 0.6.0, 0.6.1, 0.10.6
+# and 0.11.0, and the APIs selected by the scanoss/crypto_rules sha1 rules.
+#
+# THE CRATE NAME SPANS TWO UNRELATED UPSTREAM PROJECTS and this KB covers both,
+# because a consumer writes the same `sha1::Sha1` path either way:
+#
+#   0.0.1 - 0.6.1    the minimal sha1 crate (mitsuhiko). `new` (0.0.1
+#                    src/lib.rs:52), `update`, the ARITY-0 instance `digest`
+#                    (:164), `hexdigest` (:171) and `output` (:140). Its own
+#                    src/lib.rs:10-12 at 0.6.1 records the handover: the old
+#                    code moved to `sha1_smol`, and the crate name beyond 0.6
+#                    is RustCrypto's.
+#   0.10.0 - 0.11.0  RustCrypto: the digest 0.10 trait surface, including the
+#                    ARITY-1 static one-shot `digest`.
+#
+# `digest` therefore appears TWICE with different arities. That is exactly what
+# the arity key is for: ContractsFor matches method plus arity, so the instance
+# formatter and the static one-shot never resolve to each other. Splitting the
+# lineages into two YAMLs would instead collide on `new`, which both declare
+# with arity 0 and the same return.
+#
+# `sha1_smol` is a different crate and a different PURL: not covered here.
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: sha1::Sha1.new
+    arity: 0
+    return: {type: sha1::Sha1, confidence: high}
+    role: factory
+  - method: sha1::Sha1.default
+    arity: 0
+    return: {type: sha1::Sha1, confidence: high}
+    role: factory
+  - method: sha1::Sha1.new_with_prefix
+    arity: 1
+    return: {type: sha1::Sha1, confidence: high}
+    role: factory
+  - method: sha1::Sha1.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha1::Sha1.chain_update
+    arity: 1
+    return: {type: sha1::Sha1, confidence: high}
+    role: operation
+  - method: sha1::Sha1.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha1::Sha1.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha1::Sha1.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha1::Sha1.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha1::Sha1.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha1::Sha1.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha1::Sha1.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha1::Sha1.from
+    arity: 1
+    return: {type: sha1::Sha1, confidence: high}
+    role: factory
+  - method: sha1::Sha1.digest
+    arity: 0
+    return: {type: sha1::Digest, confidence: high}
+    role: output
+  - method: sha1::Sha1.hexdigest
+    arity: 0
+    return: {type: alloc::string::String, confidence: high}
+    role: output
+  - method: sha1::Sha1.output
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/sha2.yaml
+++ b/internal/callgraph/contracts/rust/sha2.yaml
@@ -1,0 +1,518 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: sha2
+  coordinates:
+    - sha2
+  version_range: ">=0.1.0,<0.12.0"
+  description: "RustCrypto SHA-2 hashes, plus the vendored rust-crypto module path of the 0.1 line"
+
+# Inventory sources: the sha2 crate's own source at 0.1.0, 0.2.0, 0.9.9, 0.10.9
+# and 0.11.0, and the APIs selected by the scanoss/crypto_rules sha2 rules.
+#
+# THE TRUNCATED PAIR WAS RENAMED INSIDE THE RANGE. `Sha512Trunc224` and
+# `Sha512Trunc256` are the 0.2.0-0.9.9 spelling (0.9.9 src/lib.rs:76);
+# `Sha512_224` and `Sha512_256` are the same algorithms from 0.10.0 onwards
+# (0.11.0 src/lib.rs:60,66). All four are declared: a consumer pinned to either
+# side of the rename must resolve, and the two spellings never co-exist in one
+# release, so nothing is ambiguous.
+#
+# THE 0.1.x LINE IS A DIFFERENT UPSTREAM PROJECT. It vendors DaGenix's
+# rust-crypto and re-exports it as a module, so the consumer path is
+# `sha2::sha2::Sha256` (0.1.0 lib.rs:8-9) and the trait is rust-crypto's own
+# `Digest`, whose `result(&mut out)` takes the output buffer as an ARGUMENT and
+# returns nothing — unlike digest's arity-0 `result`, which returns the digest.
+# Those contracts are declared under the doubled module path with the arity that
+# lineage actually uses, so neither lineage can answer for the other.
+#
+# `input`/`result` on the single-module path are the pre-digest-0.9 spelling of
+# `update`/`finalize` (0.2.0 depends on digest 0.2, 0.9.9 on digest 0.9).
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: sha2::Sha224.new
+    arity: 0
+    return: {type: sha2::Sha224, confidence: high}
+    role: factory
+  - method: sha2::Sha224.default
+    arity: 0
+    return: {type: sha2::Sha224, confidence: high}
+    role: factory
+  - method: sha2::Sha224.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha224, confidence: high}
+    role: factory
+  - method: sha2::Sha224.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha224.chain_update
+    arity: 1
+    return: {type: sha2::Sha224, confidence: high}
+    role: operation
+  - method: sha2::Sha224.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha224.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha224.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha224.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha224.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha224.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha256.new
+    arity: 0
+    return: {type: sha2::Sha256, confidence: high}
+    role: factory
+  - method: sha2::Sha256.default
+    arity: 0
+    return: {type: sha2::Sha256, confidence: high}
+    role: factory
+  - method: sha2::Sha256.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha256, confidence: high}
+    role: factory
+  - method: sha2::Sha256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha256.chain_update
+    arity: 1
+    return: {type: sha2::Sha256, confidence: high}
+    role: operation
+  - method: sha2::Sha256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha256.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha384.new
+    arity: 0
+    return: {type: sha2::Sha384, confidence: high}
+    role: factory
+  - method: sha2::Sha384.default
+    arity: 0
+    return: {type: sha2::Sha384, confidence: high}
+    role: factory
+  - method: sha2::Sha384.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha384, confidence: high}
+    role: factory
+  - method: sha2::Sha384.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha384.chain_update
+    arity: 1
+    return: {type: sha2::Sha384, confidence: high}
+    role: operation
+  - method: sha2::Sha384.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha384.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha384.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha384.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha384.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha384.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha384.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512.new
+    arity: 0
+    return: {type: sha2::Sha512, confidence: high}
+    role: factory
+  - method: sha2::Sha512.default
+    arity: 0
+    return: {type: sha2::Sha512, confidence: high}
+    role: factory
+  - method: sha2::Sha512.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha512, confidence: high}
+    role: factory
+  - method: sha2::Sha512.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512.chain_update
+    arity: 1
+    return: {type: sha2::Sha512, confidence: high}
+    role: operation
+  - method: sha2::Sha512.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha512.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc224.new
+    arity: 0
+    return: {type: sha2::Sha512Trunc224, confidence: high}
+    role: factory
+  - method: sha2::Sha512Trunc224.default
+    arity: 0
+    return: {type: sha2::Sha512Trunc224, confidence: high}
+    role: factory
+  - method: sha2::Sha512Trunc224.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha512Trunc224, confidence: high}
+    role: factory
+  - method: sha2::Sha512Trunc224.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc224.chain_update
+    arity: 1
+    return: {type: sha2::Sha512Trunc224, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc224.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc224.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc224.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc224.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc224.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc224.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc256.new
+    arity: 0
+    return: {type: sha2::Sha512Trunc256, confidence: high}
+    role: factory
+  - method: sha2::Sha512Trunc256.default
+    arity: 0
+    return: {type: sha2::Sha512Trunc256, confidence: high}
+    role: factory
+  - method: sha2::Sha512Trunc256.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha512Trunc256, confidence: high}
+    role: factory
+  - method: sha2::Sha512Trunc256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc256.chain_update
+    arity: 1
+    return: {type: sha2::Sha512Trunc256, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512Trunc256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512Trunc256.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_224.new
+    arity: 0
+    return: {type: sha2::Sha512_224, confidence: high}
+    role: factory
+  - method: sha2::Sha512_224.default
+    arity: 0
+    return: {type: sha2::Sha512_224, confidence: high}
+    role: factory
+  - method: sha2::Sha512_224.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha512_224, confidence: high}
+    role: factory
+  - method: sha2::Sha512_224.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512_224.chain_update
+    arity: 1
+    return: {type: sha2::Sha512_224, confidence: high}
+    role: operation
+  - method: sha2::Sha512_224.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_224.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha512_224.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512_224.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_224.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512_224.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_256.new
+    arity: 0
+    return: {type: sha2::Sha512_256, confidence: high}
+    role: factory
+  - method: sha2::Sha512_256.default
+    arity: 0
+    return: {type: sha2::Sha512_256, confidence: high}
+    role: factory
+  - method: sha2::Sha512_256.new_with_prefix
+    arity: 1
+    return: {type: sha2::Sha512_256, confidence: high}
+    role: factory
+  - method: sha2::Sha512_256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512_256.chain_update
+    arity: 1
+    return: {type: sha2::Sha512_256, confidence: high}
+    role: operation
+  - method: sha2::Sha512_256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::Sha512_256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512_256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::Sha512_256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::Sha512_256.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha224.new
+    arity: 0
+    return: {type: sha2::sha2::Sha224, confidence: high}
+    role: factory
+  - method: sha2::sha2::Sha224.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha224.result
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha256.new
+    arity: 0
+    return: {type: sha2::sha2::Sha256, confidence: high}
+    role: factory
+  - method: sha2::sha2::Sha256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha256.result
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha384.new
+    arity: 0
+    return: {type: sha2::sha2::Sha384, confidence: high}
+    role: factory
+  - method: sha2::sha2::Sha384.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha384.result
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha384.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha512.new
+    arity: 0
+    return: {type: sha2::sha2::Sha512, confidence: high}
+    role: factory
+  - method: sha2::sha2::Sha512.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha512.result
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha512.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha512Trunc224.new
+    arity: 0
+    return: {type: sha2::sha2::Sha512Trunc224, confidence: high}
+    role: factory
+  - method: sha2::sha2::Sha512Trunc224.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha512Trunc224.result
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha512Trunc224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha512Trunc256.new
+    arity: 0
+    return: {type: sha2::sha2::Sha512Trunc256, confidence: high}
+    role: factory
+  - method: sha2::sha2::Sha512Trunc256.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha2::sha2::Sha512Trunc256.result
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha2::sha2::Sha512Trunc256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/sha3.yaml
+++ b/internal/callgraph/contracts/rust/sha3.yaml
@@ -1,0 +1,533 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: sha3
+  coordinates:
+    - sha3
+  version_range: ">=0.1.0,<0.13.0"
+  description: "RustCrypto SHA-3, Keccak and the SHAKE/cSHAKE/TurboSHAKE extendable-output functions"
+
+# Inventory sources: the sha3 crate's own source at 0.10.9 (src/lib.rs:142-209,
+# src/macros.rs), 0.11.0 (src/lib.rs:51-65) and 0.12.0 (src/lib.rs:145-165,
+# README.md:15), and the APIs selected by the scanoss/crypto_rules sha3 rules.
+#
+# The range starts at 0.1.0 rather than the matrix's 0.0.0: that release is a
+# name reservation with an empty src/lib.rs.
+#
+# SHAKE LEFT THE CRATE AT 0.12.0. The newest stable release in the matrix range
+# moved SHAKE128/SHAKE256 to a separate `shake` crate (0.12.0 README.md:15), so
+# the XOF contracts below apply to 0.1.0-0.11.0 only. They stay in this KB
+# because every one of those releases is in range; `pkg:cargo/shake` is NOT in
+# this family's PURL set and gets no contracts here.
+#
+# The XOF surface is not the Digest trait: the terminal read is `finalize_xof`,
+# which returns a reader, and `finalize_boxed(n)` takes the output length in
+# BYTES — declared with argument_byte_length so a consumer derives bits rather
+# than reporting bytes as bits.
+#
+# cSHAKE and TurboSHAKE are reachable only through their Core types. The
+# user-facing `CShake128` is `CoreWrapper<CShake128Core>` (0.10.9
+# src/macros.rs, impl_cshake) with no constructor of its own, so
+# `CShake128Core.new(customization)` is the only factory.
+#   needs-follow-up: `digest::CoreWrapper.from_core`, which lifts a Core into
+#     the user-facing type, belongs to the digest KB. That YAML deliberately
+#     declares no contracts (it is a trait-only crate), so the wrapper call
+#     itself has no identity today and only the inner Core call does. Adding it
+#     is a change to a shared KB rather than to this family.
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: sha3::Sha3_224.new
+    arity: 0
+    return: {type: sha3::Sha3_224, confidence: high}
+    role: factory
+  - method: sha3::Sha3_224.default
+    arity: 0
+    return: {type: sha3::Sha3_224, confidence: high}
+    role: factory
+  - method: sha3::Sha3_224.new_with_prefix
+    arity: 1
+    return: {type: sha3::Sha3_224, confidence: high}
+    role: factory
+  - method: sha3::Sha3_224.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_224.chain_update
+    arity: 1
+    return: {type: sha3::Sha3_224, confidence: high}
+    role: operation
+  - method: sha3::Sha3_224.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_224.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Sha3_224.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_224.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_256.new
+    arity: 0
+    return: {type: sha3::Sha3_256, confidence: high}
+    role: factory
+  - method: sha3::Sha3_256.default
+    arity: 0
+    return: {type: sha3::Sha3_256, confidence: high}
+    role: factory
+  - method: sha3::Sha3_256.new_with_prefix
+    arity: 1
+    return: {type: sha3::Sha3_256, confidence: high}
+    role: factory
+  - method: sha3::Sha3_256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_256.chain_update
+    arity: 1
+    return: {type: sha3::Sha3_256, confidence: high}
+    role: operation
+  - method: sha3::Sha3_256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Sha3_256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_384.new
+    arity: 0
+    return: {type: sha3::Sha3_384, confidence: high}
+    role: factory
+  - method: sha3::Sha3_384.default
+    arity: 0
+    return: {type: sha3::Sha3_384, confidence: high}
+    role: factory
+  - method: sha3::Sha3_384.new_with_prefix
+    arity: 1
+    return: {type: sha3::Sha3_384, confidence: high}
+    role: factory
+  - method: sha3::Sha3_384.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_384.chain_update
+    arity: 1
+    return: {type: sha3::Sha3_384, confidence: high}
+    role: operation
+  - method: sha3::Sha3_384.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_384.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Sha3_384.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_384.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_384.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_512.new
+    arity: 0
+    return: {type: sha3::Sha3_512, confidence: high}
+    role: factory
+  - method: sha3::Sha3_512.default
+    arity: 0
+    return: {type: sha3::Sha3_512, confidence: high}
+    role: factory
+  - method: sha3::Sha3_512.new_with_prefix
+    arity: 1
+    return: {type: sha3::Sha3_512, confidence: high}
+    role: factory
+  - method: sha3::Sha3_512.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_512.chain_update
+    arity: 1
+    return: {type: sha3::Sha3_512, confidence: high}
+    role: operation
+  - method: sha3::Sha3_512.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_512.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Sha3_512.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Sha3_512.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Sha3_512.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak224.new
+    arity: 0
+    return: {type: sha3::Keccak224, confidence: high}
+    role: factory
+  - method: sha3::Keccak224.default
+    arity: 0
+    return: {type: sha3::Keccak224, confidence: high}
+    role: factory
+  - method: sha3::Keccak224.new_with_prefix
+    arity: 1
+    return: {type: sha3::Keccak224, confidence: high}
+    role: factory
+  - method: sha3::Keccak224.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak224.chain_update
+    arity: 1
+    return: {type: sha3::Keccak224, confidence: high}
+    role: operation
+  - method: sha3::Keccak224.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak224.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Keccak224.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak224.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak224.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak256.new
+    arity: 0
+    return: {type: sha3::Keccak256, confidence: high}
+    role: factory
+  - method: sha3::Keccak256.default
+    arity: 0
+    return: {type: sha3::Keccak256, confidence: high}
+    role: factory
+  - method: sha3::Keccak256.new_with_prefix
+    arity: 1
+    return: {type: sha3::Keccak256, confidence: high}
+    role: factory
+  - method: sha3::Keccak256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak256.chain_update
+    arity: 1
+    return: {type: sha3::Keccak256, confidence: high}
+    role: operation
+  - method: sha3::Keccak256.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak256.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Keccak256.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak256.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak256.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak384.new
+    arity: 0
+    return: {type: sha3::Keccak384, confidence: high}
+    role: factory
+  - method: sha3::Keccak384.default
+    arity: 0
+    return: {type: sha3::Keccak384, confidence: high}
+    role: factory
+  - method: sha3::Keccak384.new_with_prefix
+    arity: 1
+    return: {type: sha3::Keccak384, confidence: high}
+    role: factory
+  - method: sha3::Keccak384.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak384.chain_update
+    arity: 1
+    return: {type: sha3::Keccak384, confidence: high}
+    role: operation
+  - method: sha3::Keccak384.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak384.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Keccak384.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak384.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak384.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak512.new
+    arity: 0
+    return: {type: sha3::Keccak512, confidence: high}
+    role: factory
+  - method: sha3::Keccak512.default
+    arity: 0
+    return: {type: sha3::Keccak512, confidence: high}
+    role: factory
+  - method: sha3::Keccak512.new_with_prefix
+    arity: 1
+    return: {type: sha3::Keccak512, confidence: high}
+    role: factory
+  - method: sha3::Keccak512.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak512.chain_update
+    arity: 1
+    return: {type: sha3::Keccak512, confidence: high}
+    role: operation
+  - method: sha3::Keccak512.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak512.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Keccak512.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak512.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak512.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak256Full.new
+    arity: 0
+    return: {type: sha3::Keccak256Full, confidence: high}
+    role: factory
+  - method: sha3::Keccak256Full.default
+    arity: 0
+    return: {type: sha3::Keccak256Full, confidence: high}
+    role: factory
+  - method: sha3::Keccak256Full.new_with_prefix
+    arity: 1
+    return: {type: sha3::Keccak256Full, confidence: high}
+    role: factory
+  - method: sha3::Keccak256Full.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak256Full.chain_update
+    arity: 1
+    return: {type: sha3::Keccak256Full, confidence: high}
+    role: operation
+  - method: sha3::Keccak256Full.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak256Full.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Keccak256Full.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Keccak256Full.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Keccak256Full.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: sha3::Shake128.new
+    arity: 0
+    return: {type: sha3::Shake128, confidence: high}
+    role: factory
+  - method: sha3::Shake128.default
+    arity: 0
+    return: {type: sha3::Shake128, confidence: high}
+    role: factory
+  - method: sha3::Shake128.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Shake128.chain
+    arity: 1
+    return: {type: sha3::Shake128, confidence: high}
+    role: operation
+  - method: sha3::Shake128.finalize_xof
+    arity: 0
+    return: {type: sha3::Shake128Reader, confidence: high}
+    role: output
+  - method: sha3::Shake128.finalize_xof_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Shake128.finalize_boxed
+    arity: 1
+    return: {type: alloc::boxed::Box, confidence: high}
+    role: output
+    parameters:
+      - index: 0
+        name: output_size
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_byte_length}
+  - method: sha3::Shake128Reader.read
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Shake256.new
+    arity: 0
+    return: {type: sha3::Shake256, confidence: high}
+    role: factory
+  - method: sha3::Shake256.default
+    arity: 0
+    return: {type: sha3::Shake256, confidence: high}
+    role: factory
+  - method: sha3::Shake256.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: sha3::Shake256.chain
+    arity: 1
+    return: {type: sha3::Shake256, confidence: high}
+    role: operation
+  - method: sha3::Shake256.finalize_xof
+    arity: 0
+    return: {type: sha3::Shake256Reader, confidence: high}
+    role: output
+  - method: sha3::Shake256.finalize_xof_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::Shake256.finalize_boxed
+    arity: 1
+    return: {type: alloc::boxed::Box, confidence: high}
+    role: output
+    parameters:
+      - index: 0
+        name: output_size
+        role: metadata-contributing
+        contributes: {property: digestLength, derivation: argument_byte_length}
+  - method: sha3::Shake256Reader.read
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: sha3::TurboShake128Core.new
+    arity: 1
+    return: {type: sha3::TurboShake128Core, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: domain_separation
+        role: metadata-contributing
+        contributes: {property: parameterSet, derivation: argument_value}
+  - method: sha3::TurboShake256Core.new
+    arity: 1
+    return: {type: sha3::TurboShake256Core, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: domain_separation
+        role: metadata-contributing
+        contributes: {property: parameterSet, derivation: argument_value}
+  - method: sha3::CShake128Core.new
+    arity: 1
+    return: {type: sha3::CShake128Core, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: customization
+        role: metadata-contributing
+        contributes: {property: contextLength, derivation: argument_bit_length}
+  - method: sha3::CShake128Core.new_with_function_name
+    arity: 2
+    return: {type: sha3::CShake128Core, confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: customization
+        role: metadata-contributing
+        contributes: {property: contextLength, derivation: argument_bit_length}
+  - method: sha3::CShake256Core.new
+    arity: 1
+    return: {type: sha3::CShake256Core, confidence: high}
+    role: factory
+    parameters:
+      - index: 0
+        name: customization
+        role: metadata-contributing
+        contributes: {property: contextLength, derivation: argument_bit_length}
+  - method: sha3::CShake256Core.new_with_function_name
+    arity: 2
+    return: {type: sha3::CShake256Core, confidence: high}
+    role: factory
+    parameters:
+      - index: 1
+        name: customization
+        role: metadata-contributing
+        contributes: {property: contextLength, derivation: argument_bit_length}
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust/whirlpool.yaml
+++ b/internal/callgraph/contracts/rust/whirlpool.yaml
@@ -1,0 +1,71 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: whirlpool
+  coordinates:
+    - whirlpool
+  version_range: ">=0.1.0,<0.12.0"
+  description: "RustCrypto Whirlpool hash"
+
+# Inventory sources: the whirlpool crate's own source at 0.1.0, 0.10.4 and
+# 0.11.0, and the APIs selected by the scanoss/crypto_rules whirlpool rules.
+#
+# One hasher, fixed 512-bit output, unchanged constructor across the range.
+# `input`/`result` are the pre-digest-0.9 spelling of `update`/`finalize`.
+
+# Dispositions for the rest of the public surface:
+#   skipped-non-crypto: the `digest` re-export and the `Digest`/`Output`/
+#     `OutputSizeUser` trait re-exports, which carry no identity of their own.
+#   skipped-unsupported: the `*Core` block-level types and the `block_api`
+#     module of the 0.11 line, which consumers do not construct directly.
+contracts:
+  - method: whirlpool::Whirlpool.new
+    arity: 0
+    return: {type: whirlpool::Whirlpool, confidence: high}
+    role: factory
+  - method: whirlpool::Whirlpool.default
+    arity: 0
+    return: {type: whirlpool::Whirlpool, confidence: high}
+    role: factory
+  - method: whirlpool::Whirlpool.new_with_prefix
+    arity: 1
+    return: {type: whirlpool::Whirlpool, confidence: high}
+    role: factory
+  - method: whirlpool::Whirlpool.update
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: whirlpool::Whirlpool.chain_update
+    arity: 1
+    return: {type: whirlpool::Whirlpool, confidence: high}
+    role: operation
+  - method: whirlpool::Whirlpool.finalize
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: whirlpool::Whirlpool.finalize_into
+    arity: 1
+    return: {type: void, confidence: high}
+    role: output
+  - method: whirlpool::Whirlpool.finalize_reset
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: whirlpool::Whirlpool.reset
+    arity: 0
+    return: {type: void, confidence: high}
+    role: operation
+  - method: whirlpool::Whirlpool.digest
+    arity: 1
+    return: {type: digest::Output, confidence: high}
+    role: output
+  - method: whirlpool::Whirlpool.input
+    arity: 1
+    return: {type: void, confidence: high}
+    role: operation
+  - method: whirlpool::Whirlpool.result
+    arity: 0
+    return: {type: digest::Output, confidence: high}
+    role: output
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_rustcrypto_hashes_test.go
+++ b/internal/callgraph/contracts/rust_rustcrypto_hashes_test.go
@@ -1,0 +1,164 @@
+package contracts_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The RustCrypto hashes family carries three shapes that a KB keyed on one
+// spelling silently fails to resolve: a type RENAMED inside the committed
+// range (sha2's truncated pair), a crate name shared by TWO UNRELATED UPSTREAM
+// PROJECTS (sha1, and sha2's 0.1 line), and the same method name appearing in
+// both lineages with DIFFERENT ARITIES.
+func TestLoadEmbeddedRustIncludesHashesContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		lib    string
+		role   string
+	}{
+		// One hasher per crate, constructor and one-shot.
+		{"md5::Md5.new", 0, "md-5", "factory"},
+		{"md5::Md5.digest", 1, "md-5", "output"},
+		{"whirlpool::Whirlpool.new", 0, "whirlpool", "factory"},
+		{"sha1::Sha1.new", 0, "sha1", "factory"},
+		// All four RIPEMD variants, including the one that appears at 0.1.2.
+		{"ripemd::Ripemd128.new", 0, "ripemd", "factory"},
+		{"ripemd::Ripemd160.new", 0, "ripemd", "factory"},
+		{"ripemd::Ripemd256.new", 0, "ripemd", "factory"},
+		{"ripemd::Ripemd320.new", 0, "ripemd", "factory"},
+		// SHA-2, both sides of the 0.10.0 rename of the truncated pair.
+		{"sha2::Sha224.new", 0, "sha2", "factory"},
+		{"sha2::Sha512Trunc256.new", 0, "sha2", "factory"},
+		{"sha2::Sha512_256.new", 0, "sha2", "factory"},
+		{"sha2::Sha512_224.new", 0, "sha2", "factory"},
+		// SHA-3, Keccak, and the XOF surface, which is not the Digest trait.
+		{"sha3::Sha3_256.new", 0, "sha3", "factory"},
+		{"sha3::Keccak256.new", 0, "sha3", "factory"},
+		{"sha3::Keccak256Full.new", 0, "sha3", "factory"},
+		{"sha3::Shake128.default", 0, "sha3", "factory"},
+		{"sha3::Shake128.finalize_xof", 0, "sha3", "output"},
+		{"sha3::Shake128Reader.read", 1, "sha3", "output"},
+		{"sha3::CShake128Core.new", 1, "sha3", "factory"},
+		{"sha3::CShake128Core.new_with_function_name", 2, "sha3", "factory"},
+		{"sha3::TurboShake128Core.new", 1, "sha3", "factory"},
+		// BLAKE2, both sides of the 0.10.0 concrete/generic swap.
+		{"blake2::Blake2b512.new", 0, "blake2", "factory"},
+		{"blake2::Blake2b.new", 0, "blake2", "factory"},
+		{"blake2::Blake2b128.new", 0, "blake2", "factory"},
+		{"blake2::Blake2bVar.new", 1, "blake2", "factory"},
+		{"blake2::VarBlake2b.new", 1, "blake2", "factory"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].SourceLibrary != tt.lib || got[0].Role != tt.role {
+				t.Fatalf("%s#%d = %#v, want role %q from %s", tt.method, tt.arity, got[0], tt.role, tt.lib)
+			}
+		})
+	}
+}
+
+// `sha1::Sha1.digest` exists in BOTH lineages published under that crate name:
+// the pre-0.7 crate's arity-0 instance formatter, and RustCrypto's arity-1
+// static one-shot. The arity is the only thing that separates them, so assert
+// each resolves to its own shape and neither is answered by the other's.
+func TestSha1LineagesDoNotBlurTogether(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, tc := range []struct {
+		arity      int
+		wantReturn string
+	}{
+		{0, "sha1::Digest"},   // pre-0.7: m.digest() formats the result
+		{1, "digest::Output"}, // RustCrypto: Sha1::digest(data) hashes
+	} {
+		got := kb.ContractsFor("sha1::Sha1.digest", tc.arity)
+		if len(got) != 1 {
+			t.Fatalf("sha1::Sha1.digest#%d contracts = %d, want 1", tc.arity, len(got))
+		}
+		if got[0].Return.Type != tc.wantReturn {
+			t.Fatalf("sha1::Sha1.digest#%d return = %q, want %q", tc.arity, got[0].Return.Type, tc.wantReturn)
+		}
+	}
+
+	// The pre-0.7 one-shot constructor exists only in that lineage.
+	if got := kb.ContractsFor("sha1::Sha1.from", 1); len(got) != 1 {
+		t.Fatalf("sha1::Sha1.from#1 contracts = %d, want 1", len(got))
+	}
+}
+
+// sha2 0.1.x vendors DaGenix's rust-crypto and re-exports it as a module, so
+// the consumer path is doubled (`sha2::sha2::Sha256`) and its `result` takes
+// the output buffer as an argument instead of returning the digest. Neither
+// lineage may answer for the other.
+func TestSha2VendoredModulePathIsSeparate(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	got := kb.ContractsFor("sha2::sha2::Sha256.new", 0)
+	if len(got) != 1 || got[0].Return.Type != "sha2::sha2::Sha256" {
+		t.Fatalf("sha2::sha2::Sha256.new#0 = %#v, want the vendored module path", got)
+	}
+
+	// digest's `result` returns the digest at arity 0; rust-crypto's writes
+	// into an out-parameter at arity 1.
+	if got := kb.ContractsFor("sha2::Sha256.result", 0); len(got) != 1 || got[0].Return.Type != "digest::Output" {
+		t.Fatalf("sha2::Sha256.result#0 = %#v, want digest::Output", got)
+	}
+	if got := kb.ContractsFor("sha2::sha2::Sha256.result", 1); len(got) != 1 || got[0].Return.Type != "void" {
+		t.Fatalf("sha2::sha2::Sha256.result#1 = %#v, want void", got)
+	}
+}
+
+// The variable-output constructors take their length in BYTES, so the
+// parameter must derive bits rather than report the byte count as bits.
+func TestVariableOutputLengthIsDerivedFromBytes(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, method := range []string{
+		"blake2::Blake2bVar.new",
+		"blake2::VarBlake2s.new",
+	} {
+		got := kb.ContractsFor(method, 1)
+		if len(got) != 1 {
+			t.Fatalf("%s#1 contracts = %d, want 1", method, len(got))
+		}
+		params := got[0].Parameters
+		if len(params) != 1 || params[0].Contributes == nil {
+			t.Fatalf("%s#1 parameters = %#v, want one contributing parameter", method, params)
+		}
+		if params[0].Contributes.Property != "digestLength" ||
+			params[0].Contributes.Derivation != string(contracts.DerivationArgumentByteLength) {
+			t.Fatalf("%s#1 contributes = %#v, want digestLength from argument_byte_length",
+				method, params[0].Contributes)
+		}
+	}
+}


### PR DESCRIPTION
Adds callgraph contract KBs for the seven RustCrypto hash crates: blake2, md-5,
ripemd, sha1, sha2, sha3, whirlpool.

**Why they are needed at all.** No Rust contract on `main` mentions any of these
types — a full search over `internal/callgraph/contracts/rust/` for the thirteen
representative type names returns nothing — and both `digest.yaml` and
`crypto-common.yaml` declare `contracts: []` because they are trait-only crates.
Every hash call site therefore resolved to an empty signature before this.

**Three shapes needed care, each pinned by a test in
`rust_rustcrypto_hashes_test.go`:**

- `sha2`'s truncated pair was renamed at 0.10.0. Both `Sha512Trunc224`/
  `Sha512Trunc256` and `Sha512_224`/`Sha512_256` are declared; the two spellings
  never co-exist in one release, so nothing is ambiguous.
- The `sha1` crate name spans two unrelated upstream projects. The pre-0.7 crate
  and RustCrypto's both spell the constructor `Sha1::new()`, and both declare
  `digest` — at arity 0 (an instance formatter returning `sha1::Digest`) and
  arity 1 (the static one-shot) respectively. Method plus arity keeps them apart;
  splitting the lineages into two YAMLs would instead collide on `new`.
- `sha2` 0.1.x vendors DaGenix's rust-crypto and re-exports it, so the consumer
  path is doubled (`sha2::sha2::Sha256`) and that lineage's `result` writes into
  an out-parameter instead of returning the digest. Declared under the doubled
  path at the arity it actually uses.

**Parameter derivation.** The variable-output constructors take their length in
BYTES — `Blake2bVar::new(10)` is an 80-bit digest — so they use
`argument_byte_length` rather than `argument_bit_length`, which counts the length
of key material a value carries and would report 10 as if it were bits. Same for
`Shake128::finalize_boxed`.

Version ranges start at each crate's first release with an API; the
name-reservation releases (blake2 0.0.0, ripemd 0.0.0, sha3 0.0.0) have an empty
`src/lib.rs` and nothing to contract.

The keyed BLAKE2 MAC types are deliberately not declared — a MAC primitive, not
a digest — and that gap is recorded with the coverage work rather than filled
silently here.

**Validated end to end on a workstation:** 42 mined cargo components all serve
`info_code: READY`, every row carries a graph fragment and an explicit
annotation, and a consumer entry point resolves through the reachability
`/dep-tree` endpoint to findings in five mined dependencies.