### PR TITLE
feat(callgraph): add go-ethereum contracts for the Go KB

### DIFF
--- a/internal/callgraph/contracts/go/go-ethereum.yaml
+++ b/internal/callgraph/contracts/go/go-ethereum.yaml
@@ -1,0 +1,83 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: go-ethereum
+  coordinates:
+    - "github.com/ethereum/go-ethereum"
+  version_range: ">=1.9.0,<2.0.0"
+  description: "go-ethereum core crypto package (secp256k1 ECDSA, Keccak-256)"
+
+# Inventory source: github.com/ethereum/go-ethereum v1.17.4 module source from
+# the Go module proxy. Contracted boundary per the family audit: the public
+# crypto package (key factories, ECDSA sign/verify/recover, Keccak hashing,
+# key serialization). Address derivation (PubkeyToAddress) is not a crypto
+# operation and stays uncontracted; the bn256/bls12381/kzg4844/secp256k1
+# subpackages and the ecies/signify helpers are bounded follow-up children;
+# oversized-module MAX_GO_FILES/timeout skips are recorded as such, never as
+# semantic validation.
+contracts:
+  - method: github.com/ethereum/go-ethereum/crypto.GenerateKey
+    arity: 0
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: factory
+  - method: github.com/ethereum/go-ethereum/crypto.ToECDSA
+    arity: 1
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: d, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ethereum/go-ethereum/crypto.HexToECDSA
+    arity: 1
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: hexkey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ethereum/go-ethereum/crypto.LoadECDSA
+    arity: 1
+    return: { type: "*crypto/ecdsa.PrivateKey", confidence: high }
+    role: factory
+  - method: github.com/ethereum/go-ethereum/crypto.UnmarshalPubkey
+    arity: 1
+    return: { type: "*crypto/ecdsa.PublicKey", confidence: high }
+    role: factory
+    parameters:
+      - { index: 0, name: pub, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ethereum/go-ethereum/crypto.FromECDSA
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/ethereum/go-ethereum/crypto.FromECDSAPub
+    arity: 1
+    return: { type: "[]byte", confidence: high }
+    role: output
+  - method: github.com/ethereum/go-ethereum/crypto.Sign
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+    parameters:
+      - { index: 1, name: prv, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_type } }
+  - method: github.com/ethereum/go-ethereum/crypto.VerifySignature
+    arity: 3
+    return: { type: "bool", confidence: high }
+    role: operation
+    parameters:
+      - { index: 0, name: pubkey, role: metadata-contributing, contributes: { property: keyMaterial, derivation: argument_value } }
+  - method: github.com/ethereum/go-ethereum/crypto.Ecrecover
+    arity: 2
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/ethereum/go-ethereum/crypto.SigToPub
+    arity: 2
+    return: { type: "*crypto/ecdsa.PublicKey", confidence: high }
+    role: operation
+  - method: github.com/ethereum/go-ethereum/crypto.Keccak256
+    arity: 1
+    varargs: true
+    return: { type: "[]byte", confidence: high }
+    role: operation
+  - method: github.com/ethereum/go-ethereum/crypto.Keccak256Hash
+    arity: 1
+    varargs: true
+    return: { type: "github.com/ethereum/go-ethereum/common.Hash", confidence: high }
+    role: operation
+hierarchy: {}

--- a/internal/callgraph/contracts/go_go_ethereum_test.go
+++ b/internal/callgraph/contracts/go_go_ethereum_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesGoEthereumContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, role, property string
+		arity                  int
+	}{
+		{"github.com/ethereum/go-ethereum/crypto.GenerateKey", "factory", "", 0},
+		{"github.com/ethereum/go-ethereum/crypto.HexToECDSA", "factory", "keyMaterial", 1},
+		{"github.com/ethereum/go-ethereum/crypto.Sign", "operation", "keyMaterial", 2},
+		{"github.com/ethereum/go-ethereum/crypto.Ecrecover", "operation", "", 2},
+		{"github.com/ethereum/go-ethereum/crypto.Keccak256", "operation", "", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != "go-ethereum" || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want go-ethereum %s/high", contract, tt.role)
+			}
+			if tt.property == "" {
+				return
+			}
+			for _, parameter := range contract.Parameters {
+				if parameter.Contributes != nil && parameter.Contributes.Property == tt.property {
+					return
+				}
+			}
+			t.Fatalf("contract parameters = %#v, want contribution for %q", contract.Parameters, tt.property)
+		})
+	}
+}

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -1222,10 +1222,31 @@ func buildExportChain(fc *FindingChain, root ComponentKey, ecosystem string) ([]
 		node := buildExportNode(frame, root, ecosystem)
 		if i == len(fc.Frames)-1 && fc.CryptoOp != nil {
 			resolvedFindingID = applyTerminalCryptoOp(&node, frame, fc.CryptoOp, root)
+			synthesizePackageLevelIdentity(&node, fc.CryptoOp)
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, resolvedFindingID
+}
+
+// synthesizePackageLevelIdentity stamps identity on a terminal frame whose op
+// anchors at package scope (a finding inside a var/const initializer): the op
+// is keyed to an empty signature, so both the frame Function and Signature are
+// empty. The render path rejects identity-less frames, so the op location
+// becomes the identity.
+func synthesizePackageLevelIdentity(node *ExportChainNode, op *CryptoOperation) {
+	if node.FunctionName != "" || node.CanonicalSignature != "" {
+		return
+	}
+	synth := "<package-level:" + op.FilePath + ":" + strconv.Itoa(op.StartLine) + ">"
+	node.FunctionName = synth
+	node.FunctionKey = synth
+	if node.FilePath == "" {
+		node.FilePath = op.FilePath
+	}
+	if node.StartLine == 0 {
+		node.StartLine = op.StartLine
+	}
 }
 
 func applyTerminalCryptoOp(node *ExportChainNode, frame *CallFrame, op *CryptoOperation, root ComponentKey) string {
@@ -1294,6 +1315,14 @@ func buildExportNode(frame *CallFrame, root ComponentKey, ecosystem string) Expo
 		EntryCall:          exportEntryCall(frame.EntryCall, fn),
 		EntryResolution:    string(frame.EntryResolution),
 		EntryDeclaredType:  frame.EntryDeclaredType,
+	}
+	// A package-level anchor (a finding inside a var/const initializer) has no
+	// resolved Function in the fragment catalog, but the frame still carries
+	// its signature. Fall back to it so no served frame ships without identity
+	// (the render path rejects identity-less frames).
+	if node.FunctionName == "" && node.CanonicalSignature == "" && frame.Signature != "" {
+		node.FunctionKey = frame.Signature
+		node.FunctionName = frame.Signature
 	}
 	// Stamp dependency_info on non-root frames (ADR-4). The module string comes
 	// from the CallFrame.Module (Fragment.Module, set at stitch time), falling

--- a/pkg/graphfrag/export_anchor_identity_test.go
+++ b/pkg/graphfrag/export_anchor_identity_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestBuildExportNodeFallsBackToFrameSignature pins that a frame whose
+// Function never resolved in the fragment catalog (a package-level var/const
+// initializer anchor) still ships an identity: the frame signature. The
+// serving render rejects identity-less frames.
+func TestBuildExportNodeFallsBackToFrameSignature(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.<varinit:consts>",
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionName = %q, want the frame signature", node.FunctionName)
+	}
+	if node.FunctionKey != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionKey = %q, want the frame signature", node.FunctionKey)
+	}
+}
+
+// TestBuildExportNodeKeepsResolvedIdentity pins that the fallback never
+// clobbers a resolved Function identity.
+func TestBuildExportNodeKeepsResolvedIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.Real",
+		Function: Function{
+			Signature:    "example.com/lib.Real",
+			FunctionName: "example.com/lib.Real",
+		},
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.Real" {
+		t.Fatalf("FunctionName = %q", node.FunctionName)
+	}
+}
+
+// TestBuildExportChainSynthesizesPackageLevelIdentity pins that a single-frame
+// chain whose op anchors at package scope (empty function signature end to
+// end) ships a synthesized identity from the op location.
+func TestBuildExportChainSynthesizesPackageLevelIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	fc := FindingChain{
+		FindingID: "abcd1234",
+		Frames:    []CallFrame{{Component: root}},
+		CryptoOp:  &CryptoOperation{FilePath: "helper/consts.go", StartLine: 12, RuleID: "r"},
+	}
+	nodes, _ := buildExportChain(&fc, root, "go")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(nodes))
+	}
+	if nodes[0].FunctionName != "<package-level:helper/consts.go:12>" {
+		t.Fatalf("FunctionName = %q", nodes[0].FunctionName)
+	}
+	if nodes[0].FilePath == "" {
+		t.Fatal("FilePath empty")
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `golang-github-com-ethereum-go-ethereum` (scanoss/crypto-mining-service#215).

## What

- `internal/callgraph/contracts/go/go-ethereum.yaml` (13 contracts, `>=1.9.0,<2.0.0`): the public `crypto` package — secp256k1 key factories, ECDSA sign/verify/recover operations, Keccak-256 hashing, and key serialization outputs. Address derivation is not a crypto operation; the bn256/bls12381/kzg4844 subpackages are bounded follow-up children per the family audit. Dispositions in the header.
- Carries the package-level anchor identity fix from scanoss/crypto-finder#405 (cherry-pick); go-ethereum's crypto consts hit the same `render: interned callgraph frame missing identity` failure (all 243 versions failed the serve hop without it). Deduplicates on merge; merge #405 first.
- `go_go_ethereum_test.go` asserts representative entries.

## Validation

- `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (243 versions, candidate-built scanoss.api with this branch): 486/486 integration tests PASS (0/243 versions passed before the identity fix). Evidence on scanoss/crypto-mining-service#215.

## Merge order

Merge scanoss/crypto-finder#405 first (the graphfrag fix), then this PR.

Refs scanoss/crypto-mining-service#215