### PR TITLE
feat(callgraph): add uTLS contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/utls.yaml
+++ b/internal/callgraph/contracts/go/utls.yaml
@@ -1,0 +1,75 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: utls
+  coordinates:
+    - "github.com/refraction-networking/utls"
+  version_range: ">=0.9.0,<2.0.0"
+  description: "uTLS crypto/tls fork with ClientHello fingerprinting"
+
+# Inventory source: github.com/refraction-networking/utls v1.8.2 module source
+# from the Go module proxy. The fork keeps package name tls; contracts pin the
+# fork import path so the stdlib and the fork never share an FQN. The
+# ClientHelloID names a parroted fingerprint profile, never the negotiated
+# runtime suite (family audit). The forked stdlib surface (Conn read/write,
+# config plumbing, session cache) mirrors crypto/tls semantics and stays
+# uncontracted at this boundary; the dicttls constant tables and extension
+# structs are data (skipped-non-crypto).
+contracts:
+  - method: github.com/refraction-networking/utls.UClient
+    arity: 3
+    return: { type: "*github.com/refraction-networking/utls.UConn", confidence: high }
+    role: factory
+    parameters:
+      - { index: 2, name: clientHelloID, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/refraction-networking/utls.Client
+    arity: 2
+    return: { type: "*github.com/refraction-networking/utls.Conn", confidence: high }
+    role: factory
+  - method: github.com/refraction-networking/utls.Server
+    arity: 2
+    return: { type: "*github.com/refraction-networking/utls.Conn", confidence: high }
+    role: factory
+  - method: github.com/refraction-networking/utls.Dial
+    arity: 3
+    return: { type: "*github.com/refraction-networking/utls.Conn", confidence: high }
+    role: factory
+  - method: github.com/refraction-networking/utls.DialWithDialer
+    arity: 4
+    return: { type: "*github.com/refraction-networking/utls.Conn", confidence: high }
+    role: factory
+  - method: github.com/refraction-networking/utls.(*UConn).Handshake
+    arity: 0
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/refraction-networking/utls.(*UConn).HandshakeContext
+    arity: 1
+    return: { type: "()", confidence: high }
+    role: operation
+  - method: github.com/refraction-networking/utls.(*UConn).BuildHandshakeState
+    arity: 0
+    return: { type: "()", confidence: high }
+    role: config
+  - method: github.com/refraction-networking/utls.(*UConn).BuildHandshakeStateWithoutSession
+    arity: 0
+    return: { type: "()", confidence: high }
+    role: config
+  - method: github.com/refraction-networking/utls.(*UConn).ApplyPreset
+    arity: 1
+    return: { type: "()", confidence: high }
+    role: config
+    parameters:
+      - { index: 0, name: p, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+  - method: github.com/refraction-networking/utls.LoadX509KeyPair
+    arity: 2
+    return: { type: "github.com/refraction-networking/utls.Certificate", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: certFile, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/refraction-networking/utls.X509KeyPair
+    arity: 2
+    return: { type: "github.com/refraction-networking/utls.Certificate", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: certPEMBlock, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+hierarchy: {}

--- a/internal/callgraph/contracts/go_utls_test.go
+++ b/internal/callgraph/contracts/go_utls_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesUTLSContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/refraction-networking/utls.UClient", "factory", "algorithm", 3},
+		{"github.com/refraction-networking/utls.(*UConn).Handshake", "operation", "", 0},
+		{"github.com/refraction-networking/utls.(*UConn).ApplyPreset", "config", "algorithm", 1},
+		{"github.com/refraction-networking/utls.X509KeyPair", "factory", "keyMaterial", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "utls" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want utls %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -1222,10 +1222,31 @@ func buildExportChain(fc *FindingChain, root ComponentKey, ecosystem string) ([]
 		node := buildExportNode(frame, root, ecosystem)
 		if i == len(fc.Frames)-1 && fc.CryptoOp != nil {
 			resolvedFindingID = applyTerminalCryptoOp(&node, frame, fc.CryptoOp, root)
+			synthesizePackageLevelIdentity(&node, fc.CryptoOp)
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, resolvedFindingID
+}
+
+// synthesizePackageLevelIdentity stamps identity on a terminal frame whose op
+// anchors at package scope (a finding inside a var/const initializer): the op
+// is keyed to an empty signature, so both the frame Function and Signature are
+// empty. The render path rejects identity-less frames, so the op location
+// becomes the identity.
+func synthesizePackageLevelIdentity(node *ExportChainNode, op *CryptoOperation) {
+	if node.FunctionName != "" || node.CanonicalSignature != "" {
+		return
+	}
+	synth := "<package-level:" + op.FilePath + ":" + strconv.Itoa(op.StartLine) + ">"
+	node.FunctionName = synth
+	node.FunctionKey = synth
+	if node.FilePath == "" {
+		node.FilePath = op.FilePath
+	}
+	if node.StartLine == 0 {
+		node.StartLine = op.StartLine
+	}
 }
 
 func applyTerminalCryptoOp(node *ExportChainNode, frame *CallFrame, op *CryptoOperation, root ComponentKey) string {
@@ -1294,6 +1315,14 @@ func buildExportNode(frame *CallFrame, root ComponentKey, ecosystem string) Expo
 		EntryCall:          exportEntryCall(frame.EntryCall, fn),
 		EntryResolution:    string(frame.EntryResolution),
 		EntryDeclaredType:  frame.EntryDeclaredType,
+	}
+	// A package-level anchor (a finding inside a var/const initializer) has no
+	// resolved Function in the fragment catalog, but the frame still carries
+	// its signature. Fall back to it so no served frame ships without identity
+	// (the render path rejects identity-less frames).
+	if node.FunctionName == "" && node.CanonicalSignature == "" && frame.Signature != "" {
+		node.FunctionKey = frame.Signature
+		node.FunctionName = frame.Signature
 	}
 	// Stamp dependency_info on non-root frames (ADR-4). The module string comes
 	// from the CallFrame.Module (Fragment.Module, set at stitch time), falling

--- a/pkg/graphfrag/export_anchor_identity_test.go
+++ b/pkg/graphfrag/export_anchor_identity_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestBuildExportNodeFallsBackToFrameSignature pins that a frame whose
+// Function never resolved in the fragment catalog (a package-level var/const
+// initializer anchor) still ships an identity: the frame signature. The
+// serving render rejects identity-less frames.
+func TestBuildExportNodeFallsBackToFrameSignature(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.<varinit:consts>",
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionName = %q, want the frame signature", node.FunctionName)
+	}
+	if node.FunctionKey != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionKey = %q, want the frame signature", node.FunctionKey)
+	}
+}
+
+// TestBuildExportNodeKeepsResolvedIdentity pins that the fallback never
+// clobbers a resolved Function identity.
+func TestBuildExportNodeKeepsResolvedIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.Real",
+		Function: Function{
+			Signature:    "example.com/lib.Real",
+			FunctionName: "example.com/lib.Real",
+		},
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.Real" {
+		t.Fatalf("FunctionName = %q", node.FunctionName)
+	}
+}
+
+// TestBuildExportChainSynthesizesPackageLevelIdentity pins that a single-frame
+// chain whose op anchors at package scope (empty function signature end to
+// end) ships a synthesized identity from the op location.
+func TestBuildExportChainSynthesizesPackageLevelIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	fc := FindingChain{
+		FindingID: "abcd1234",
+		Frames:    []CallFrame{{Component: root}},
+		CryptoOp:  &CryptoOperation{FilePath: "helper/consts.go", StartLine: 12, RuleID: "r"},
+	}
+	nodes, _ := buildExportChain(&fc, root, "go")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(nodes))
+	}
+	if nodes[0].FunctionName != "<package-level:helper/consts.go:12>" {
+		t.Fatalf("FunctionName = %q", nodes[0].FunctionName)
+	}
+	if nodes[0].FilePath == "" {
+		t.Fatal("FilePath empty")
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-refraction-networking-utls` (scanoss/crypto-mining-service#228).

## What

- `internal/callgraph/contracts/go/utls.yaml` (13 contracts, `>=0.9.0,<2.0.0`): UClient with the operation-determining ClientHelloID, client/server/dial factories, UConn handshake operations and preset configuration, and X509 key-pair loading. The fork keeps package `tls` and never shares an FQN with the stdlib. Dispositions in the header.
- Carries the package-level anchor identity fix from scanoss/crypto-finder#405 (cherry-pick; 30 of 55 utls versions hit the same `render: interned callgraph frame missing identity` failure without it — utls also holds crypto findings in package-level initializers). Deduplicates on merge; merge #405 first.
- `go_utls_test.go` asserts representative entries.

## Validation

- `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (55 versions, candidate-built scanoss.api with this branch): 110/110 integration tests PASS (25/55 versions passed before the identity fix). Evidence on scanoss/crypto-mining-service#228.

## Merge order

Merge scanoss/crypto-finder#405 first (the graphfrag fix), then this PR.

Refs scanoss/crypto-mining-service#228