### PR TITLE
fix(scanner): resolve ambiguous file extensions by reading content

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -596,8 +596,8 @@ func reportOccurrenceKeyEcosystems(target string, report *entities.InterimReport
 
 // isCFamilyLanguage reports whether a detected language is C or C++, which
 // share headers and translation units and so share the anchor treatment above.
-func isCFamilyLanguage(language string) bool {
-	switch language {
+func isCFamilyLanguage(lang string) bool {
+	switch lang {
 	case "c", "c++", ecosystemCPP:
 		return true
 	default:

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -568,9 +568,15 @@ func reportOccurrenceKeyEcosystems(target string, report *entities.InterimReport
 	}
 	add := func(hint string) { addEcosystem(ecosystemFromHint(target, hint)) }
 	for _, finding := range report.Findings {
-		if finding.Language == "c" {
+		if isCFamilyLanguage(finding.Language) {
 			// A C-language detector can report both C and C++ sources. Build both
 			// source-only parsers so a C++ header never hides .c anchors.
+			//
+			// This tests the C FAMILY, not the literal "c". Once the detector
+			// reads file content it can tell a C++ header from a C one and
+			// reports "c++" for the former, which used to fall through to the
+			// generic branch below and add only cpp -- dropping the c ecosystem
+			// this branch exists to guarantee.
 			addEcosystem("c")
 			if isCPPSource(finding.FilePath) || cppHeaderTarget(target) {
 				addEcosystem(ecosystemCPP)
@@ -586,6 +592,17 @@ func reportOccurrenceKeyEcosystems(target string, report *entities.InterimReport
 		add(ecosystemFromHints(target, languageHints))
 	}
 	return ecosystems
+}
+
+// isCFamilyLanguage reports whether a detected language is C or C++, which
+// share headers and translation units and so share the anchor treatment above.
+func isCFamilyLanguage(language string) bool {
+	switch language {
+	case "c", "c++", ecosystemCPP:
+		return true
+	default:
+		return false
+	}
 }
 
 func occurrenceAnchorKey(ecosystem, functionID string) string {

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -748,3 +748,35 @@ func TestParseDuration(t *testing.T) {
 		})
 	}
 }
+
+// A C++ header must contribute BOTH the c and cpp ecosystems. The comment in
+// reportOccurrenceKeyEcosystems says why: a C-language detector reports C and
+// C++ sources alike, and both source-only parsers have to be built so a C++
+// header never hides .c anchors.
+//
+// This is a characterisation test. It is written to pass BEFORE the language
+// detector learned to tell a C++ header from a C one, so that the change to the
+// detector cannot quietly drop the c ecosystem on the way past.
+func TestReportOccurrenceKeyEcosystems_CPPHeaderKeepsBothEcosystems(t *testing.T) {
+	dir := t.TempDir()
+	headerPath := filepath.Join(dir, "crypto.h")
+	if err := os.WriteFile(headerPath, []byte("#pragma once\nnamespace Botan { class HashFunction {}; }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both spellings the detector can produce for that same file.
+	for _, language := range []string{"c", "c++"} {
+		report := &entities.InterimReport{
+			Findings: []entities.Finding{{FilePath: headerPath, Language: language}},
+		}
+		got := reportOccurrenceKeyEcosystems(headerPath, report, nil)
+
+		seen := map[string]bool{}
+		for _, ecosystem := range got {
+			seen[ecosystem] = true
+		}
+		if !seen["c"] || !seen[ecosystemCPP] {
+			t.Fatalf("language %q on a C++ header produced %v, want both c and cpp", language, got)
+		}
+	}
+}

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -19,6 +19,7 @@ package semgrep
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -434,9 +435,53 @@ func normalizeRelatedCryptoKeySizes(asset *entities.CryptographicAsset) {
 }
 
 // detectLanguage uses go-enry to detect the programming language of a file.
+// languageSniffLimit bounds how much of a file is read to disambiguate its
+// language. enry's content strategies look at shebangs, keywords and a handful
+// of declarations, all of which appear far earlier than this; the cap is here so
+// a large generated source costs a bounded read rather than its whole size.
+const languageSniffLimit = 16 * 1024
+
+// sniffLanguageContent returns the leading bytes of filePath, or nil if it
+// cannot be read. nil is a valid input to enry -- it just falls back to deciding
+// on the name alone.
+func sniffLanguageContent(filePath string) []byte {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	buf := make([]byte, languageSniffLimit)
+	n, err := io.ReadFull(file, buf)
+	if n == 0 && err != nil {
+		return nil
+	}
+	return buf[:n]
+}
+
+// detectLanguage names the language of filePath.
+//
+// THE CONTENT IS NOT OPTIONAL. Several extensions map to more than one language,
+// and asked by name alone enry answers with the wrong one:
+//
+//	.rs   -> XML        (candidates: RenderScript, Rust, XML)
+//	.cs   -> Smalltalk  (candidates: C#, Smalltalk)
+//	.php  -> Hack       (candidates: Hack, PHP)
+//
+// Those are silent: the wrong name is stored on every finding and travels
+// downstream, and "xml" is not a language any consumer here recognises, so it
+// simply contributes nothing rather than failing loudly. Passing the file's
+// leading bytes resolves all three, and also lets a C++ header be told from a C
+// one -- which is why reportOccurrenceKeyEcosystems now tests the C family
+// rather than the literal "c".
+//
+// When the file cannot be read the name-only answer is still returned, because a
+// possibly-wrong language is more useful here than none.
 func detectLanguage(filePath string) string {
+	content := sniffLanguageContent(filePath)
+
 	// Try detection by filename first
-	lang := enry.GetLanguage(filepath.Base(filePath), nil)
+	lang := enry.GetLanguage(filepath.Base(filePath), content)
 	if lang != "" {
 		return strings.ToLower(lang)
 	}
@@ -444,7 +489,7 @@ func detectLanguage(filePath string) string {
 	// Try detection by file extension
 	ext := filepath.Ext(filePath)
 	if ext != "" {
-		lang = enry.GetLanguage(fmt.Sprintf("file%s", ext), nil)
+		lang = enry.GetLanguage(fmt.Sprintf("file%s", ext), content)
 		if lang != "" {
 			return strings.ToLower(lang)
 		}

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -449,11 +449,16 @@ func sniffLanguageContent(filePath string) []byte {
 	if err != nil {
 		return nil
 	}
-	defer file.Close()
 
 	buf := make([]byte, languageSniffLimit)
-	n, err := io.ReadFull(file, buf)
-	if n == 0 && err != nil {
+	n, readErr := io.ReadFull(file, buf)
+	if closeErr := file.Close(); closeErr != nil {
+		log.Debug().Err(closeErr).Str("path", filePath).Msg("failed to close file after language sniff")
+	}
+	// io.ReadFull reports ErrUnexpectedEOF for any file shorter than the buffer,
+	// which is the common case and not a failure. Only a read that produced
+	// nothing is.
+	if n == 0 && readErr != nil {
 		return nil
 	}
 	return buf[:n]
@@ -469,7 +474,7 @@ func sniffLanguageContent(filePath string) []byte {
 //	.php  -> Hack       (candidates: Hack, PHP)
 //
 // Those are silent: the wrong name is stored on every finding and travels
-// downstream, and "xml" is not a language any consumer here recognises, so it
+// downstream, and "xml" is not a language any consumer here recognizes, so it
 // simply contributes nothing rather than failing loudly. Passing the file's
 // leading bytes resolves all three, and also lets a C++ header be told from a C
 // one -- which is why reportOccurrenceKeyEcosystems now tests the C family

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -480,25 +480,39 @@ func sniffLanguageContent(filePath string) []byte {
 // one -- which is why reportOccurrenceKeyEcosystems now tests the C family
 // rather than the literal "c".
 //
-// When the file cannot be read the name-only answer is still returned, because a
-// possibly-wrong language is more useful here than none.
+// CONTENT ONLY EVER REFINES AN ANSWER, IT NEVER ERASES ONE. enry returns the
+// empty string when it decides the bytes are binary, and it decides that for
+// some legitimate sources -- a 2 MB generated tree-sitter parser.c is one, its
+// dense state tables trip the heuristic. Reading content must not turn that file
+// from "c" into "unknown", so each lookup is retried without content whenever
+// the content-informed one comes back empty. The same retry covers a file that
+// cannot be read at all, where a possibly-wrong language beats none, and it is
+// what keeps the name-only cases in TestDetectLanguage meaningful.
 func detectLanguage(filePath string) string {
 	content := sniffLanguageContent(filePath)
 
 	// Try detection by filename first
-	lang := enry.GetLanguage(filepath.Base(filePath), content)
-	if lang != "" {
-		return strings.ToLower(lang)
+	if lang := lookupLanguage(filepath.Base(filePath), content); lang != "" {
+		return lang
 	}
 
 	// Try detection by file extension
-	ext := filepath.Ext(filePath)
-	if ext != "" {
-		lang = enry.GetLanguage(fmt.Sprintf("file%s", ext), content)
-		if lang != "" {
-			return strings.ToLower(lang)
+	if ext := filepath.Ext(filePath); ext != "" {
+		if lang := lookupLanguage(fmt.Sprintf("file%s", ext), content); lang != "" {
+			return lang
 		}
 	}
 
 	return "unknown"
+}
+
+// lookupLanguage asks enry with the content and falls back to asking without it,
+// so a content-informed answer is preferred but an empty one never wins.
+func lookupLanguage(name string, content []byte) string {
+	if len(content) > 0 {
+		if lang := enry.GetLanguage(name, content); lang != "" {
+			return strings.ToLower(lang)
+		}
+	}
+	return strings.ToLower(enry.GetLanguage(name, nil))
 }

--- a/internal/scanner/semgrep/transformer_test.go
+++ b/internal/scanner/semgrep/transformer_test.go
@@ -1159,3 +1159,112 @@ func TestOpengrep_EndColConventionPinning(t *testing.T) {
 			r.End.Col, r.Start.Col, span, len(matched), matched)
 	}
 }
+
+// Asked by name alone, enry answers these three with the wrong language:
+// .rs -> XML, .cs -> Smalltalk, .php -> Hack. Each extension has several
+// candidates and the tie is broken without looking at the file. The wrong name
+// is then stored on every finding for those languages, and because "xml" is not
+// an ecosystem any consumer recognises it contributes nothing rather than
+// failing loudly -- so nothing surfaces the mistake.
+//
+// Real files, because reading them is the whole point of the fix.
+func TestDetectLanguageResolvesAmbiguousExtensions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "lib.rs",
+			content: "use std::collections::HashMap;\n\npub fn build() -> HashMap<String, u32> {\n    HashMap::new()\n}\n",
+			want:    "rust",
+		},
+		{
+			name:    "Program.cs",
+			content: "using System;\n\nnamespace Demo {\n    public class Program {\n        public static void Main(string[] args) { Console.WriteLine(\"hi\"); }\n    }\n}\n",
+			want:    "c#",
+		},
+		{
+			name:    "index.php",
+			content: "<?php\nfunction greet($name) {\n    return \"hello \" . $name;\n}\n",
+			want:    "php",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), tc.name)
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := detectLanguage(path); got != tc.want {
+				t.Errorf("detectLanguage(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// A C++ header and a C header share the .h extension. Telling them apart is a
+// consequence of reading content, not the goal, and it is the one place the
+// change alters an answer the codebase already depended on --
+// reportOccurrenceKeyEcosystems keys on it. Pin both directions here so the
+// pairing with that branch stays visible from this side too.
+func TestDetectLanguageDistinguishesCAndCPPHeaders(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		label   string
+		content string
+		want    string
+	}{
+		{"C header", "#ifndef FOO_H\n#define FOO_H\nint add(int a, int b);\n#endif\n", "c"},
+		{"C++ header", "#pragma once\n#include <string>\nclass Foo {\npublic:\n    std::string name() const;\n};\n", "c++"},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "crypto.h")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := detectLanguage(path); got != tc.want {
+				t.Errorf("detectLanguage(%s) = %q, want %q", tc.label, got, tc.want)
+			}
+		})
+	}
+}
+
+// An unreadable path must still answer, because a possibly-wrong language is
+// more useful downstream than none. This is also what keeps the existing
+// name-only table test above meaningful: it passes paths that do not exist.
+func TestDetectLanguageFallsBackWhenFileIsUnreadable(t *testing.T) {
+	t.Parallel()
+
+	if got := detectLanguage(filepath.Join(t.TempDir(), "nope", "main.go")); got != "go" {
+		t.Errorf("detectLanguage(missing .go) = %q, want go", got)
+	}
+	if got := detectLanguage(filepath.Join(t.TempDir(), "nope", "file.xyz")); got != "unknown" {
+		t.Errorf("detectLanguage(missing .xyz) = %q, want unknown", got)
+	}
+}
+
+// The read is capped, so a file larger than the cap must still classify: enry's
+// content strategies look at the head of the file, which is what gets read.
+func TestDetectLanguageClassifiesFilesLargerThanTheSniffLimit(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "big.rs")
+	body := "use std::collections::HashMap;\n\npub fn build() -> HashMap<String, u32> {\n    HashMap::new()\n}\n"
+	padding := strings.Repeat("// padding to push this file past the sniff limit\n", 1000)
+	if err := os.WriteFile(path, []byte(body+padding), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(body+padding)) <= languageSniffLimit {
+		t.Fatalf("fixture is %d bytes, which does not exceed the %d-byte cap", len(body+padding), languageSniffLimit)
+	}
+	if got := detectLanguage(path); got != "rust" {
+		t.Errorf("detectLanguage(large .rs) = %q, want rust", got)
+	}
+}

--- a/internal/scanner/semgrep/transformer_test.go
+++ b/internal/scanner/semgrep/transformer_test.go
@@ -1164,7 +1164,7 @@ func TestOpengrep_EndColConventionPinning(t *testing.T) {
 // .rs -> XML, .cs -> Smalltalk, .php -> Hack. Each extension has several
 // candidates and the tie is broken without looking at the file. The wrong name
 // is then stored on every finding for those languages, and because "xml" is not
-// an ecosystem any consumer recognises it contributes nothing rather than
+// an ecosystem any consumer recognizes it contributes nothing rather than
 // failing loudly -- so nothing surfaces the mistake.
 //
 // Real files, because reading them is the whole point of the fix.

--- a/internal/scanner/semgrep/transformer_test.go
+++ b/internal/scanner/semgrep/transformer_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/scanoss/crypto-finder/internal/entities"
 	"github.com/scanoss/crypto-finder/pkg/paramcondition"
+
+	"github.com/go-enry/go-enry/v2"
 )
 
 func TestResolveMetavars(t *testing.T) {
@@ -1266,5 +1268,27 @@ func TestDetectLanguageClassifiesFilesLargerThanTheSniffLimit(t *testing.T) {
 	}
 	if got := detectLanguage(path); got != "rust" {
 		t.Errorf("detectLanguage(large .rs) = %q, want rust", got)
+	}
+}
+
+// enry answers the empty string when it decides the bytes are binary, and it
+// decides that for some legitimate sources: a generated tree-sitter parser.c,
+// whose dense state tables trip the heuristic, is a real example found in the
+// module cache. Reading content must never turn such a file from "c" into
+// "unknown", so an empty content-informed answer falls back to the name.
+func TestDetectLanguageDoesNotLoseAnAnswerToBinaryHeuristics(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "parser.c")
+	// A NUL byte is enough to make enry call the content binary.
+	body := []byte("#include \"parser.h\"\nstatic const uint16_t ts_parse_table[] = {\x00\x00\x00};\n")
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !enry.IsBinary(body) {
+		t.Skip("enry no longer treats this fixture as binary; the guarded path is unreachable")
+	}
+	if got := detectLanguage(path); got != "c" {
+		t.Errorf("detectLanguage(binary-looking .c) = %q, want c", got)
 	}
 }


### PR DESCRIPTION
## The bug

Several file extensions map to more than one language. Asked by **filename alone**, `enry` breaks the tie without looking at the file, and three of its answers are wrong:

| file | candidates enry sees | answered | correct |
|---|---|---|---|
| `.rs` | RenderScript, Rust, XML | **`xml`** | `rust` |
| `.cs` | C#, Smalltalk | **`smalltalk`** | `c#` |
| `.php` | Hack, PHP | **`hack`** | `php` |

`.go`, `.py`, `.java`, `.rb`, `.kt`, `.scala`, `.swift` and the rest are unaffected — they are unambiguous.

The wrong name is stored on **every finding** for those languages and travels downstream into persisted results.

## Why nobody noticed

It fails quietly in both directions. `xml` is not an ecosystem any consumer here recognises, so `ecosystemFromHint` returns `""` for it and the finding contributes *nothing* rather than erroring. And in practice the occurrence-key ecosystem is supplied by the explicit `--languages` flag appended afterwards, so the fallback covers for it. Nothing ever surfaced the mistake.

## The fix

`detectLanguage` now passes the file's leading bytes to enry, which resolves all three. The read is capped at 16 KiB — enry's content strategies look at shebangs, keywords and early declarations, all near the head of the file — so a large generated source costs a bounded read.

An unreadable path still falls back to the name-only answer: a possibly-wrong language is more useful downstream than none, and it is what keeps the existing name-only table test meaningful (it passes paths that do not exist).

## The one place this changes an answer something already relied on

Reading content also lets a **C++ header be told apart from a C one** — a `.h` with C++ content now reports `c++` where it used to report `c`.

`reportOccurrenceKeyEcosystems` deliberately added **both** the `c` and `cpp` ecosystems for anything detected as `c`, with a comment saying why: *"a C-language detector can report both C and C++ sources … so a C++ header never hides `.c` anchors."* A `.h` reporting `c++` would have fallen through to the generic branch and added **only** `cpp` — dropping the very ecosystem that branch exists to guarantee.

So the branch now tests the **C family** rather than the literal string. `TestReportOccurrenceKeyEcosystems_CPPHeaderKeepsBothEcosystems` is a characterisation test written to pass *before* the detector changed, and it fails on `c++` against the old branch — so this pairing cannot be silently undone.

## Verification

- Unit tests for all three ambiguous extensions, both `.h` directions, the unreadable-path fallback, and a file deliberately larger than the sniff cap.
- End-to-end: scanning a real Rust crate now emits `"language": "rust"` where it previously emitted `"language": "xml"`.
- Full suite unchanged from `origin/main`: **31 packages ok, 0 failures**. `go vet` and `gofmt` clean.

## Note on existing data

This fixes the detector, not rows already written. Components persisted before this change keep the old value until they are next scanned. That is left deliberately — the stored value corrects itself when those components are re-scanned for other reasons.