### PR TITLE
feat(callgraph): add gnark contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/gnark.yaml
+++ b/internal/callgraph/contracts/go/gnark.yaml
@@ -1,0 +1,83 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: gnark
+  coordinates:
+    - "github.com/consensys/gnark"
+  version_range: ">=0.5.0,<1.0.0"
+  description: "ConsenSys gnark zk-SNARK proof systems (Groth16, PLONK)"
+
+# Inventory source: github.com/consensys/gnark v0.10.0 module source from the
+# Go module proxy. The declared range starts at v0.5.0: earlier alphas expose
+# the proof systems at different paths and are not importable through the
+# backend/groth16 and backend/plonk identities below. Frontend circuit
+# compilation and witness plumbing carry no algorithm choice
+# (skipped-non-crypto); DummySetup is a test-only API and is deliberately
+# uncontracted (audit: never report test setup as production);
+# serialization ReadFrom/WriteTo methods are container plumbing
+# (skipped-non-crypto); the std/ gadget library is circuit content, not a
+# crypto call boundary (needs-follow-up as its own child if ever required).
+contracts:
+  - method: github.com/consensys/gnark/backend/groth16.Setup
+    arity: 1
+    return: { type: "github.com/consensys/gnark/backend/groth16.ProvingKey", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark/backend/groth16.Prove
+    arity: 4
+    varargs: true
+    return: { type: "github.com/consensys/gnark/backend/groth16.Proof", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: pk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark/backend/groth16.Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: vk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark/backend/groth16.NewProvingKey
+    arity: 1
+    return: { type: "github.com/consensys/gnark/backend/groth16.ProvingKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: curveID, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/consensys/gnark/backend/groth16.NewVerifyingKey
+    arity: 1
+    return: { type: "github.com/consensys/gnark/backend/groth16.VerifyingKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: curveID, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/consensys/gnark/backend/groth16.NewProof
+    arity: 1
+    return: { type: "github.com/consensys/gnark/backend/groth16.Proof", confidence: high }
+    role: factory
+  - method: github.com/consensys/gnark/backend/plonk.Setup
+    arity: 2
+    return: { type: "github.com/consensys/gnark/backend/plonk.ProvingKey", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: kzgSrs, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark/backend/plonk.Prove
+    arity: 4
+    varargs: true
+    return: { type: "github.com/consensys/gnark/backend/plonk.Proof", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: pk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark/backend/plonk.Verify
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: vk, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark/backend/plonk.NewProvingKey
+    arity: 1
+    return: { type: "github.com/consensys/gnark/backend/plonk.ProvingKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: curveID, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/consensys/gnark/backend/plonk.NewProof
+    arity: 1
+    return: { type: "github.com/consensys/gnark/backend/plonk.Proof", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go_gnark_test.go
+++ b/internal/callgraph/contracts/go_gnark_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGnarkContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/consensys/gnark/backend/groth16.Setup", "operation", "", 1},
+		{"github.com/consensys/gnark/backend/groth16.Prove", "operation", "keyMaterial", 4},
+		{"github.com/consensys/gnark/backend/groth16.NewProvingKey", "factory", "curve", 1},
+		{"github.com/consensys/gnark/backend/plonk.Verify", "operation", "keyMaterial", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "gnark" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want gnark %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-consensys-gnark` (scanoss/crypto-mining-service#212).

## What

- `internal/callgraph/contracts/go/gnark.yaml` (11 contracts, `>=0.5.0,<1.0.0`): Groth16/PLONK Setup/Prove/Verify operations with keyMaterial parameter roles and the curve-carrying NewProvingKey/NewVerifyingKey/NewProof factories. `DummySetup` deliberately uncontracted per the audit; frontend circuit/witness plumbing and the std/ gadget library recorded as out of boundary. Dispositions in the header.
- `go_gnark_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (37 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#212.

Refs scanoss/crypto-mining-service#212