### PR TITLE
feat(callgraph): add go-libp2p contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/go-libp2p.yaml
+++ b/internal/callgraph/contracts/go/go-libp2p.yaml
@@ -1,0 +1,100 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: go-libp2p
+  coordinates:
+    - "github.com/libp2p/go-libp2p"
+  version_range: ">=0.0.1,<1.0.0"
+  description: "go-libp2p core/crypto key and signature boundary"
+
+# Inventory source: github.com/libp2p/go-libp2p v0.48.0 module source from the
+# Go module proxy. Contracted boundary per the family audit: the core/crypto
+# key interfaces (interface-authored Sign/Verify with concrete resolution),
+# per-family and generic key generation, and marshal/unmarshal/std-key
+# conversion. The pre-modules gx-era tags (v6.x +incompatible) expose the
+# crypto package at a different path and never match these identities.
+# Transports, muxers, peer/host plumbing, and the rest of the host stack are
+# out of the crypto boundary (skipped-non-crypto); secure-transport session
+# setup (noise, tls) delegates to its own modules (bounded follow-ups).
+contracts:
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateKeyPair
+    arity: 2
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: typ, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateKeyPairWithReader
+    arity: 3
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: typ, role: operation-determining, contributes: { property: algorithm, derivation: argument_value } }
+      - { index: 1, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateEd25519Key
+    arity: 1
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateECDSAKeyPair
+    arity: 1
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateECDSAKeyPairWithCurve
+    arity: 2
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: curve, role: metadata-contributing, contributes: { property: curve, derivation: argument_value } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateSecp256k1Key
+    arity: 1
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+  - method: github.com/libp2p/go-libp2p/core/crypto.GenerateRSAKeyPair
+    arity: 2
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: bits, role: metadata-contributing, contributes: { property: keySize, derivation: argument_value } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.UnmarshalPrivateKey
+    arity: 1
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: data, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.UnmarshalPublicKey
+    arity: 1
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PubKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: data, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.MarshalPrivateKey
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/libp2p/go-libp2p/core/crypto.MarshalPublicKey
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/libp2p/go-libp2p/core/crypto.KeyPairFromStdKey
+    arity: 1
+    return: { type: "github.com/libp2p/go-libp2p/core/crypto.PrivKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: priv, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/libp2p/go-libp2p/core/crypto.PrivKeyToStdKey
+    arity: 1
+    return: { type: "crypto.PrivateKey", confidence: high }
+    role: output
+  - method: github.com/libp2p/go-libp2p/core/crypto.PubKeyToStdKey
+    arity: 1
+    return: { type: "crypto.PublicKey", confidence: high }
+    role: output
+  - method: github.com/libp2p/go-libp2p/core/crypto.(PrivKey).Sign
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/libp2p/go-libp2p/core/crypto.(PubKey).Verify
+    arity: 2
+    return: { type: "bool", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go_go_libp2p_test.go
+++ b/internal/callgraph/contracts/go_go_libp2p_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGoLibp2pContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/libp2p/go-libp2p/core/crypto.GenerateKeyPair", "factory", "algorithm", 2},
+		{"github.com/libp2p/go-libp2p/core/crypto.GenerateRSAKeyPair", "factory", "keySize", 2},
+		{"github.com/libp2p/go-libp2p/core/crypto.UnmarshalPrivateKey", "factory", "keyMaterial", 1},
+		{"github.com/libp2p/go-libp2p/core/crypto.(PrivKey).Sign", "operation", "", 1},
+		{"github.com/libp2p/go-libp2p/core/crypto.(PubKey).Verify", "operation", "", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "go-libp2p" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want go-libp2p %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -1222,10 +1222,31 @@ func buildExportChain(fc *FindingChain, root ComponentKey, ecosystem string) ([]
 		node := buildExportNode(frame, root, ecosystem)
 		if i == len(fc.Frames)-1 && fc.CryptoOp != nil {
 			resolvedFindingID = applyTerminalCryptoOp(&node, frame, fc.CryptoOp, root)
+			synthesizePackageLevelIdentity(&node, fc.CryptoOp)
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, resolvedFindingID
+}
+
+// synthesizePackageLevelIdentity stamps identity on a terminal frame whose op
+// anchors at package scope (a finding inside a var/const initializer): the op
+// is keyed to an empty signature, so both the frame Function and Signature are
+// empty. The render path rejects identity-less frames, so the op location
+// becomes the identity.
+func synthesizePackageLevelIdentity(node *ExportChainNode, op *CryptoOperation) {
+	if node.FunctionName != "" || node.CanonicalSignature != "" {
+		return
+	}
+	synth := "<package-level:" + op.FilePath + ":" + strconv.Itoa(op.StartLine) + ">"
+	node.FunctionName = synth
+	node.FunctionKey = synth
+	if node.FilePath == "" {
+		node.FilePath = op.FilePath
+	}
+	if node.StartLine == 0 {
+		node.StartLine = op.StartLine
+	}
 }
 
 func applyTerminalCryptoOp(node *ExportChainNode, frame *CallFrame, op *CryptoOperation, root ComponentKey) string {
@@ -1294,6 +1315,14 @@ func buildExportNode(frame *CallFrame, root ComponentKey, ecosystem string) Expo
 		EntryCall:          exportEntryCall(frame.EntryCall, fn),
 		EntryResolution:    string(frame.EntryResolution),
 		EntryDeclaredType:  frame.EntryDeclaredType,
+	}
+	// A package-level anchor (a finding inside a var/const initializer) has no
+	// resolved Function in the fragment catalog, but the frame still carries
+	// its signature. Fall back to it so no served frame ships without identity
+	// (the render path rejects identity-less frames).
+	if node.FunctionName == "" && node.CanonicalSignature == "" && frame.Signature != "" {
+		node.FunctionKey = frame.Signature
+		node.FunctionName = frame.Signature
 	}
 	// Stamp dependency_info on non-root frames (ADR-4). The module string comes
 	// from the CallFrame.Module (Fragment.Module, set at stitch time), falling

--- a/pkg/graphfrag/export_anchor_identity_test.go
+++ b/pkg/graphfrag/export_anchor_identity_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestBuildExportNodeFallsBackToFrameSignature pins that a frame whose
+// Function never resolved in the fragment catalog (a package-level var/const
+// initializer anchor) still ships an identity: the frame signature. The
+// serving render rejects identity-less frames.
+func TestBuildExportNodeFallsBackToFrameSignature(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.<varinit:consts>",
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionName = %q, want the frame signature", node.FunctionName)
+	}
+	if node.FunctionKey != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionKey = %q, want the frame signature", node.FunctionKey)
+	}
+}
+
+// TestBuildExportNodeKeepsResolvedIdentity pins that the fallback never
+// clobbers a resolved Function identity.
+func TestBuildExportNodeKeepsResolvedIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.Real",
+		Function: Function{
+			Signature:    "example.com/lib.Real",
+			FunctionName: "example.com/lib.Real",
+		},
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.Real" {
+		t.Fatalf("FunctionName = %q", node.FunctionName)
+	}
+}
+
+// TestBuildExportChainSynthesizesPackageLevelIdentity pins that a single-frame
+// chain whose op anchors at package scope (empty function signature end to
+// end) ships a synthesized identity from the op location.
+func TestBuildExportChainSynthesizesPackageLevelIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	fc := FindingChain{
+		FindingID: "abcd1234",
+		Frames:    []CallFrame{{Component: root}},
+		CryptoOp:  &CryptoOperation{FilePath: "helper/consts.go", StartLine: 12, RuleID: "r"},
+	}
+	nodes, _ := buildExportChain(&fc, root, "go")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(nodes))
+	}
+	if nodes[0].FunctionName != "<package-level:helper/consts.go:12>" {
+		t.Fatalf("FunctionName = %q", nodes[0].FunctionName)
+	}
+	if nodes[0].FilePath == "" {
+		t.Fatal("FilePath empty")
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-libp2p-go-libp2p` (scanoss/crypto-mining-service#221).

## What

- `internal/callgraph/contracts/go/go-libp2p.yaml` (17 contracts, `>=0.0.1,<1.0.0`): the `core/crypto` boundary — type-selector and per-family key factories with keySize/curve roles, marshal/unmarshal and std-key conversion, and the interface-authored `PrivKey.Sign`/`PubKey.Verify` operations. The gx-era v6 `+incompatible` tags expose the crypto package at a different path and never match these identities. Dispositions in the header.
- Carries the package-level anchor identity fix from scanoss/crypto-finder#405 (cherry-pick); deduplicates on merge — merge #405 first.
- `go_go_libp2p_test.go` asserts representative entries.

## Validation

- `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (184 versions, candidate-built scanoss.api with this branch): 368/368 integration tests PASS. Evidence on scanoss/crypto-mining-service#221.

## Merge order

Merge scanoss/crypto-finder#405 first (the graphfrag fix), then this PR.

Refs scanoss/crypto-mining-service#221