### PR TITLE
feat(callgraph): add Vault SDK contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/vault-sdk.yaml
+++ b/internal/callgraph/contracts/go/vault-sdk.yaml
@@ -1,0 +1,92 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: vault-sdk
+  coordinates:
+    - "github.com/hashicorp/vault/sdk"
+  version_range: ">=0.1.0,<1.0.0"
+  description: "HashiCorp Vault SDK crypto helpers (keysutil transit, kdf, certutil)"
+
+# Inventory source: github.com/hashicorp/vault/sdk v0.9.2 module source from
+# the Go module proxy. Contracted boundary per the family audit: the keysutil
+# transit policy lifecycle, the SP 800-108 counter-mode KDF, and certutil key
+# parsing. The key type/algorithm lives in PolicyConfig/Policy state and is
+# capture-side. Storage, logical framework, plugin plumbing, base62/compress/
+# json helpers, and the salt/locksutil utilities are out of the crypto
+# boundary (skipped-non-crypto); cryptoutil's small blake2b wrapper and
+# managed-key interfaces are bounded follow-ups.
+contracts:
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.NewPolicy
+    arity: 1
+    return: { type: "*github.com/hashicorp/vault/sdk/helper/keysutil.Policy", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: config, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.NewLockManager
+    arity: 2
+    return: { type: "*github.com/hashicorp/vault/sdk/helper/keysutil.LockManager", confidence: high }
+    role: factory
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*LockManager).GetPolicy
+    arity: 3
+    return: { type: "*github.com/hashicorp/vault/sdk/helper/keysutil.Policy", confidence: high }
+    role: factory
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Encrypt
+    arity: 4
+    return: { type: "string", confidence: high }
+    role: operation
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Decrypt
+    arity: 3
+    return: { type: "string", confidence: high }
+    role: operation
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Sign
+    arity: 6
+    return: { type: "*github.com/hashicorp/vault/sdk/helper/keysutil.SigningResult", confidence: high }
+    role: operation
+    parameters:
+      - { index: 3, name: hashAlgorithm, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).VerifySignature
+    arity: 6
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: hashAlgorithm, role: metadata-contributing, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).HMACKey
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Rotate
+    arity: 3
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Import
+    arity: 4
+    return: { type: "()", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Backup
+    arity: 2
+    return: { type: "string", confidence: high }
+    role: output
+  - method: github.com/hashicorp/vault/sdk/helper/kdf.CounterMode
+    arity: 5
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 2, name: key, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+      - { index: 4, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/hashicorp/vault/sdk/helper/kdf.HMACSHA256PRF
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/hashicorp/vault/sdk/helper/certutil.ParsePEMKey
+    arity: 1
+    return: { type: "crypto.Signer", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: keyPem, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/hashicorp/vault/sdk/helper/certutil.ParsePEMBundle
+    arity: 1
+    return: { type: "*github.com/hashicorp/vault/sdk/helper/certutil.ParsedCertBundle", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go_vault_sdk_test.go
+++ b/internal/callgraph/contracts/go_vault_sdk_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesVaultSDKContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/hashicorp/vault/sdk/helper/keysutil.NewPolicy", "factory", "algorithm", 1},
+		{"github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Encrypt", "operation", "", 4},
+		{"github.com/hashicorp/vault/sdk/helper/keysutil.(*Policy).Sign", "operation", "algorithm", 6},
+		{"github.com/hashicorp/vault/sdk/helper/kdf.CounterMode", "operation", "keySize", 5},
+		{"github.com/hashicorp/vault/sdk/helper/certutil.ParsePEMKey", "factory", "keyMaterial", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "vault-sdk" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want vault-sdk %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -1222,10 +1222,31 @@ func buildExportChain(fc *FindingChain, root ComponentKey, ecosystem string) ([]
 		node := buildExportNode(frame, root, ecosystem)
 		if i == len(fc.Frames)-1 && fc.CryptoOp != nil {
 			resolvedFindingID = applyTerminalCryptoOp(&node, frame, fc.CryptoOp, root)
+			synthesizePackageLevelIdentity(&node, fc.CryptoOp)
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, resolvedFindingID
+}
+
+// synthesizePackageLevelIdentity stamps identity on a terminal frame whose op
+// anchors at package scope (a finding inside a var/const initializer): the op
+// is keyed to an empty signature, so both the frame Function and Signature are
+// empty. The render path rejects identity-less frames, so the op location
+// becomes the identity.
+func synthesizePackageLevelIdentity(node *ExportChainNode, op *CryptoOperation) {
+	if node.FunctionName != "" || node.CanonicalSignature != "" {
+		return
+	}
+	synth := "<package-level:" + op.FilePath + ":" + strconv.Itoa(op.StartLine) + ">"
+	node.FunctionName = synth
+	node.FunctionKey = synth
+	if node.FilePath == "" {
+		node.FilePath = op.FilePath
+	}
+	if node.StartLine == 0 {
+		node.StartLine = op.StartLine
+	}
 }
 
 func applyTerminalCryptoOp(node *ExportChainNode, frame *CallFrame, op *CryptoOperation, root ComponentKey) string {
@@ -1294,6 +1315,14 @@ func buildExportNode(frame *CallFrame, root ComponentKey, ecosystem string) Expo
 		EntryCall:          exportEntryCall(frame.EntryCall, fn),
 		EntryResolution:    string(frame.EntryResolution),
 		EntryDeclaredType:  frame.EntryDeclaredType,
+	}
+	// A package-level anchor (a finding inside a var/const initializer) has no
+	// resolved Function in the fragment catalog, but the frame still carries
+	// its signature. Fall back to it so no served frame ships without identity
+	// (the render path rejects identity-less frames).
+	if node.FunctionName == "" && node.CanonicalSignature == "" && frame.Signature != "" {
+		node.FunctionKey = frame.Signature
+		node.FunctionName = frame.Signature
 	}
 	// Stamp dependency_info on non-root frames (ADR-4). The module string comes
 	// from the CallFrame.Module (Fragment.Module, set at stitch time), falling

--- a/pkg/graphfrag/export_anchor_identity_test.go
+++ b/pkg/graphfrag/export_anchor_identity_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestBuildExportNodeFallsBackToFrameSignature pins that a frame whose
+// Function never resolved in the fragment catalog (a package-level var/const
+// initializer anchor) still ships an identity: the frame signature. The
+// serving render rejects identity-less frames.
+func TestBuildExportNodeFallsBackToFrameSignature(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.<varinit:consts>",
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionName = %q, want the frame signature", node.FunctionName)
+	}
+	if node.FunctionKey != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionKey = %q, want the frame signature", node.FunctionKey)
+	}
+}
+
+// TestBuildExportNodeKeepsResolvedIdentity pins that the fallback never
+// clobbers a resolved Function identity.
+func TestBuildExportNodeKeepsResolvedIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.Real",
+		Function: Function{
+			Signature:    "example.com/lib.Real",
+			FunctionName: "example.com/lib.Real",
+		},
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.Real" {
+		t.Fatalf("FunctionName = %q", node.FunctionName)
+	}
+}
+
+// TestBuildExportChainSynthesizesPackageLevelIdentity pins that a single-frame
+// chain whose op anchors at package scope (empty function signature end to
+// end) ships a synthesized identity from the op location.
+func TestBuildExportChainSynthesizesPackageLevelIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	fc := FindingChain{
+		FindingID: "abcd1234",
+		Frames:    []CallFrame{{Component: root}},
+		CryptoOp:  &CryptoOperation{FilePath: "helper/consts.go", StartLine: 12, RuleID: "r"},
+	}
+	nodes, _ := buildExportChain(&fc, root, "go")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(nodes))
+	}
+	if nodes[0].FunctionName != "<package-level:helper/consts.go:12>" {
+		t.Fatalf("FunctionName = %q", nodes[0].FunctionName)
+	}
+	if nodes[0].FilePath == "" {
+		t.Fatal("FilePath empty")
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-hashicorp-vault-sdk` (scanoss/crypto-mining-service#218).

## What

- `internal/callgraph/contracts/go/vault-sdk.yaml` (16 contracts, `>=0.1.0,<1.0.0`): the keysutil transit policy lifecycle (factories with operation-determining PolicyConfig, encrypt/decrypt, sign/verify with hash-algorithm roles, HMAC key derivation, rotate/import/backup), the SP 800-108 counter-mode KDF with keySize roles, and certutil key parsing. Dispositions in the header.
- **Engine fix found by this family's gate, carried as its own commit**: a finding inside a package-level var/const initializer (vault's `keysutil/consts.go` maps `sha1.New`/`sha256.New` values) anchors to no enclosing function, so its stitched chain frame shipped with an EMPTY identity and the serving render rejected the entire component (`render: interned callgraph frame missing identity` — every version failed the serve hop). `pkg/graphfrag` now synthesizes the identity from the op location (`<package-level:file:line>`) with unit tests pinning both the fallback and that resolved identities are never clobbered.
- `go_vault_sdk_test.go` asserts representative contract entries.

## Validation

- `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (47 versions, candidate-built scanoss.api with this branch): 94/94 integration tests PASS — 0/94 before the graphfrag fix. Evidence on scanoss/crypto-mining-service#218.

Refs scanoss/crypto-mining-service#218