### PR TITLE
feat(callgraph): add tokio-rustls contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/tokio-rustls.yaml
+++ b/internal/callgraph/contracts/rust/tokio-rustls.yaml
@@ -1,0 +1,119 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: tokio-rustls
+  coordinates:
+    - tokio-rustls
+    - tokio_rustls
+  version_range: ">=0.1.0,<0.27.0"
+  description: "Async TLS session establishment over rustls for tokio"
+
+# API read at tokio-rustls 0.26.4 (src/client.rs, src/server.rs) for the modern
+# surface and at 0.6.0 (src/lib.rs) for the legacy free functions.
+# Cross-checked at 0.8.0, 0.10.0, 0.12.0, 0.23.1 and 0.25.0.
+#
+# WHY A CONTRACT EXISTS HERE. The matrix reported contract_gap=Y and an exported
+# call graph agreed: a consumer calling TlsConnector::connect produced
+# `tokio_rustls.TlsConnector.connect(?, ?)` with empty parameter_types, which is
+# what an absent contract looks like. The consumer's own functions in the same
+# graph resolved fully, so the gap was the contract and not the parser.
+#
+# THIS CRATE CONTAINS NO CRYPTOGRAPHY. Measured across all 58 stable releases in
+# the committed matrix: zero occurrences of CryptoProvider, cipher_suites,
+# kx_groups, SignatureScheme or any provider name in `src/`. Every cipher, curve
+# and protocol decision belongs to rustls, which this crate re-exports
+# (`pub use rustls;`, lib.rs:49, present from 0.12.0). What is typed here is
+# session establishment: the boundary a consumer crosses to reach rustls.
+#
+# KEY SHAPES, READ OFF AN EXPORTED GRAPH RATHER THAN ASSUMED. Type methods emit
+# `tokio_rustls.TlsConnector.connect` -- two dots -- which the Rust key
+# normalisation rewrites to the authored `tokio_rustls::TlsConnector.connect`.
+# The crate-root free functions emit `tokio_rustls.connect_async_with_session`,
+# one dot, which rustAuthoredKey returns unchanged (contracts.go:267), so they
+# are authored with a dot and NOT with "::".
+#
+# ARITIES READ FROM THE DECLARATIONS (self excluded):
+#   TlsConnector::from(Arc<ClientConfig>)              client.rs:116  -> 1
+#   TlsConnector.connect(domain, stream)               client.rs:40   -> 2
+#   TlsConnector.connect_with(domain, stream, f)       client.rs:48   -> 3
+#   TlsConnector.early_data(flag)                      client.rs:34   -> 1
+#   TlsAcceptor::from(Arc<ServerConfig>)               server.rs:23   -> 1
+#   TlsAcceptor.accept(stream)                         server.rs:31   -> 1
+#   TlsAcceptor.accept_with(stream, f)                 server.rs:38   -> 2
+#   LazyConfigAcceptor::new(acceptor, io)              server.rs:81   -> 2
+#   connect_async_with_session(stream, session)        0.6.0 lib.rs:54 -> 2
+#   accept_async_with_session(stream, session)         0.6.0 lib.rs:75 -> 2
+#
+# THE PRE-0.8 EXTENSION-TRAIT METHODS ARE DELIBERATELY ABSENT, AND THAT IS A
+# MEASURED LIMIT RATHER THAN AN OMISSION. 0.1.0-0.7.2 exposed
+# `ClientConfigExt::connect_async` and `ServerConfigExt::accept_async` as trait
+# methods implemented on `Arc<rustls::ClientConfig>` / `Arc<rustls::ServerConfig>`
+# (0.6.0 lib.rs:44-52, 64-72). The receiver is therefore a RUSTLS type, not a
+# tokio-rustls one, and an exported graph confirms the consequence: a consumer
+# calling `client_config.connect_async(domain, tcp)` emits
+# `<consumer_crate>.connect_async(?, ?)`, attributed to the consumer, never to
+# tokio_rustls. A contract keyed `tokio_rustls::ClientConfigExt.connect_async`
+# would never join, so writing one would create the appearance of coverage
+# without any. The rules still detect those call sites through the import guard;
+# it is the call-graph attribution that cannot be recovered without receiver
+# typing. The two free functions those traits delegate to ARE typed below, and
+# they are the part of the legacy era a graph can attribute.
+#
+# `with_alpn` / `TlsConnectorWithAlpn` (0.26.3+, client.rs:103) is absent for the
+# same reason the rules do not match it: ALPN selects an application protocol and
+# carries no cryptographic operation.
+contracts:
+  - method: tokio_rustls::TlsConnector.from
+    arity: 1
+    return: { type: tokio_rustls::TlsConnector, confidence: high }
+    parameter_types: ["std::sync::Arc<rustls::ClientConfig>"]
+    role: factory
+  - method: tokio_rustls::TlsConnector.connect
+    arity: 2
+    return: { type: tokio_rustls::Connect, confidence: high }
+    parameter_types: ["rustls::pki_types::ServerName<'static>", "IO"]
+    role: operation
+  - method: tokio_rustls::TlsConnector.connect_with
+    arity: 3
+    return: { type: tokio_rustls::Connect, confidence: high }
+    parameter_types: ["rustls::pki_types::ServerName<'static>", "IO", "F"]
+    role: operation
+  - method: tokio_rustls::TlsConnector.early_data
+    arity: 1
+    return: { type: tokio_rustls::TlsConnector, confidence: high }
+    parameter_types: ["bool"]
+    role: config
+  - method: tokio_rustls::TlsAcceptor.from
+    arity: 1
+    return: { type: tokio_rustls::TlsAcceptor, confidence: high }
+    parameter_types: ["std::sync::Arc<rustls::ServerConfig>"]
+    role: factory
+  - method: tokio_rustls::TlsAcceptor.accept
+    arity: 1
+    return: { type: tokio_rustls::Accept, confidence: high }
+    parameter_types: ["IO"]
+    role: operation
+  - method: tokio_rustls::TlsAcceptor.accept_with
+    arity: 2
+    return: { type: tokio_rustls::Accept, confidence: high }
+    parameter_types: ["IO", "F"]
+    role: operation
+  - method: tokio_rustls::LazyConfigAcceptor.new
+    arity: 2
+    return: { type: tokio_rustls::LazyConfigAcceptor, confidence: high }
+    parameter_types: ["rustls::server::Acceptor", "IO"]
+    role: factory
+  # Crate-root free functions, 0.6.0-0.7.2. Authored with a dot, not "::":
+  # a one-dot call-site key has no module/type separator to move.
+  - method: tokio_rustls.connect_async_with_session
+    arity: 2
+    return: { type: tokio_rustls::ConnectAsync, confidence: high }
+    parameter_types: ["S", "rustls::ClientSession"]
+    role: operation
+  - method: tokio_rustls.accept_async_with_session
+    arity: 2
+    return: { type: tokio_rustls::AcceptAsync, confidence: high }
+    parameter_types: ["S", "rustls::ServerSession"]
+    role: operation
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_tokio_rustls_test.go
+++ b/internal/callgraph/contracts/rust_tokio_rustls_test.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// tokio-rustls carries no cryptography of its own; what is typed is TLS session
+// establishment, the boundary a consumer crosses to reach rustls.
+//
+// Two key shapes, both read off an exported call graph rather than assumed.
+// Type methods emit `tokio_rustls.TlsConnector.connect` -- two dots -- which the
+// Rust key normalisation rewrites to the authored
+// `tokio_rustls::TlsConnector.connect`. The crate-root free functions emit
+// `tokio_rustls.connect_async_with_session`, one dot, which rustAuthoredKey
+// returns unchanged, so they are authored WITH A DOT. Getting that backwards
+// silently produces a contract nothing joins to.
+func TestLoadEmbeddedRustIncludesTokioRustlsContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		role   string
+	}{
+		{"tokio_rustls::TlsConnector.from", 1, "factory"},
+		{"tokio_rustls::TlsConnector.connect", 2, "operation"},
+		{"tokio_rustls::TlsConnector.connect_with", 3, "operation"},
+		{"tokio_rustls::TlsConnector.early_data", 1, "config"},
+		{"tokio_rustls::TlsAcceptor.from", 1, "factory"},
+		{"tokio_rustls::TlsAcceptor.accept", 1, "operation"},
+		{"tokio_rustls::TlsAcceptor.accept_with", 2, "operation"},
+		{"tokio_rustls::LazyConfigAcceptor.new", 2, "factory"},
+		{"tokio_rustls.connect_async_with_session", 2, "operation"},
+		{"tokio_rustls.accept_async_with_session", 2, "operation"},
+	}
+
+	for _, tc := range tests {
+		got := kb.ContractsFor(tc.method, tc.arity)
+		if len(got) == 0 {
+			t.Errorf("ContractsFor(%q, %d): no contract", tc.method, tc.arity)
+			continue
+		}
+		if got[0].SourceLibrary != "tokio-rustls" {
+			t.Errorf("%s: library = %q, want tokio-rustls", tc.method, got[0].SourceLibrary)
+		}
+		if got[0].Role != tc.role {
+			t.Errorf("%s: role = %q, want %q", tc.method, got[0].Role, tc.role)
+		}
+		if len(got[0].ParameterTypes) != tc.arity {
+			t.Errorf("%s: %d parameter_types, want %d", tc.method, len(got[0].ParameterTypes), tc.arity)
+		}
+	}
+
+	// The dot-joined call-site shape and unknown arity must both resolve.
+	for _, m := range []string{
+		"tokio_rustls.TlsConnector.connect",
+		"tokio_rustls.TlsAcceptor.accept",
+		"tokio_rustls.LazyConfigAcceptor.new",
+	} {
+		if got := kb.ContractsFor(m, -1); len(got) == 0 {
+			t.Errorf("ContractsFor(%q, -1): no contract for the emitted key", m)
+		}
+	}
+}
+
+// The pre-0.8 extension-trait methods are deliberately NOT contracted, and this
+// pins the reason rather than the omission.
+//
+// 0.1.0-0.7.2 exposed ClientConfigExt::connect_async and
+// ServerConfigExt::accept_async as trait methods implemented on
+// Arc<rustls::ClientConfig> / Arc<rustls::ServerConfig> (0.6.0 lib.rs:44-52,
+// 64-72). The receiver is a RUSTLS type, so an exported graph attributes
+// `client_config.connect_async(domain, tcp)` to the CONSUMER crate, never to
+// tokio_rustls -- measured, not assumed. A contract under a tokio_rustls key
+// would therefore never join, and writing one would create the appearance of
+// coverage without any.
+//
+// The free functions those traits delegate to are contracted, and they are the
+// part of that era a call graph can attribute.
+func TestTokioRustlsDoesNotContractUnattributableLegacyTraits(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, m := range []string{
+		"tokio_rustls::ClientConfigExt.connect_async",
+		"tokio_rustls::ServerConfigExt.accept_async",
+		"tokio_rustls.ClientConfigExt.connect_async",
+		"tokio_rustls.ServerConfigExt.accept_async",
+	} {
+		for _, a := range []int{1, 2, -1} {
+			if got := kb.ContractsFor(m, a); len(got) > 0 {
+				t.Errorf("ContractsFor(%q, %d) resolved to %q: the receiver is a rustls type, "+
+					"so this key can never be emitted and the contract is unreachable",
+					m, a, got[0].SourceLibrary)
+			}
+		}
+	}
+}
+
+// ALPN selects an application protocol and carries no cryptographic operation.
+// `with_alpn`/TlsConnectorWithAlpn arrived in 0.26.3 (client.rs:103) and is the
+// most plausible thing for a later author to add.
+func TestTokioRustlsDoesNotContractAlpn(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	for _, m := range []string{
+		"tokio_rustls::TlsConnector.with_alpn",
+		"tokio_rustls::TlsConnectorWithAlpn.connect",
+		"tokio_rustls::TlsConnector.config",
+	} {
+		for _, a := range []int{1, 2, -1} {
+			if got := kb.ContractsFor(m, a); len(got) > 0 {
+				t.Errorf("ContractsFor(%q, %d) resolved to %q: not a cryptographic operation",
+					m, a, got[0].SourceLibrary)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Ten contracts for the async TLS session establishment surface of the
`tokio-rustls` crate, covering `>=0.1.0,<0.27.0`.

## Why

Without them a consumer's `TlsConnector::connect` exported as
`tokio_rustls.TlsConnector.connect(?, ?)` with empty `parameter_types`, which is
what an absent contract looks like. The consumer's own functions in the same
exported graph resolved fully, so the gap was the contract and not the parser.
All ten keys now resolve with typed parameters.

This crate contains no cryptography of its own — measured across all 58 stable
releases, its `src/` names no provider, suite or protocol version. What is typed
here is the boundary a consumer crosses to reach rustls, which this crate
re-exports (`pub use rustls;`, present from 0.12.0).

## Two key shapes, both read off an exported graph

Type methods emit `tokio_rustls.TlsConnector.connect` — two dots — which the Rust
key normalisation rewrites to the authored `tokio_rustls::TlsConnector.connect`.
The crate-root free functions emit `tokio_rustls.connect_async_with_session`, one
dot, which `rustAuthoredKey` returns unchanged, so they are authored **with a
dot**. Getting that backwards silently produces a contract nothing joins to, so
both shapes are pinned by tests.

## What is deliberately not contracted

The pre-0.8 `ClientConfigExt::connect_async` / `ServerConfigExt::accept_async`
trait methods. They are implemented on `Arc<rustls::ClientConfig>` /
`Arc<rustls::ServerConfig>`, so the receiver is a rustls type and an exported
graph attributes the call to the **consumer** crate, never to `tokio_rustls` —
measured, not assumed. A contract under a `tokio_rustls` key could never join,
and writing one would create the appearance of coverage without any. The two free
functions those traits delegate to are contracted instead, and a test asserts the
trait keys stay absent.

`with_alpn` / `TlsConnectorWithAlpn` (0.26.3+) is also absent: ALPN selects an
application protocol and carries no cryptographic operation.

## A limitation this exposed, recorded not closed

For 0.26.x the API moved from `src/lib.rs` into `src/client.rs` / `src/server.rs`,
re-exported at the crate root with an explicit braced `pub use`.
`rustFileModulePath` collapses a child module's path onto the parent only for
**glob** re-exports, so those declarations do not join a root-keyed contract and
0.26.x synthesises no entry points. Reduced to a minimal two-crate repro: the
identical declarations yield 2 entry points under `pub use client::*;` and 0
under `pub use client::{TlsConnector};`.

Not fixed here on purpose. Collapsing explicit re-exports would change module
attribution for every Rust crate and would break merged contracts that
deliberately key on the module path (`openssl::rsa::Rsa.generate`,
`aws_lc_rs::aead::UnboundKey.new`) — the same class of regression that function's
own comment already records.

## Verification

- `go test ./internal/callgraph/...` green; `make lint` at the pinned
  golangci-lint 2.10.1 reports 0 issues.
- Three new tests: the ten keys with arity/role/parameter counts, the
  dot-joined call-site shape at unknown arity, and two negative tests pinning the
  unattributable legacy traits and the ALPN surface.