### PR TITLE
feat(callgraph): add totp-rs contract knowledge base

### DIFF
--- a/internal/callgraph/contracts/rust/totp-rs.yaml
+++ b/internal/callgraph/contracts/rust/totp-rs.yaml
@@ -1,0 +1,115 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: totp-rs
+  coordinates:
+    - totp-rs
+    - totp_rs
+  version_range: ">=0.2.0,<6.0.0"
+  description: "RFC 6238 TOTP (time-based one-time passwords)"
+
+# API read at totp-rs 5.7.2 (src/lib.rs, src/secret.rs) and cross-checked at
+# 0.2.0, 0.7.4, 1.4.0 and 3.1.0 from the committed sample.
+#
+# WHY A CONTRACT EXISTS HERE. The matrix reported contract_gap=Y. An exported
+# call graph over the crate's own examples agreed: the matched operations came
+# back as `totp_rs.TOTP.generate` and `totp_rs.Secret.generate_secret` with no
+# typing behind them, which is what an absent contract looks like.
+#
+# KEY SHAPE, READ OFF THE EXPORTED GRAPH RATHER THAN ASSUMED. The call-site FQNs
+# are `totp_rs.TOTP.<method>` and `totp_rs.Secret.<method>` -- two dots, which
+# the Rust key normalisation rewrites to the authored `totp_rs::<Type>.<method>`.
+#
+# NOTE THAT `Secret` IS NOT MODULE-QUALIFIED. It is DEFINED in src/secret.rs but
+# `pub use`-exported from the crate root (lib.rs:62), and consumers write
+# `totp_rs::Secret::generate_secret()`. The emitted key follows the consumer's
+# spelling, not the defining module, so `totp_rs::secret.Secret.generate_secret`
+# would never resolve. TOTP and Algorithm are declared in lib.rs and so have no
+# such distinction.
+#
+# TWO ARITIES FOR `new`, AND THIS IS NOT AN OVERSIGHT. Cargo.toml declares
+# `default = []`, so the DEFAULT build takes the `cfg(not(feature = "otpauth"))`
+# branch at lib.rs:379, which is arity 5. The seven-argument form at lib.rs:284
+# -- the one that carries `issuer` and `account_name` -- exists only under the
+# `otpauth` feature. Contracts are indexed as `<method>#<arity>`, so both are
+# distinct keys and both are recorded. Recording only one would leave every
+# consumer on the other feature setting unresolved.
+#
+# THE URI AND SECRET-ENCODING METHODS ARE LISTED AS FACTORIES, NOT OPERATIONS,
+# and this is deliberate in both directions. The rules do NOT match `from_url`,
+# `from_url_unchecked` or `from_rfc6238`, because parsing an otpauth:// URI is
+# not cryptography. But a consumer that writes
+# `TOTP::from_url(uri)?.generate_current()` needs the receiver typed or the
+# `generate_current` call has nothing to resolve against. A contract entry
+# carries no crypto assertion -- only a return type, an arity and a role -- so
+# typing them here aids reachability without claiming they are crypto. The rules
+# remain the thing that decides what is reported, and
+# uri-and-secret-parsing-negative.rs pins that they stay silent.
+#
+# `generate_secret` IS the one member of that neighbourhood the rules do match:
+# it fills 20 bytes from the RNG (secret.rs:171) and returns Secret::Raw. Twenty
+# bytes is 160 bits, which is the length RFC 6238 recommends and is what the
+# rule records as materialSize. It sits behind the `gen_secret` feature.
+contracts:
+  - method: totp_rs::TOTP.new
+    arity: 5
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["totp_rs::Algorithm", "usize", "u8", "u64", "alloc::vec::Vec<u8>"]
+    role: factory
+  - method: totp_rs::TOTP.new
+    arity: 7
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["totp_rs::Algorithm", "usize", "u8", "u64", "alloc::vec::Vec<u8>", "core::option::Option<alloc::string::String>", "alloc::string::String"]
+    role: factory
+  - method: totp_rs::TOTP.new_unchecked
+    arity: 7
+    return: { type: totp_rs::TOTP, confidence: high }
+    parameter_types: ["totp_rs::Algorithm", "usize", "u8", "u64", "alloc::vec::Vec<u8>", "core::option::Option<alloc::string::String>", "alloc::string::String"]
+    role: factory
+  - method: totp_rs::TOTP.from_url
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["S"]
+    role: factory
+  - method: totp_rs::TOTP.from_url_unchecked
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["S"]
+    role: factory
+  - method: totp_rs::TOTP.from_rfc6238
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["totp_rs::Rfc6238"]
+    role: factory
+  - method: totp_rs::TOTP.generate
+    arity: 1
+    return: { type: alloc::string::String, confidence: high }
+    parameter_types: ["u64"]
+    role: operation
+  - method: totp_rs::TOTP.generate_current
+    arity: 0
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: []
+    role: operation
+  - method: totp_rs::TOTP.sign
+    arity: 1
+    return: { type: alloc::vec::Vec<u8>, confidence: high }
+    parameter_types: ["u64"]
+    role: operation
+  - method: totp_rs::TOTP.check
+    arity: 2
+    return: { type: bool, confidence: high }
+    parameter_types: ["&str", "u64"]
+    role: operation
+  - method: totp_rs::TOTP.check_current
+    arity: 1
+    return: { type: core::result::Result, confidence: high }
+    parameter_types: ["&str"]
+    role: operation
+  - method: totp_rs::Secret.generate_secret
+    arity: 0
+    return: { type: totp_rs::Secret, confidence: high }
+    parameter_types: []
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/rust_totp_contract_wiring_test.go
+++ b/internal/callgraph/rust_totp_contract_wiring_test.go
@@ -1,0 +1,182 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package callgraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// The totp-rs KB is keyed on what the Rust parser emits, so a parser identity
+// change must fail here rather than leaving the contracts silently unmatched.
+//
+// Two things in this family are easy to get wrong and both are pinned below.
+// `Secret` is declared in src/secret.rs but re-exported from the crate root, so
+// the emitted key follows the consumer's spelling (`totp_rs.Secret.*`) and not
+// the defining module. And `TOTP::new` has two arities: Cargo.toml declares
+// `default = []`, so the five-argument form is the default build and the
+// seven-argument one requires the `otpauth` feature.
+func TestTotpContractsResolveParsedCallIdentities(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	dir := t.TempDir()
+	src := `use totp_rs::{Algorithm, Secret, TOTP};
+
+// default build: no features, so new/5
+fn build_default(secret: Vec<u8>) {
+    let totp = TOTP::new(Algorithm::SHA1, 6, 1, 30, secret).unwrap();
+    let _code = totp.generate(1_700_000_000);
+    let _mac = totp.sign(1_700_000_000);
+}
+
+// otpauth feature: new/7
+fn build_otpauth(secret: Vec<u8>, issuer: Option<String>, account: String) {
+    let totp = TOTP::new(Algorithm::SHA256, 8, 1, 30, secret, issuer, account).unwrap();
+    let _now = totp.generate_current().unwrap();
+    let _ok = totp.check_current("123456").unwrap();
+}
+
+fn verify(totp: &TOTP) {
+    let _ok = totp.check("123456", 1_700_000_000);
+}
+
+// The receiver a URI factory returns must be typed, or the operation chained
+// off it has nothing to resolve against.
+fn from_uri(uri: &str) {
+    let totp = TOTP::from_url(uri).unwrap();
+    let _code = totp.generate_current().unwrap();
+}
+
+fn mint() {
+    let _s = Secret::generate_secret();
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.rs"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	analyses, err := NewRustParser().ParseDirectory(dir, "app")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Call-site keys join segments with "."; the KB keeps Rust's "::" module
+	// separator and ContractsFor bridges the two.
+	type want struct {
+		role  string
+		arity int
+	}
+	wants := map[string][]want{
+		"totp_rs.TOTP.new":               {{"factory", 5}, {"factory", 7}},
+		"totp_rs.TOTP.from_url":          {{"factory", 1}},
+		"totp_rs.TOTP.generate":          {{"operation", 1}},
+		"totp_rs.TOTP.generate_current":  {{"operation", 0}},
+		"totp_rs.TOTP.sign":              {{"operation", 1}},
+		"totp_rs.TOTP.check":             {{"operation", 2}},
+		"totp_rs.TOTP.check_current":     {{"operation", 1}},
+		"totp_rs.Secret.generate_secret": {{"factory", 0}},
+	}
+	seen := map[string]map[int]bool{}
+
+	for _, analysis := range analyses {
+		for _, fn := range analysis.Functions {
+			for _, call := range fn.Calls {
+				callee := call.Callee
+				method, _ := splitMethodArity(&callee)
+				expected, ok := wants[method]
+				if !ok {
+					continue
+				}
+				arity := len(call.Arguments)
+				got := kb.ContractsFor(method, arity)
+				if len(got) != 1 {
+					t.Fatalf("ContractsFor(%q, %d) = %d, want exactly one contract",
+						method, arity, len(got))
+				}
+				if got[0].SourceLibrary != "totp-rs" {
+					t.Fatalf("contract for %q came from %q, want totp-rs", method, got[0].SourceLibrary)
+				}
+				var matched bool
+				for _, w := range expected {
+					if w.arity != arity {
+						continue
+					}
+					matched = true
+					if got[0].Role != w.role {
+						t.Fatalf("contract for %q/%d role = %q, want %q", method, arity, got[0].Role, w.role)
+					}
+				}
+				if !matched {
+					t.Fatalf("parsed %q at arity %d, which the KB does not declare", method, arity)
+				}
+				if seen[method] == nil {
+					seen[method] = map[int]bool{}
+				}
+				seen[method][arity] = true
+			}
+		}
+	}
+
+	for method, expected := range wants {
+		for _, w := range expected {
+			if !seen[method][w.arity] {
+				t.Fatalf("parsed calls did not cover %q at arity %d; seen = %v", method, w.arity, seen)
+			}
+		}
+	}
+}
+
+// `Secret` is declared in src/secret.rs and `pub use`-exported from lib.rs.
+// Keying the contract on the defining module would compile, load and silently
+// never resolve, so assert the module-qualified spelling is NOT what answers.
+func TestTotpSecretContractFollowsConsumerSpellingNotDefiningModule(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	if got := kb.ContractsFor("totp_rs.Secret.generate_secret", 0); len(got) != 1 {
+		t.Fatalf("ContractsFor(consumer spelling) = %d, want exactly one", len(got))
+	}
+	if got := kb.ContractsFor("totp_rs.secret.Secret.generate_secret", 0); len(got) != 0 {
+		t.Fatalf("the defining-module spelling resolved (%d contracts); the KB must "+
+			"follow the crate-root re-export the consumer writes", len(got))
+	}
+}
+
+// The URI and RFC factories are typed so a chained operation resolves, and they
+// must stay factories: a contract carries no crypto assertion, and promoting
+// them to operations is the nearest way this file could start claiming that
+// parsing an otpauth:// URI is cryptography.
+func TestTotpUriFactoriesAreNotOperations(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, method := range []string{
+		"totp_rs.TOTP.from_url",
+		"totp_rs.TOTP.from_url_unchecked",
+		"totp_rs.TOTP.from_rfc6238",
+	} {
+		got := kb.ContractsFor(method, 1)
+		if len(got) != 1 {
+			t.Fatalf("ContractsFor(%q, 1) = %d, want exactly one", method, len(got))
+		}
+		if got[0].Role != "factory" {
+			t.Errorf("%s: role = %q, want factory", method, got[0].Role)
+		}
+	}
+}


### PR DESCRIPTION
Types the `totp-rs` (RFC 6238 TOTP) call sites so a consumer's OTP operations resolve instead of coming back as `totp_rs.TOTP.generate(?, ?)` with an empty parameter list.

Keys were read off an **exported call graph**, not assumed.

## Two things in this crate are easy to key wrongly

**`Secret` is not module-qualified.** It is declared in `src/secret.rs` but `pub use`-exported from the crate root, and consumers write `totp_rs::Secret::generate_secret()`. The emitted key follows the consumer's spelling, so keying on the defining module (`totp_rs::secret.Secret.generate_secret`) would load cleanly and then silently never resolve. `TestTotpSecretContractFollowsConsumerSpellingNotDefiningModule` asserts the module-qualified spelling does **not** answer.

**`TOTP::new` has two arities.** `Cargo.toml` declares `default = []`, so the five-argument form is the default build; the seven-argument one (carrying `issuer` and `account_name`) requires the `otpauth` feature. Contracts are indexed as `<method>#<arity>`, so both are distinct keys and both are recorded. Recording only one would leave every consumer on the other feature setting unresolved — and a real published consumer uses the five-argument form.

## The URI factories are typed, and stay factories

`from_url`, `from_url_unchecked` and `from_rfc6238` are listed so that a consumer writing `TOTP::from_url(uri)?.generate_current()` has a typed receiver for the chained operation to resolve against.

They are deliberately `role: factory`. A contract entry carries no crypto assertion — only a return type, an arity and a role — so typing them aids reachability without claiming they are cryptography. `TestTotpUriFactoriesAreNotOperations` pins that, because promoting them to `operation` is the nearest way this file could start claiming that parsing an `otpauth://` URI is a cryptographic act.

## Verification

The three wiring tests were **mutation-checked**, not just run: keying `Secret` on its defining module and deleting the `new/5` entry each make them fail, so the assertions are not vacuous.

Full suite unchanged from `origin/main`: 31 packages ok, 0 failures.