### PR TITLE
feat(callgraph): add gnark-crypto contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/gnark-crypto.yaml
+++ b/internal/callgraph/contracts/go/gnark-crypto.yaml
@@ -1,0 +1,130 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: gnark-crypto
+  coordinates:
+    - "github.com/consensys/gnark-crypto"
+  version_range: ">=0.4.0,<2.0.0"
+  description: "ConsenSys gnark-crypto generated curve primitives"
+
+# Inventory source: github.com/consensys/gnark-crypto v0.9.2 module source
+# from the Go module proxy. Contracted boundary per the family audit: the
+# flagship generated curve packages (ECDSA on bn254/bls12-381/secp256k1,
+# EdDSA/MiMC/KZG on bn254/bls12-381) and the top-level hash registry, each
+# with its exact generated-package identity. The remaining generated curves
+# repeat these shapes (bounded follow-up children); field/group arithmetic,
+# pairings, FFT, and marshalling are utilities (skipped-non-crypto).
+contracts:
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/ecdsa.GenerateKey
+    arity: 1
+    return: { type: "*github.com/consensys/gnark-crypto/ecc/bn254/ecdsa.PrivateKey", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/ecdsa.(*PrivateKey).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: hFunc, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/ecdsa.(*PublicKey).Verify
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: hFunc, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/ecdsa.GenerateKey
+    arity: 1
+    return: { type: "*github.com/consensys/gnark-crypto/ecc/bls12-381/ecdsa.PrivateKey", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/ecdsa.(*PrivateKey).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: hFunc, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/ecdsa.(*PublicKey).Verify
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: hFunc, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa.GenerateKey
+    arity: 1
+    return: { type: "*github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa.PrivateKey", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa.(*PrivateKey).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: hFunc, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa.(*PublicKey).Verify
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: hFunc, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa.GenerateKey
+    arity: 1
+    return: { type: "*github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa.PrivateKey", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa.(*PrivateKey).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa.(*PublicKey).Verify
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc.NewMiMC
+    arity: 0
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg.Commit
+    arity: 3
+    return: { type: "github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg.Digest", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: srs, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg.Open
+    arity: 3
+    return: { type: "github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg.OpeningProof", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg.Verify
+    arity: 4
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa.GenerateKey
+    arity: 1
+    return: { type: "*github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa.PrivateKey", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa.(*PrivateKey).Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa.(*PublicKey).Verify
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/fr/mimc.NewMiMC
+    arity: 0
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg.Commit
+    arity: 3
+    return: { type: "github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg.Digest", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: srs, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg.Open
+    arity: 3
+    return: { type: "github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg.OpeningProof", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/ecc/bls12-381/fr/kzg.Verify
+    arity: 4
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/consensys/gnark-crypto/hash.(Hash).New
+    arity: 0
+    return: { type: "hash.Hash", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go_gnark_crypto_test.go
+++ b/internal/callgraph/contracts/go_gnark_crypto_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGnarkCryptoContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role string
+		arity        int
+	}{
+		{"github.com/consensys/gnark-crypto/ecc/bn254/ecdsa.GenerateKey", "operation", 1},
+		{"github.com/consensys/gnark-crypto/ecc/secp256k1/ecdsa.(*PrivateKey).Sign", "operation", 2},
+		{"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards/eddsa.(*PublicKey).Verify", "operation", 3},
+		{"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc.NewMiMC", "factory", 0},
+		{"github.com/consensys/gnark-crypto/ecc/bn254/fr/kzg.Commit", "operation", 3},
+		{"github.com/consensys/gnark-crypto/hash.(Hash).New", "factory", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "gnark-crypto" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want gnark-crypto %s/high", contract, tt.role)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-consensys-gnark-crypto` (scanoss/crypto-mining-service#213).

## What

- `internal/callgraph/contracts/go/gnark-crypto.yaml` (27 contracts, `>=0.4.0,<2.0.0`): the flagship generated curve packages with exact per-curve identities — ECDSA GenerateKey/Sign/Verify on bn254/bls12-381/secp256k1, EdDSA on bn254/bls12-381, MiMC factories, KZG Commit/Open/Verify with SRS keyMaterial roles, and the top-level hash registry `(Hash).New`. The remaining generated curves are bounded follow-up children per the audit; arithmetic/pairings/FFT stay uncontracted.
- `go_gnark_crypto_test.go` asserts representative entries.

## Validation

- `go test ./internal/callgraph/contracts/...` and full `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (44 versions, candidate-built scanoss.api with this branch): evidence on scanoss/crypto-mining-service#213.

Refs scanoss/crypto-mining-service#213