### PR TITLE
feat(callgraph): add DEDIS kyber contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/kyber.yaml
+++ b/internal/callgraph/contracts/go/kyber.yaml
@@ -1,0 +1,88 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: kyber
+  coordinates:
+    - "go.dedis.ch/kyber/v3"
+  version_range: ">=3.0.0-pre1,<4.0.0"
+  description: "DEDIS kyber v3 advanced cryptographic toolbox"
+
+# Inventory source: go.dedis.ch/kyber/v3 v3.1.0-alpha module source from the
+# Go module proxy. Contracted boundary per the family audit: the suite
+# registry, the core signature packages (schnorr, eddsa, bls), ECIES, and
+# key-pair generation. The Group/Scalar/Point arithmetic interfaces are
+# generic algebra, not crypto operations (audit: never label generic
+# arithmetic); the threshold/distributed protocol packages (tbls, bdn, dss,
+# cosi, anon, share, proof, shuffle, pairing internals) are bounded protocol
+# children (needs-follow-up); xof/random are supporting primitives reached
+# through the suites (skipped-non-crypto at this boundary).
+contracts:
+  - method: go.dedis.ch/kyber/v3/suites.Find
+    arity: 1
+    return: { type: "go.dedis.ch/kyber/v3/suites.Suite", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: name, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: go.dedis.ch/kyber/v3/suites.MustFind
+    arity: 1
+    return: { type: "go.dedis.ch/kyber/v3/suites.Suite", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: name, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: go.dedis.ch/kyber/v3/sign/schnorr.Sign
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: private, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: go.dedis.ch/kyber/v3/sign/schnorr.Verify
+    arity: 4
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: go.dedis.ch/kyber/v3/sign/schnorr.VerifyWithChecks
+    arity: 4
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: go.dedis.ch/kyber/v3/sign/eddsa.NewEdDSA
+    arity: 1
+    return: { type: "*go.dedis.ch/kyber/v3/sign/eddsa.EdDSA", confidence: high }
+    role: factory
+  - method: go.dedis.ch/kyber/v3/sign/eddsa.(*EdDSA).Sign
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: go.dedis.ch/kyber/v3/sign/eddsa.Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: go.dedis.ch/kyber/v3/sign/eddsa.VerifyWithChecks
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: go.dedis.ch/kyber/v3/sign/bls.Sign
+    arity: 3
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: x, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: go.dedis.ch/kyber/v3/sign/bls.Verify
+    arity: 4
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: go.dedis.ch/kyber/v3/encrypt/ecies.Encrypt
+    arity: 4
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: public, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: go.dedis.ch/kyber/v3/encrypt/ecies.Decrypt
+    arity: 4
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: private, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: go.dedis.ch/kyber/v3/util/key.NewKeyPair
+    arity: 1
+    return: { type: "*go.dedis.ch/kyber/v3/util/key.Pair", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go_kyber_test.go
+++ b/internal/callgraph/contracts/go_kyber_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesKyberContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"go.dedis.ch/kyber/v3/suites.MustFind", "factory", "algorithm", 1},
+		{"go.dedis.ch/kyber/v3/sign/schnorr.Sign", "operation", "keyMaterial", 3},
+		{"go.dedis.ch/kyber/v3/sign/eddsa.(*EdDSA).Sign", "operation", "", 1},
+		{"go.dedis.ch/kyber/v3/encrypt/ecies.Encrypt", "operation", "keyMaterial", 4},
+		{"go.dedis.ch/kyber/v3/util/key.NewKeyPair", "factory", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "kyber" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want kyber %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}

--- a/internal/scanner/semgrep/scanner.go
+++ b/internal/scanner/semgrep/scanner.go
@@ -36,6 +36,9 @@ import (
 // ScannerName is the identifier for the Semgrep scanner.
 const ScannerName = "semgrep"
 
+// unknownResult is the fallback for version and language detection.
+const unknownResult = "unknown"
+
 // Scanner implements the scanner.Scanner interface for Semgrep.
 type Scanner struct {
 	executablePath string
@@ -170,7 +173,7 @@ func (s *Scanner) detectVersion(ctx context.Context) string {
 	cmd := scanner.CommandContext(ctx, s.executablePath, "--version")
 	output, err := cmd.Output()
 	if err != nil {
-		return "unknown" // Non-fatal, continue without version
+		return unknownResult // Non-fatal, continue without version
 	}
 
 	// Parse version from output (e.g., "1.45.0")

--- a/internal/scanner/semgrep/transformer.go
+++ b/internal/scanner/semgrep/transformer.go
@@ -503,7 +503,7 @@ func detectLanguage(filePath string) string {
 		}
 	}
 
-	return "unknown"
+	return unknownResult
 }
 
 // lookupLanguage asks enry with the content and falls back to asking without it,


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-go-dedis-ch-kyber-v3` (scanoss/crypto-mining-service#233).

## What

- `internal/callgraph/contracts/go/kyber.yaml` (14 contracts, `>=3.0.0-pre1,<4.0.0`): suite registry factories with operation-determining names, schnorr/eddsa/bls signature operations, ECIES with keyMaterial roles, and key-pair generation. The Group/Scalar/Point arithmetic stays uncontracted per the audit ("never label generic arithmetic"); threshold/distributed packages recorded as bounded follow-up children. Dispositions in the header.
- `go_kyber_test.go` asserts representative entries.
- Includes a small lint fix-forward: main's `internal/scanner/semgrep` had a goconst failure (repeated `"unknown"` literal from a recent merge) — hoisted into a package constant so `make lint` is green again.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues (after the fix-forward).
- Full local tier0 E2E gate (23 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#233.

Refs scanoss/crypto-mining-service#233