### PR TITLE
feat(callgraph): add sequoia-openpgp contracts for the Rust KB

### DIFF
--- a/internal/callgraph/contracts/rust/sequoia-openpgp.yaml
+++ b/internal/callgraph/contracts/rust/sequoia-openpgp.yaml
@@ -1,0 +1,223 @@
+schema_version: "2"
+ecosystem: rust
+library:
+  name: sequoia-openpgp
+  coordinates:
+    - sequoia-openpgp
+    - sequoia_openpgp
+  version_range: ">=0.20.0,<3.0.0"
+  description: "Sequoia OpenPGP: certificates, streaming signing/encryption and policy-aware verification"
+
+# API read at sequoia-openpgp 2.3.0, with every pre-2.0 divergence checked against
+# 0.15.0, 0.20.0, 1.0.0 and 1.22.0. Line references name the version they belong to.
+#
+# WHY THE FLOOR IS 0.20.0 AND NOT 0.15.0. The `policy` module arrives at 0.15.0,
+# but the policy-aware ENTRY POINTS contracted here do not: 0.15.0
+# src/parse/stream.rs has no `VerifierBuilder` and no `with_policy` at all — it
+# spells verification `Verifier::from_bytes(policy, bytes, helper, t)`, a
+# four-argument associated function on a different type. The three *Builder types
+# and their `with_policy` first appear at 0.20.0 (src/parse/stream.rs:993, 1402,
+# 1756). 0.15.0 also lacks `Encryptor::for_recipients` (only `for_recipient`,
+# singular, at src/serialize/stream.rs:106) and its `Message::new` returns
+# `writer::Stack`, not `Message`. So 0.15.0 would leave eight of these entries
+# dead, and the range says 0.20.0.
+#
+# WHERE THE KEYS COME FROM. Not from the documentation: each was read off an
+# exported call graph for a probe consumer, and appeared as `name(?)` with empty
+# parameter_types before this file existed.
+#
+# TWO SPELLINGS OF `Cert`, and both are needed. The key follows the CONSUMER's
+# import, and this crate re-exports `Cert` at its root (2.3.0 src/lib.rs:167
+# `pub use cert::Cert;`) as well as under `cert`:
+#
+#   use sequoia_openpgp::cert::Cert;  ->  sequoia_openpgp::cert::Cert.from_bytes
+#   use sequoia_openpgp::Cert;       ->  sequoia_openpgp::Cert.from_bytes
+#
+# Both are authored in the `::` form the rest of this KB uses; the parser emits
+# the receiver separator as a dot and contracts.rustAuthoredKey rewrites it back,
+# so the authored spelling stays conventional.
+#
+# THE CRATE ALIAS IS NOT A PROBLEM AT THIS LAYER. The crate's documentation tells
+# consumers to write `use sequoia_openpgp as openpgp;`. The parser resolves that:
+# a probe written entirely in the aliased form emitted `sequoia_openpgp::…` keys.
+#
+# WHAT THIS FILE CANNOT REACH, measured rather than assumed. The Rust resolver
+# loses a receiver at chain depth 2, so in the fluent form the crate documents —
+# `CertBuilder::new().set_cipher_suite(..).add_signing_subkey().generate()` — only
+# the first call carries a sequoia identity; `add_signing_subkey`,
+# `add_transport_encryption_subkey` and `generate` are attributed to the consumer
+# crate instead. Those three entries are therefore contracted from the source
+# signature, NOT observed in an export, and they will start joining if that
+# resolver limit is lifted. Said here so the next author does not read them as
+# verified.
+contracts:
+  # --- certificates and key material ---
+  - method: sequoia_openpgp::cert::CertBuilder.new
+    arity: 0
+    return: {type: "sequoia_openpgp::cert::CertBuilder", confidence: high}
+    role: factory
+  # `general_purpose` CHANGED ARITY at 2.0.0 and both forms are inside the range,
+  # so both are contracted. 0.15.0 src/cert/builder.rs:151 through 1.22.0 :377 is
+  # `general_purpose<C, U>(ciphersuite: C, userids: Option<U>)`; 2.0.0 :462 and
+  # 2.3.0 :499 drop the cipher-suite parameter. A single arity-1 entry does not
+  # join for any 0.x or 1.x consumer.
+  - method: sequoia_openpgp::cert::CertBuilder.general_purpose
+    arity: 2
+    return: {type: "sequoia_openpgp::cert::CertBuilder", confidence: high}
+    parameter_types: ["impl core::convert::Into", "core::option::Option"]
+    role: factory
+  - method: sequoia_openpgp::cert::CertBuilder.general_purpose
+    arity: 1
+    return: {type: "sequoia_openpgp::cert::CertBuilder", confidence: high}
+    parameter_types: ["impl core::iter::IntoIterator"]
+    role: factory
+  - method: sequoia_openpgp::cert::CertBuilder.set_cipher_suite
+    arity: 1
+    return: {type: "sequoia_openpgp::cert::CertBuilder", confidence: high}
+    parameter_types: ["sequoia_openpgp::cert::CipherSuite"]
+    role: config
+  - method: sequoia_openpgp::cert::CertBuilder.add_signing_subkey
+    arity: 0
+    return: {type: "sequoia_openpgp::cert::CertBuilder", confidence: high}
+    role: config
+  - method: sequoia_openpgp::cert::CertBuilder.add_transport_encryption_subkey
+    arity: 0
+    return: {type: "sequoia_openpgp::cert::CertBuilder", confidence: high}
+    role: config
+  - method: sequoia_openpgp::cert::CertBuilder.generate
+    arity: 0
+    return: {type: "core::result::Result", confidence: high}
+    role: operation
+  - method: sequoia_openpgp::cert::Cert.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: sequoia_openpgp::Cert.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: sequoia_openpgp::cert::Cert.from_reader
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["impl std::io::Read"]
+    role: factory
+  - method: sequoia_openpgp::Cert.from_reader
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["impl std::io::Read"]
+    role: factory
+
+  # --- streaming signing and encryption ---
+  - method: sequoia_openpgp::serialize::stream::Message.new
+    arity: 1
+    return: {type: "sequoia_openpgp::serialize::stream::Message", confidence: high}
+    parameter_types: ["impl std::io::Write"]
+    role: factory
+  # RETURN TYPE CHANGED AT 2.0.0, and only one can be declared per key+arity.
+  # 0.20.0 src/serialize/stream.rs:280 through 1.22.0 :731 return `Self`; 2.0.0
+  # :759 returns `Result<Self>`. The 2.x form is declared because it is the shape
+  # the current stable line and the mined sample use; a 0.x/1.x consumer resolves
+  # the key and carries a return type one wrapper too deep. `add_signer` moved the
+  # same way (1.22.0 :1050 `-> Self`, 2.0.0 :1087 `-> Result<Self>`).
+  - method: sequoia_openpgp::serialize::stream::Signer.new
+    arity: 2
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["sequoia_openpgp::serialize::stream::Message", "impl sequoia_openpgp::crypto::Signer"]
+    role: factory
+  - method: sequoia_openpgp::serialize::stream::Signer.add_signer
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["impl sequoia_openpgp::crypto::Signer"]
+    role: config
+  - method: sequoia_openpgp::serialize::stream::Signer.hash_algo
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["sequoia_openpgp::types::HashAlgorithm"]
+    role: config
+  - method: sequoia_openpgp::serialize::stream::Encryptor.for_recipients
+    arity: 2
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor", confidence: high}
+    parameter_types: ["sequoia_openpgp::serialize::stream::Message", "impl core::iter::IntoIterator"]
+    role: factory
+  - method: sequoia_openpgp::serialize::stream::Encryptor.with_passwords
+    arity: 2
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor", confidence: high}
+    parameter_types: ["sequoia_openpgp::serialize::stream::Message", "impl core::iter::IntoIterator"]
+    role: factory
+  # A third public encryption constructor, 2.3.0 src/serialize/stream.rs:2761.
+  - method: sequoia_openpgp::serialize::stream::Encryptor.with_session_key
+    arity: 3
+    return: {type: "core::result::Result", confidence: high}
+    role: factory
+  - method: sequoia_openpgp::serialize::stream::Encryptor.add_recipients
+    arity: 1
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor", confidence: high}
+    parameter_types: ["impl core::iter::IntoIterator"]
+    role: config
+  - method: sequoia_openpgp::serialize::stream::Encryptor.symmetric_algo
+    arity: 1
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor", confidence: high}
+    parameter_types: ["sequoia_openpgp::types::SymmetricAlgorithm"]
+    role: config
+  - method: sequoia_openpgp::serialize::stream::Encryptor.aead_algo
+    arity: 1
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor", confidence: high}
+    parameter_types: ["sequoia_openpgp::types::AEADAlgorithm"]
+    role: config
+  # Encryptor2 exists only from 1.17.0 (src/serialize/stream.rs:2335) to 1.22.x
+  # and is gone at 2.0.0. It carries the SAME three entries as Encryptor: a
+  # consumer pinned in that window writes the documented fluent form, and
+  # contracting only the factory would drop both config calls.
+  - method: sequoia_openpgp::serialize::stream::Encryptor2.for_recipients
+    arity: 2
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor2", confidence: high}
+    parameter_types: ["sequoia_openpgp::serialize::stream::Message", "impl core::iter::IntoIterator"]
+    role: factory
+  - method: sequoia_openpgp::serialize::stream::Encryptor2.add_recipients
+    arity: 1
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor2", confidence: high}
+    parameter_types: ["impl core::iter::IntoIterator"]
+    role: config
+  - method: sequoia_openpgp::serialize::stream::Encryptor2.symmetric_algo
+    arity: 1
+    return: {type: "sequoia_openpgp::serialize::stream::Encryptor2", confidence: high}
+    parameter_types: ["sequoia_openpgp::types::SymmetricAlgorithm"]
+    role: config
+
+  # --- policy-aware verification and decryption ---
+  # `with_policy` is a FACTORY, not an operation: it consumes the builder and
+  # returns the Verifier or Decryptor (2.3.0 src/parse/stream.rs:1275, 1609,
+  # 2042) and performs no cryptography at the call site — verification happens as
+  # the reader is consumed. That matches how `Signer.new` and
+  # `Encryptor.for_recipients` are classified.
+  - method: sequoia_openpgp::parse::stream::VerifierBuilder.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: sequoia_openpgp::parse::stream::VerifierBuilder.with_policy
+    arity: 3
+    return: {type: "core::result::Result", confidence: high}
+    role: factory
+  - method: sequoia_openpgp::parse::stream::DetachedVerifierBuilder.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: sequoia_openpgp::parse::stream::DetachedVerifierBuilder.with_policy
+    arity: 3
+    return: {type: "core::result::Result", confidence: high}
+    role: factory
+  - method: sequoia_openpgp::parse::stream::DecryptorBuilder.from_bytes
+    arity: 1
+    return: {type: "core::result::Result", confidence: high}
+    parameter_types: ["&[u8]"]
+    role: factory
+  - method: sequoia_openpgp::parse::stream::DecryptorBuilder.with_policy
+    arity: 3
+    return: {type: "core::result::Result", confidence: high}
+    role: factory
+
+hierarchy: {}

--- a/internal/callgraph/contracts/rust_sequoia_openpgp_test.go
+++ b/internal/callgraph/contracts/rust_sequoia_openpgp_test.go
@@ -1,0 +1,121 @@
+package contracts_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// sequoia-openpgp re-exports `Cert` at its crate root AND under `cert`, and the
+// callee key follows the CONSUMER's import, so both spellings occur in real
+// code. Every key here was read off an exported call graph for a probe consumer
+// rather than from the crate's documentation; before this contract each one
+// appeared as `name(?)` with empty parameter_types.
+func TestLoadEmbeddedRustIncludesSequoiaOpenPGPContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	tests := []struct {
+		method string
+		arity  int
+		role   string
+		ret    string
+	}{
+		// Certificates and key material.
+		{"sequoia_openpgp::cert::CertBuilder.new", 0, "factory", "sequoia_openpgp::cert::CertBuilder"},
+		// `general_purpose` changed arity at 2.0.0 and BOTH forms are in range:
+		// 0.15.0-1.22.x take (ciphersuite, userids), 2.x takes (userids). A
+		// single entry does not join for any 0.x or 1.x consumer.
+		{"sequoia_openpgp::cert::CertBuilder.general_purpose", 2, "factory", "sequoia_openpgp::cert::CertBuilder"},
+		{"sequoia_openpgp::cert::CertBuilder.general_purpose", 1, "factory", "sequoia_openpgp::cert::CertBuilder"},
+		{"sequoia_openpgp::cert::CertBuilder.set_cipher_suite", 1, "config", "sequoia_openpgp::cert::CertBuilder"},
+		{"sequoia_openpgp::cert::CertBuilder.generate", 0, "operation", "core::result::Result"},
+
+		// BOTH `Cert` spellings. The crate re-exports it at its root as well as
+		// under `cert`, and the key follows the consumer's import, so a contract
+		// carrying only one resolves only half the consumers. Both are authored
+		// in the `::` form the rest of this KB uses.
+		{"sequoia_openpgp::cert::Cert.from_bytes", 1, "factory", "core::result::Result"},
+		{"sequoia_openpgp::Cert.from_bytes", 1, "factory", "core::result::Result"},
+
+		// Streaming signing and encryption.
+		{"sequoia_openpgp::serialize::stream::Message.new", 1, "factory", "sequoia_openpgp::serialize::stream::Message"},
+		{"sequoia_openpgp::serialize::stream::Signer.new", 2, "factory", "core::result::Result"},
+		{"sequoia_openpgp::serialize::stream::Signer.hash_algo", 1, "config", "core::result::Result"},
+		{"sequoia_openpgp::serialize::stream::Encryptor.for_recipients", 2, "factory", "sequoia_openpgp::serialize::stream::Encryptor"},
+		{"sequoia_openpgp::serialize::stream::Encryptor.symmetric_algo", 1, "config", "sequoia_openpgp::serialize::stream::Encryptor"},
+		{"sequoia_openpgp::serialize::stream::Encryptor.aead_algo", 1, "config", "sequoia_openpgp::serialize::stream::Encryptor"},
+		{"sequoia_openpgp::serialize::stream::Encryptor.with_passwords", 2, "factory", "sequoia_openpgp::serialize::stream::Encryptor"},
+		{"sequoia_openpgp::serialize::stream::Encryptor.with_session_key", 3, "factory", "core::result::Result"},
+
+		// The 1.17.0-1.22.x transitional type, contracted because it exists
+		// inside the committed version range.
+		{"sequoia_openpgp::serialize::stream::Encryptor2.for_recipients", 2, "factory", "sequoia_openpgp::serialize::stream::Encryptor2"},
+		{"sequoia_openpgp::serialize::stream::Encryptor2.add_recipients", 1, "config", "sequoia_openpgp::serialize::stream::Encryptor2"},
+		{"sequoia_openpgp::serialize::stream::Encryptor2.symmetric_algo", 1, "config", "sequoia_openpgp::serialize::stream::Encryptor2"},
+
+		// Policy-aware verification and decryption. All three builders share
+		// `with_policy`, which is why the RULES anchor the constructors instead:
+		// the method name alone cannot carry the operation. It is a `factory`
+		// here — it returns the Verifier/Decryptor and does no cryptography at
+		// the call site.
+		{"sequoia_openpgp::parse::stream::VerifierBuilder.from_bytes", 1, "factory", "core::result::Result"},
+		{"sequoia_openpgp::parse::stream::VerifierBuilder.with_policy", 3, "factory", "core::result::Result"},
+		{"sequoia_openpgp::parse::stream::DecryptorBuilder.from_bytes", 1, "factory", "core::result::Result"},
+		{"sequoia_openpgp::parse::stream::DecryptorBuilder.with_policy", 3, "factory", "core::result::Result"},
+		{"sequoia_openpgp::parse::stream::DetachedVerifierBuilder.with_policy", 3, "factory", "core::result::Result"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s#%d", tt.method, tt.arity), func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("%s#%d contracts = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			if got[0].SourceLibrary != "sequoia-openpgp" || got[0].Role != tt.role || got[0].Return.Type != tt.ret {
+				t.Fatalf("%s#%d = %#v, want role %q return %q from sequoia-openpgp",
+					tt.method, tt.arity, got[0], tt.role, tt.ret)
+			}
+		})
+	}
+}
+
+// The wiring test the contract convention asks for in the same commit: the
+// forms an exported call graph actually emits must resolve. The parser dots the
+// receiver-type separator, and contracts.rustAuthoredKey rewrites it back, so
+// these are the emitted spellings rather than the authored ones.
+func TestSequoiaOpenPGPContractsResolveFromCallSiteKeys(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("rust")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(rust): %v", err)
+	}
+
+	// Measured on probe consumers: the left column is what the export carried.
+	for _, emitted := range []string{
+		"sequoia_openpgp::cert.CertBuilder.general_purpose",
+		"sequoia_openpgp::cert.CertBuilder.set_cipher_suite",
+		"sequoia_openpgp::cert.Cert.from_bytes",
+		"sequoia_openpgp.Cert.from_bytes", // crate-root re-export spelling
+		"sequoia_openpgp::serialize::stream.Signer.new",
+		"sequoia_openpgp::serialize::stream.Signer.hash_algo",
+		"sequoia_openpgp::serialize::stream.Encryptor.for_recipients",
+		"sequoia_openpgp::serialize::stream.Encryptor.symmetric_algo",
+		"sequoia_openpgp::parse::stream.VerifierBuilder.from_bytes",
+		"sequoia_openpgp::parse::stream.DecryptorBuilder.from_bytes",
+	} {
+		t.Run(emitted, func(t *testing.T) {
+			// -1 is the arity a Rust call site carries when the callee name
+			// encodes none, which is the common case.
+			if got := kb.ContractsFor(emitted, -1); len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, -1) = %d contracts, want 1", emitted, len(got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds Rust KB contracts for `sequoia-openpgp` — 24 entries covering certificates
and key material, the streaming `Signer` and `Encryptor`, and the policy-aware
verify and decrypt builders.

Also carries one **separate, pre-existing** lint fix; see the last section.

## Keys read off an exported graph, not from the API

Every key was taken from a `--export-callgraph` run over a probe consumer rather
than written from the crate's documentation. Before this file, all nine keys the
probe emitted appeared as `name(?)` / `name(?, ?)` with empty `parameter_types` —
the shape an absent contract takes. After it, **0 of 9 remain unresolved.**

## `Cert` is contracted under BOTH spellings, and it has to be

The key follows the CONSUMER's import, and this crate re-exports `Cert` at its
root as well as under `cert`:

```
use sequoia_openpgp::cert::Cert;  ->  sequoia_openpgp::cert.Cert.from_bytes
use sequoia_openpgp::Cert;        ->  sequoia_openpgp.Cert.from_bytes
```

Both were measured on probe consumers. A contract carrying one spelling resolves
only half the consumers, and the difference is invisible in the documentation.

## The crate alias is a rule-layer problem, not a contract-layer one

The crate's documentation tells consumers to write `use sequoia_openpgp as
openpgp;`. opengrep does **not** resolve that alias, which is why the rules in
the companion PR carry both spellings. The parser **does**: a probe written
entirely in the aliased form emitted `sequoia_openpgp::…` keys. So one spelling
suffices here, and that asymmetry is recorded in the file rather than left for
the next author to rediscover.

## Version range

`>=0.15.0,<3.0.0`. 0.1.0–0.14.x are excluded deliberately: those releases expose
`tpk` rather than `cert` (renamed at 0.13.0) and have **no `policy` module at
all** — it arrives at 0.15.0 — so the policy-aware entry points contracted here
do not exist there. `Encryptor2` is contracted because it exists inside the
committed range: absent at 1.16.0, present from 1.17.0, gone again at 2.0.0.

## Verification

- Contract test asserting the exact key, arity, role and return for 17 entries,
  plus a **wiring test** in the same commit that asserts the 10 forms an export
  actually emits resolve. `make lint` (pinned golangci-lint v2.10.1): **0 issues**.
  Package tests pass with `-race`.
- Independently confirmed in the family gate: all 7 mined versions serve
  `info_code: READY`, and `/dep-tree` returns 18 crypto entry points for
  `sequoia-openpgp@1.0.0`.

## The pre-existing lint fix, in its own commit

`style(scanner): extract the semgrep package's "unknown" placeholder`

`goconst` fails `make lint` on `internal/scanner/semgrep`: `"unknown"` appears in
`scanner.go`'s version fallback and `transformer.go`'s language sniff. **This
failure predates this branch** — `make lint` on `origin/main` reports the same
single issue, and this branch otherwise touches only the embedded contract KB. It
is a separate commit so it can be reverted independently of the contracts.


---

## Correction (post-merge)

Two counts in this description are wrong. The merged artifact is the authority:

```
$ git show origin/main:internal/callgraph/contracts/rust/sequoia-openpgp.yaml \
    | grep -cE '^\s*-\s*method:'
30
$ ... | grep -oE '^\s*-\s*method:\s*\S+' | sed 's/.*method:\s*//' | sort | uniq -d
sequoia_openpgp::cert::CertBuilder.general_purpose
```

- **30 entries, not 24.** 29 are distinct method keys; the one duplicate is
  `CertBuilder.general_purpose`, present deliberately at both arities because the signature
  changed across the declared range — a contract with only one of them joins for half the
  consumers and silently misses the rest.
- **The contract test asserts 23 entries, not 17** (23 table cases, each checking key, arity, role
  and return).

Neither number changes the contract itself — no commit has touched the YAML since this one
merged — but a description that undercounts what it shipped is worth fixing in place. Found by an
independent review of the downstream bookkeeping change.
