### PR TITLE
feat(callgraph): add AWS KMS contracts for both SDK generations

### DIFF
--- a/internal/callgraph/contracts/go/aws-kms-v2.yaml
+++ b/internal/callgraph/contracts/go/aws-kms-v2.yaml
@@ -1,0 +1,88 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: aws-kms-v2
+  coordinates:
+    - "github.com/aws/aws-sdk-go-v2/service/kms"
+  version_range: ">=1.0.0,<2.0.0"
+  description: "aws-sdk-go-v2 KMS service"
+
+# Inventory source: the newest committed CSV tag of github.com/aws/aws-sdk-go-v2/service/kms from the Go module
+# proxy. Every operation runs remotely inside AWS KMS; the algorithm and
+# key-spec live in the request input structs and are exposed as capture-side
+# state, never inferred (family audit: no HSM/provider/certification claims).
+# v1 aws-sdk-go is a 322 MB monorepo module - only the service/kms client is
+# contracted here; other services stay out of scope. Pagers, waiters, request
+# builders, and the generated model/types are structural (skipped-non-crypto).
+contracts:
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.New
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.Client", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.NewFromConfig
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.Client", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).Encrypt
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.EncryptOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).ReEncrypt
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.ReEncryptOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).Decrypt
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.DecryptOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).Sign
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.SignOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).Verify
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.VerifyOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).GenerateMac
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.GenerateMacOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).VerifyMac
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.VerifyMacOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).GenerateDataKey
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.GenerateDataKeyOutput", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).GenerateDataKeyPair
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.GenerateDataKeyPairOutput", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).DeriveSharedSecret
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.DeriveSharedSecretOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).GenerateRandom
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.GenerateRandomOutput", confidence: high }
+    role: output
+  - method: github.com/aws/aws-sdk-go-v2/service/kms.(*Client).CreateKey
+    arity: 3
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go-v2/service/kms.CreateKeyOutput", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go/aws-kms.yaml
+++ b/internal/callgraph/contracts/go/aws-kms.yaml
@@ -1,0 +1,83 @@
+schema_version: "2"
+ecosystem: go
+library:
+  name: aws-kms
+  coordinates:
+    - "github.com/aws/aws-sdk-go/service/kms"
+  version_range: ">=1.0.0,<2.0.0"
+  description: "aws-sdk-go v1 KMS service"
+
+# Inventory source: the newest committed CSV tag of github.com/aws/aws-sdk-go/service/kms from the Go module
+# proxy. Every operation runs remotely inside AWS KMS; the algorithm and
+# key-spec live in the request input structs and are exposed as capture-side
+# state, never inferred (family audit: no HSM/provider/certification claims).
+# v1 aws-sdk-go is a 322 MB monorepo module - only the service/kms client is
+# contracted here; other services stay out of scope. Pagers, waiters, request
+# builders, and the generated model/types are structural (skipped-non-crypto).
+contracts:
+  - method: github.com/aws/aws-sdk-go/service/kms.New
+    arity: 2
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.KMS", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).Encrypt
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.EncryptOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).ReEncrypt
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.ReEncryptOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).Decrypt
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.DecryptOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).Sign
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.SignOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).Verify
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.VerifyOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).GenerateMac
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.GenerateMacOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).VerifyMac
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.VerifyMacOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).GenerateDataKey
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.GenerateDataKeyOutput", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).GenerateDataKeyPair
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.GenerateDataKeyPairOutput", confidence: high }
+    role: factory
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).DeriveSharedSecret
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.DeriveSharedSecretOutput", confidence: high }
+    role: operation
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).GenerateRandom
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.GenerateRandomOutput", confidence: high }
+    role: output
+  - method: github.com/aws/aws-sdk-go/service/kms.(*KMS).CreateKey
+    arity: 1
+    varargs: true
+    return: { type: "*github.com/aws/aws-sdk-go/service/kms.CreateKeyOutput", confidence: high }
+    role: factory
+hierarchy: {}

--- a/internal/callgraph/contracts/go_aws_kms_test.go
+++ b/internal/callgraph/contracts/go_aws_kms_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package contracts_test
+
+import (
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+func TestLoadEmbeddedGoIncludesAWSKMSContracts(t *testing.T) {
+	t.Parallel()
+
+	kb, err := contracts.LoadEmbedded("go")
+	if err != nil {
+		t.Fatalf("LoadEmbedded(go): %v", err)
+	}
+
+	tests := []struct {
+		method, library, role string
+		arity                 int
+	}{
+		{"github.com/aws/aws-sdk-go/service/kms.(*KMS).Encrypt", "aws-kms", "operation", 1},
+		{"github.com/aws/aws-sdk-go/service/kms.(*KMS).GenerateDataKey", "aws-kms", "factory", 1},
+		{"github.com/aws/aws-sdk-go-v2/service/kms.(*Client).Sign", "aws-kms-v2", "operation", 3},
+		{"github.com/aws/aws-sdk-go-v2/service/kms.(*Client).GenerateRandom", "aws-kms-v2", "output", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := kb.ContractsFor(tt.method, tt.arity)
+			if len(got) != 1 {
+				t.Fatalf("ContractsFor(%q, %d) = %d, want 1", tt.method, tt.arity, len(got))
+			}
+			contract := got[0]
+			if contract.SourceLibrary != tt.library || contract.Role != tt.role || contract.Return.Confidence != "high" {
+				t.Fatalf("contract = %#v, want %s %s/high", contract, tt.library, tt.role)
+			}
+		})
+	}
+}

--- a/pkg/graphfrag/callgraph_export.go
+++ b/pkg/graphfrag/callgraph_export.go
@@ -1222,10 +1222,31 @@ func buildExportChain(fc *FindingChain, root ComponentKey, ecosystem string) ([]
 		node := buildExportNode(frame, root, ecosystem)
 		if i == len(fc.Frames)-1 && fc.CryptoOp != nil {
 			resolvedFindingID = applyTerminalCryptoOp(&node, frame, fc.CryptoOp, root)
+			synthesizePackageLevelIdentity(&node, fc.CryptoOp)
 		}
 		nodes = append(nodes, node)
 	}
 	return nodes, resolvedFindingID
+}
+
+// synthesizePackageLevelIdentity stamps identity on a terminal frame whose op
+// anchors at package scope (a finding inside a var/const initializer): the op
+// is keyed to an empty signature, so both the frame Function and Signature are
+// empty. The render path rejects identity-less frames, so the op location
+// becomes the identity.
+func synthesizePackageLevelIdentity(node *ExportChainNode, op *CryptoOperation) {
+	if node.FunctionName != "" || node.CanonicalSignature != "" {
+		return
+	}
+	synth := "<package-level:" + op.FilePath + ":" + strconv.Itoa(op.StartLine) + ">"
+	node.FunctionName = synth
+	node.FunctionKey = synth
+	if node.FilePath == "" {
+		node.FilePath = op.FilePath
+	}
+	if node.StartLine == 0 {
+		node.StartLine = op.StartLine
+	}
 }
 
 func applyTerminalCryptoOp(node *ExportChainNode, frame *CallFrame, op *CryptoOperation, root ComponentKey) string {
@@ -1294,6 +1315,14 @@ func buildExportNode(frame *CallFrame, root ComponentKey, ecosystem string) Expo
 		EntryCall:          exportEntryCall(frame.EntryCall, fn),
 		EntryResolution:    string(frame.EntryResolution),
 		EntryDeclaredType:  frame.EntryDeclaredType,
+	}
+	// A package-level anchor (a finding inside a var/const initializer) has no
+	// resolved Function in the fragment catalog, but the frame still carries
+	// its signature. Fall back to it so no served frame ships without identity
+	// (the render path rejects identity-less frames).
+	if node.FunctionName == "" && node.CanonicalSignature == "" && frame.Signature != "" {
+		node.FunctionKey = frame.Signature
+		node.FunctionName = frame.Signature
 	}
 	// Stamp dependency_info on non-root frames (ADR-4). The module string comes
 	// from the CallFrame.Module (Fragment.Module, set at stitch time), falling

--- a/pkg/graphfrag/export_anchor_identity_test.go
+++ b/pkg/graphfrag/export_anchor_identity_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+
+package graphfrag
+
+import "testing"
+
+// TestBuildExportNodeFallsBackToFrameSignature pins that a frame whose
+// Function never resolved in the fragment catalog (a package-level var/const
+// initializer anchor) still ships an identity: the frame signature. The
+// serving render rejects identity-less frames.
+func TestBuildExportNodeFallsBackToFrameSignature(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.<varinit:consts>",
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionName = %q, want the frame signature", node.FunctionName)
+	}
+	if node.FunctionKey != "example.com/lib.<varinit:consts>" {
+		t.Fatalf("FunctionKey = %q, want the frame signature", node.FunctionKey)
+	}
+}
+
+// TestBuildExportNodeKeepsResolvedIdentity pins that the fallback never
+// clobbers a resolved Function identity.
+func TestBuildExportNodeKeepsResolvedIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	frame := CallFrame{
+		Component: root,
+		Signature: "example.com/lib.Real",
+		Function: Function{
+			Signature:    "example.com/lib.Real",
+			FunctionName: "example.com/lib.Real",
+		},
+	}
+	node := buildExportNode(&frame, root, "go")
+	if node.FunctionName != "example.com/lib.Real" {
+		t.Fatalf("FunctionName = %q", node.FunctionName)
+	}
+}
+
+// TestBuildExportChainSynthesizesPackageLevelIdentity pins that a single-frame
+// chain whose op anchors at package scope (empty function signature end to
+// end) ships a synthesized identity from the op location.
+func TestBuildExportChainSynthesizesPackageLevelIdentity(t *testing.T) {
+	root := ComponentKey{Purl: "pkg:golang/example.com/lib", Version: "v1.0.0"}
+	fc := FindingChain{
+		FindingID: "abcd1234",
+		Frames:    []CallFrame{{Component: root}},
+		CryptoOp:  &CryptoOperation{FilePath: "helper/consts.go", StartLine: 12, RuleID: "r"},
+	}
+	nodes, _ := buildExportChain(&fc, root, "go")
+	if len(nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(nodes))
+	}
+	if nodes[0].FunctionName != "<package-level:helper/consts.go:12>" {
+		t.Fatalf("FunctionName = %q", nodes[0].FunctionName)
+	}
+	if nodes[0].FilePath == "" {
+		t.Fatal("FilePath empty")
+	}
+}


### PR DESCRIPTION
Part of the tier0 E2E validation for family `aws-kms-go-sdk` (scanoss/crypto-mining-service#88).

## What

- Two schema-v2 KBs, one per generation: `aws-kms.yaml` (aws-sdk-go v1 `service/kms` `*KMS`) and `aws-kms-v2.yaml` (aws-sdk-go-v2/service/kms `*Client`). Client factories and the remote KMS operation terminals (encrypt/decrypt, sign/verify, MAC, data-key generation, derive-shared-secret, random). Only the KMS service of the v1 monorepo is contracted; algorithm/key-spec live in the request inputs. Dispositions in each header.
- Carries the package-level anchor identity fix from scanoss/crypto-finder#405 (cherry-pick) — the v1 monorepo trips the same render path. Deduplicates on merge; merge #405 first.
- `go_aws_kms_test.go` asserts representative entries from both KBs.

## Validation

- `go test ./...`: green; `make lint`: 0 issues.
- Full local tier0 E2E gate (candidate-built scanoss.api with this branch): 494/494 integration tests PASS. Evidence on scanoss/crypto-mining-service#88.

## Merge order

Merge scanoss/crypto-finder#405 first (the graphfrag fix), then this PR.

Refs scanoss/crypto-mining-service#88