### PR TITLE
feat(contracts/python): add the python-gnupg OpenPGP callgraph contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A callgraph contract KB for the `python-gnupg` PyPI package, so a consumer's OpenPGP call sites resolve to a declared signature instead of an uncataloged frame. python-gnupg implements no cryptography -- it builds an argv and runs the `gpg` binary -- so these entries type the consumer's REQUEST and every return type is one of the library's own status-line parsers (`Crypt`, `Sign`, `Verify`, `GenKey`, `AddSubkey`, `ImportResult`, `ListKeys`, `ScanKeys`, `SearchKeys`, `SendResult`, `AutoLocateKey`). The whole distribution is one module, so there is no submodule spelling to declare, but the constructor still needs TWO keys: `import gnupg; gnupg.GPG(...)` emits no `.<init>` while `from gnupg import GPG; GPG(...)` does, and both are ordinary consumer code. Those two entries are what makes the other 116 join -- without them the graph emits the consumer's own variable name. 118 entries for 24 methods because arity is an exact match key for Python and eight of these methods forward `**kwargs` to a `_file` sibling, so one method is callable at up to nine argument counts; every method's range is derived from its declared signature. `export_keys` carries `confidence: low` and no `canonical_return_type`, because it returns `str` or `bytes` depending on its `armor` argument. Key deletion, ownertrust writes, recipient listing and the argv/validation helpers are deliberately not contracted.
 
 ## [0.26.0] - 2026-09-10
 ### Fixed

--- a/internal/callgraph/contracts/python/python-gnupg.yaml
+++ b/internal/callgraph/contracts/python/python-gnupg.yaml
@@ -1,0 +1,940 @@
+schema_version: "2"
+ecosystem: python
+
+library:
+  name: python-gnupg
+  coordinates:
+    - python-gnupg
+    - python_gnupg
+    - gnupg
+  version_range: ">=0.3.3,<0.6"
+  description: >-
+    python-gnupg lifecycle contracts - the `GPG` subprocess wrapper and every
+    cryptographic entry point on it. python-gnupg IMPLEMENTS NO CRYPTOGRAPHY:
+    it builds an argv and runs the `gpg` executable, so these entries type the
+    consumer's REQUEST rather than any computation this library performs.
+    Authored against python-gnupg 0.5.6 and cross-checked against ALL 25
+    archived sdists (0.3.3 through 0.5.6).
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HOW THESE KEYS WERE OBTAINED.
+#
+# Every key below was read off an EXPORTED CALL GRAPH, never written from the
+# API, and re-exported after each edit until nothing moved:
+#
+#   crypto-finder scan --no-remote-rules \
+#     --rules-dir semgrep-rules/python/python-gnupg \
+#     --export-callgraph /tmp/cg.json <a probe consumer PACKAGE>
+#   jq -r '.finding_graphs[]?.call_chains[]?[]? | select(.crypto_call)
+#          | .crypto_call.canonical_signature' /tmp/cg.json | sort -u
+#
+# For Python the emitted key is the CONSUMER'S IMPORT PATH, dots throughout,
+# with no module/type separator rewrite; the Rust `rustAuthoredKey` "::"
+# substitution is reached only from `rustContractsFor` and must not be copied
+# here.
+#
+# THE PROBE MUST BE A PACKAGE, NOT A LOOSE FILE. A bare `.py` resolves no
+# ecosystem and `crypto-finder scan` over a fixture tree returns 0 assets
+# because opengrep's built-in excludes skip `tests/`. The probe used here is a
+# neutral package with a `setup.py`.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE TWO CONSTRUCTOR KEYS, MEASURED. python-gnupg is a SINGLE MODULE -- the
+# sdist holds `gnupg.py` and nothing else importable -- so there is no
+# submodule spelling and no directory-versus-import-path divergence to worry
+# about. There are still TWO keys, because the `<init>` suffix follows the
+# consumer's import:
+#
+#   import gnupg;          gnupg.GPG(gnupghome=...)  ->  gnupg.GPG
+#   from gnupg import GPG; GPG(gnupghome=...)        ->  gnupg.GPG.<init>
+#
+# Read off the export, one call per file, with crypto-finder built from the
+# branch under test. The module-qualified spelling emits NO `.<init>`; the
+# from-import spelling does, and it additionally renders `: GPG` on its own,
+# which the module-qualified spelling does not. BOTH are declared, because both
+# are ordinary consumer code -- `pulpcore 3.95.3` pulpcore/app/util.py:402
+# writes the first and `ospd-openvas 22.9.1` ospd_openvas/gpg_sha_verifier.py:40
+# writes the second.
+#
+# THE CONSTRUCTOR ENTRIES ARE WHAT MAKES EVERY OTHER ENTRY JOIN. Without them
+# the graph emits the CONSUMER'S variable name -- measured as
+# `probeconsumer.g.encrypt(?, ?)` with empty `parameter_types`, which is the
+# uncontracted shape -- because the receiver's type is unknown. With
+# `canonical_return_type: gnupg.GPG` on the two constructor keys, the same
+# lines resolve to `gnupg.GPG.encrypt`. That is the fixed point this file was
+# iterated to: export, author, re-export, repeat until nothing moved.
+#
+# A CONSUMER'S `import gnupg as g` ALIAS IS A KNOWN LIMITATION AND IT IS NOT
+# ENCODED HERE. The module alias leaks into the emitted key, so no contract can
+# join it, and encoding a consumer's variable or alias name would be worse than
+# the gap. `from gnupg import GPG as PGP` DOES join: the parser keys an aliased
+# from-import on the exported name `GPG` (python_parser.go, plus the
+# `delete(analysis.ImportedTypes, alias)` that goes with it), which landed on
+# crypto-finder main before this branch was cut.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY THERE ARE 118 ENTRIES FOR 24 METHODS: ARITY IS AN EXACT MATCH KEY AND
+# `varargs` DOES NOT HELP FOR PYTHON.
+#
+# `KnowledgeBase.ContractsFor` looks up `method#arity` exactly and, for any
+# ecosystem other than rust, returns nil on a miss (contracts.go:203-211). So a
+# method reachable at five different argument counts needs five entries.
+#
+#   MEASURED: `varargs: true` IS INERT FOR PYTHON. The only consumer of
+#   `Contract.Varargs` is `javaVarargsChainContracts`, and its single call site
+#   is gated on `kb.Ecosystem == ecosystemJava` (builder.go:1562). Marking a
+#   python entry varargs would therefore collapse nothing and would read as
+#   coverage it does not provide. No entry here uses the field.
+#
+# THE ARITY RANGE OF EVERY METHOD IS DERIVED FROM ITS `def` LINE, NOT FROM A
+# CORPUS. min = parameters without a default (self excluded); max = parameters
+# declared, plus the forwarded target's remaining parameters when the method's
+# tail is `**kwargs`. Eight of these methods are thin wrappers that forward
+# `**kwargs` to a `_file` sibling (0.5.6 :2172->:2104, :2202->:2225,
+# :1387->:1442, :1520->:1542, :1628->:1606), which is why their range is wider
+# than their signature reads. Each method's range and its citation are on its
+# own comment below, and `python_gnupg_contract_test.go` holds the same table
+# hand-written from the same source lines.
+#
+#   TWO CAPS ARE A CHOICE RATHER THAN A SIGNATURE, AND BOTH ARE STATED.
+#   `gen_key_input(**kwargs)` (:2016) declares NO parameters and accepts any
+#   gpg `--gen-key` keyword, so its arity is unbounded in principle; it is
+#   capped at 8. The highest arity measured anywhere -- across the 24-package
+#   real-consumer draw, python-gnupg's own test_gnupg.py and the probe -- is 6
+#   (`lime-comb 0.0.9` lime_comb/gpg/__init__.py:46). `recv_keys` (:1638) and
+#   `send_keys` (:1662) take `*keyids`, also unbounded, and are capped at 4
+#   (keyserver plus two key ids plus `extra_args`). A call above either cap does
+#   not resolve; that is a stated recall gap, not an undeclared one.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# PER-SYMBOL VERSION WINDOWS. `library.version_range` spans the whole archived
+# range; each symbol's own window is narrower where it arrives later, and is
+# stated on its entry. Derived by parsing every `class` and `def` out of ALL 25
+# archived sdists, not from a changelog, and each boundary was checked against
+# the release on BOTH sides of it.
+#
+#   0.3.3  the oldest release with ANY published archive. encrypt, encrypt_file,
+#          decrypt, decrypt_file, sign, sign_file, verify, verify_file,
+#          gen_key, gen_key_input, import_keys, export_keys, list_keys,
+#          recv_keys and delete_keys already exist (gnupg.py:1020, 992, 1066,
+#          1072, 685, 692, 723, 743, 922, 941, 772, 858, 875, 825, 846).
+#   0.3.5  search_keys, send_keys, SearchKeys, SendResult. Also the release
+#          where `--cipher-algo` pass-through arrives (:1182) and where the
+#          `Key-Length` default moves from 1024 to 2048 (:1132).
+#   0.3.6  verify_data.
+#   0.3.7  scan_keys, ScanKeys, set_output_without_confirmation.
+#   0.4.2  trust_keys, TrustResult.
+#   0.4.4  is_valid_passphrase.
+#   0.4.8  get_recipients, get_recipients_file, is_valid_file.
+#   0.4.9  add_subkey, AddSubkey, ExportResult.
+#   0.5.0  import_keys_file.
+#   0.5.1  scan_keys_mem.
+#   0.5.3  auto_locate_key, AutoLocateKey.
+#   0.5.6  first PEP 625 sdist filename (`python_gnupg-0.5.6.tar.gz`).
+#          Packaging only; no API change.
+#
+#   PyPI SERVES NO FILES AT ALL FOR NINE OF THE 34 COMMITTED CSV ROWS.
+#   0.2.3, 0.2.4, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.3.0, 0.3.1 and 0.3.2 each have
+#   an index entry with an EMPTY file list (checked against
+#   https://pypi.org/pypi/python-gnupg/json). No sdist, no wheel, so no API
+#   could be read and none is claimed. That is why `version_range` starts at
+#   0.3.3 and not at the matrix's oldest row.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE RETURN TYPES ARE THIS LIBRARY'S OWN RESULT PARSERS, NOT GnuPG'S OUTPUT.
+# `GPG.result_map` (0.5.6 gnupg.py:1082-1097) maps each operation to the class
+# that parses gpg's `--status-fd` lines, and every method returns an instance of
+# its mapped class: 'crypt'->Crypt, 'sign'->Sign, 'verify'->Verify,
+# 'generate'->GenKey, 'addSubkey'->AddSubkey, 'import'->ImportResult,
+# 'send'->SendResult, 'list'->ListKeys, 'scan'->ScanKeys, 'search'->SearchKeys,
+# 'export'->ExportResult, 'auto-locate-key'->AutoLocateKey. Two methods return
+# something else and are declared accordingly: `gen_key_input` returns the
+# rendered parameter block as a `str` (:2039-2045) and `export_keys` returns
+# `result.data`, decoded to `str` only when `armor` is set (:1811-1814).
+#
+#   `export_keys` IS THE ONE DIVERGENT RETURN, AND IT CARRIES NO
+#   `canonical_return_type`. `str` when armored (the default) and `bytes`
+#   otherwise, decided by an argument. A divergent return on one
+#   (method, arity) key is a HARD LOAD ERROR (contracts.go:936-968, Rule 2), so
+#   ONE value is declared -- the default path -- at `confidence: low`, and
+#   `canonical_return_type` is withheld rather than asserting the armored form
+#   holds for every call.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# API AUDIT. Disposition legend: contracted | skipped-non-crypto.
+#
+# gnupg.GPG (0.5.6 gnupg.py:1072)
+#   __init__(...)          contracted (factory) -> gnupg.GPG, both key spellings
+#   encrypt/encrypt_file   contracted (operation) -> Crypt
+#   decrypt/decrypt_file   contracted (operation) -> Crypt
+#   sign/sign_file         contracted (operation) -> Sign
+#   verify/verify_file/verify_data
+#                          contracted (operation) -> Verify
+#   gen_key                contracted (operation) -> GenKey
+#   gen_key_input          contracted (factory)   -> builtins.str
+#   add_subkey             contracted (operation) -> AddSubkey
+#   import_keys/_file      contracted (operation) -> ImportResult
+#   export_keys            contracted (output)    -> builtins.str, low
+#   list_keys              contracted (output)    -> ListKeys
+#   scan_keys/_mem         contracted (output)    -> ScanKeys
+#   search_keys            contracted (output)    -> SearchKeys
+#   send_keys              contracted (operation) -> SendResult
+#   recv_keys              contracted (operation) -> ImportResult
+#   auto_locate_key        contracted (output)    -> AutoLocateKey
+#   delete_keys            skipped-non-crypto - removes a keyring entry and
+#                            produces no material (:1688)
+#   trust_keys             skipped-non-crypto - writes an ownertrust value into
+#                            gpg's trustdb (:2290)
+#   get_recipients / get_recipients_file
+#                          skipped-non-crypto - `--decrypt --list-only`, which
+#                            READS the key ids a message is addressed to
+#                            (:2255, :2271)
+#   make_args              skipped-non-crypto - builds an argv (:1179)
+#   set_output_without_confirmation
+#                          skipped-non-crypto - appends `--output` (:1414)
+#   is_valid_passphrase    skipped-non-crypto - a newline/NUL check (:1429)
+#   is_valid_file          skipped-non-crypto - a file-object check (:1331)
+#
+# The eleven result classes (Crypt, Sign, Verify, GenKey, AddSubkey,
+# ImportResult, ExportResult, ListKeys, ScanKeys, SearchKeys, SendResult,
+# TrustResult, DeleteResult, AutoLocateKey; :228-1071) are NOT contracted as
+# callables. A consumer never constructs one -- `result_map` does -- so there is
+# no consumer call site to key, and their public surface is `handle_status`,
+# which parses gpg's status lines rather than computing anything. They appear
+# here only as the declared RETURN types above, which is what makes a chained
+# `gpg.encrypt(...).data` typed.
+#
+# NO ENTRY HERE DECLARES `parameter_types`. Eight of these methods take
+# `**kwargs` and eight take keyword arguments in any order, so at a given arity
+# the positional types are genuinely not knowable -- `encrypt(data, recipients,
+# armor=False)` and `encrypt(data, recipients, always_trust=True)` are both
+# arity 3 with different third types. Declaring one would assert a signature the
+# library does not have. This follows merged `python/eth-account`, which omits
+# the field on its multi-arity entries for the same reason.
+
+contracts:
+  # ── GPG -- 0.5.6 gnupg.py:1100. Arity 0-8: module-qualified spelling: `import gnupg; gnupg.GPG(...)` emits NO `.<init>`.
+  - method: gnupg.GPG
+    arity: 0
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 1
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 2
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 3
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 4
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 5
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 6
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 7
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG
+    arity: 8
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  # ── <init> -- 0.5.6 gnupg.py:1100. Arity 0-8: from-import spelling: `from gnupg import GPG; GPG(...)` emits `.<init>`.
+  - method: gnupg.GPG.<init>
+    arity: 0
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 1
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 2
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 3
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 4
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 5
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 6
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 7
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.<init>
+    arity: 8
+    canonical_return_type: gnupg.GPG
+    return: { type: gnupg.GPG, confidence: high }
+    role: factory
+
+  # ── encrypt -- 0.5.6 gnupg.py:2172. Arity 2-9: `**kwargs` forward to encrypt_file (:2104, 9 params).
+  - method: gnupg.GPG.encrypt
+    arity: 2
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 3
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 4
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 5
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 6
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 7
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 8
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt
+    arity: 9
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  # ── encrypt_file -- 0.5.6 gnupg.py:2104. Arity 2-9: 9 declared parameters.
+  - method: gnupg.GPG.encrypt_file
+    arity: 2
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 3
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 4
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 5
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 6
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 7
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 8
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.encrypt_file
+    arity: 9
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  # ── decrypt -- 0.5.6 gnupg.py:2202. Arity 1-5: `**kwargs` forward to decrypt_file (:2225, 5 params).
+  - method: gnupg.GPG.decrypt
+    arity: 1
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt
+    arity: 2
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt
+    arity: 3
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt
+    arity: 4
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt
+    arity: 5
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  # ── decrypt_file -- 0.5.6 gnupg.py:2225. Arity 1-5: 5 declared parameters.
+  - method: gnupg.GPG.decrypt_file
+    arity: 1
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt_file
+    arity: 2
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt_file
+    arity: 3
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt_file
+    arity: 4
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.decrypt_file
+    arity: 5
+    canonical_return_type: gnupg.Crypt
+    return: { type: gnupg.Crypt, confidence: high }
+    role: operation
+
+  # ── sign -- 0.5.6 gnupg.py:1387. Arity 1-8: `**kwargs` forward to sign_file (:1442, 8 params).
+  - method: gnupg.GPG.sign
+    arity: 1
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 2
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 3
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 4
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 5
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 6
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 7
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign
+    arity: 8
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  # ── sign_file -- 0.5.6 gnupg.py:1442. Arity 1-8: 8 declared parameters.
+  - method: gnupg.GPG.sign_file
+    arity: 1
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 2
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 3
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 4
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 5
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 6
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 7
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.sign_file
+    arity: 8
+    canonical_return_type: gnupg.Sign
+    return: { type: gnupg.Sign, confidence: high }
+    role: operation
+
+  # ── verify -- 0.5.6 gnupg.py:1520. Arity 1-4: `**kwargs` forward to verify_file (:1542, 4 params).
+  - method: gnupg.GPG.verify
+    arity: 1
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify
+    arity: 2
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify
+    arity: 3
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify
+    arity: 4
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  # ── verify_file -- 0.5.6 gnupg.py:1542. Arity 1-4: 4 declared parameters.
+  - method: gnupg.GPG.verify_file
+    arity: 1
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify_file
+    arity: 2
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify_file
+    arity: 3
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify_file
+    arity: 4
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  # ── verify_data -- 0.5.6 gnupg.py:1581. Arity 2-3: 3 declared parameters.
+  - method: gnupg.GPG.verify_data
+    arity: 2
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.verify_data
+    arity: 3
+    canonical_return_type: gnupg.Verify
+    return: { type: gnupg.Verify, confidence: high }
+    role: operation
+
+  # ── gen_key -- 0.5.6 gnupg.py:2002. Arity 1-1: one parameter, no kwargs.
+  - method: gnupg.GPG.gen_key
+    arity: 1
+    canonical_return_type: gnupg.GenKey
+    return: { type: gnupg.GenKey, confidence: high }
+    role: operation
+
+  # ── gen_key_input -- 0.5.6 gnupg.py:2016. Arity 0-8: `**kwargs` only; the 8 cap is the ONE bounded choice -- see the header.
+  - method: gnupg.GPG.gen_key_input
+    arity: 0
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 1
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 2
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 3
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 4
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 5
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 6
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 7
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  - method: gnupg.GPG.gen_key_input
+    arity: 8
+    canonical_return_type: builtins.str
+    return: { type: builtins.str, confidence: high }
+    role: factory
+
+  # ── add_subkey -- 0.5.6 gnupg.py:2069. Arity 1-5: 5 declared parameters; ARRIVES 0.4.9.
+  - method: gnupg.GPG.add_subkey
+    arity: 1
+    canonical_return_type: gnupg.AddSubkey
+    return: { type: gnupg.AddSubkey, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.add_subkey
+    arity: 2
+    canonical_return_type: gnupg.AddSubkey
+    return: { type: gnupg.AddSubkey, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.add_subkey
+    arity: 3
+    canonical_return_type: gnupg.AddSubkey
+    return: { type: gnupg.AddSubkey, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.add_subkey
+    arity: 4
+    canonical_return_type: gnupg.AddSubkey
+    return: { type: gnupg.AddSubkey, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.add_subkey
+    arity: 5
+    canonical_return_type: gnupg.AddSubkey
+    return: { type: gnupg.AddSubkey, confidence: high }
+    role: operation
+
+  # ── import_keys -- 0.5.6 gnupg.py:1606. Arity 1-3: 3 declared parameters.
+  - method: gnupg.GPG.import_keys
+    arity: 1
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.import_keys
+    arity: 2
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.import_keys
+    arity: 3
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  # ── import_keys_file -- 0.5.6 gnupg.py:1628. Arity 1-3: `**kwargs` forward to import_keys; ARRIVES 0.5.0.
+  - method: gnupg.GPG.import_keys_file
+    arity: 1
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.import_keys_file
+    arity: 2
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.import_keys_file
+    arity: 3
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  # ── export_keys -- 0.5.6 gnupg.py:1743. Arity 1-7: returns str when armor (the default) and bytes otherwise (:1811-1814) -- divergent, so no canonical_return_type.
+  - method: gnupg.GPG.export_keys
+    arity: 1
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  - method: gnupg.GPG.export_keys
+    arity: 2
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  - method: gnupg.GPG.export_keys
+    arity: 3
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  - method: gnupg.GPG.export_keys
+    arity: 4
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  - method: gnupg.GPG.export_keys
+    arity: 5
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  - method: gnupg.GPG.export_keys
+    arity: 6
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  - method: gnupg.GPG.export_keys
+    arity: 7
+    return: { type: builtins.str, confidence: low }
+    role: output
+
+  # ── list_keys -- 0.5.6 gnupg.py:1839. Arity 0-3: 3 declared parameters; via _get_list_output (:1833-1837).
+  - method: gnupg.GPG.list_keys
+    arity: 0
+    canonical_return_type: gnupg.ListKeys
+    return: { type: gnupg.ListKeys, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.list_keys
+    arity: 1
+    canonical_return_type: gnupg.ListKeys
+    return: { type: gnupg.ListKeys, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.list_keys
+    arity: 2
+    canonical_return_type: gnupg.ListKeys
+    return: { type: gnupg.ListKeys, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.list_keys
+    arity: 3
+    canonical_return_type: gnupg.ListKeys
+    return: { type: gnupg.ListKeys, confidence: high }
+    role: output
+
+  # ── scan_keys -- 0.5.6 gnupg.py:1883. Arity 1-1: ARRIVES 0.3.7.
+  - method: gnupg.GPG.scan_keys
+    arity: 1
+    canonical_return_type: gnupg.ScanKeys
+    return: { type: gnupg.ScanKeys, confidence: high }
+    role: output
+
+  # ── scan_keys_mem -- 0.5.6 gnupg.py:1909. Arity 1-1: ARRIVES 0.5.1.
+  - method: gnupg.GPG.scan_keys_mem
+    arity: 1
+    canonical_return_type: gnupg.ScanKeys
+    return: { type: gnupg.ScanKeys, confidence: high }
+    role: output
+
+  # ── search_keys -- 0.5.6 gnupg.py:1939. Arity 1-3: 3 declared parameters; ARRIVES 0.3.5.
+  - method: gnupg.GPG.search_keys
+    arity: 1
+    canonical_return_type: gnupg.SearchKeys
+    return: { type: gnupg.SearchKeys, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.search_keys
+    arity: 2
+    canonical_return_type: gnupg.SearchKeys
+    return: { type: gnupg.SearchKeys, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.search_keys
+    arity: 3
+    canonical_return_type: gnupg.SearchKeys
+    return: { type: gnupg.SearchKeys, confidence: high }
+    role: output
+
+  # ── send_keys -- 0.5.6 gnupg.py:1662. Arity 1-4: `*keyids` varargs; the 4 cap is bounded -- see the header. ARRIVES 0.3.5.
+  - method: gnupg.GPG.send_keys
+    arity: 1
+    canonical_return_type: gnupg.SendResult
+    return: { type: gnupg.SendResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.send_keys
+    arity: 2
+    canonical_return_type: gnupg.SendResult
+    return: { type: gnupg.SendResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.send_keys
+    arity: 3
+    canonical_return_type: gnupg.SendResult
+    return: { type: gnupg.SendResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.send_keys
+    arity: 4
+    canonical_return_type: gnupg.SendResult
+    return: { type: gnupg.SendResult, confidence: high }
+    role: operation
+
+  # ── recv_keys -- 0.5.6 gnupg.py:1638. Arity 1-4: `*keyids` varargs; the 4 cap is bounded -- see the header.
+  - method: gnupg.GPG.recv_keys
+    arity: 1
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.recv_keys
+    arity: 2
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.recv_keys
+    arity: 3
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  - method: gnupg.GPG.recv_keys
+    arity: 4
+    canonical_return_type: gnupg.ImportResult
+    return: { type: gnupg.ImportResult, confidence: high }
+    role: operation
+
+  # ── auto_locate_key -- 0.5.6 gnupg.py:1978. Arity 1-3: 2 declared parameters plus extra_args in `**kwargs`; ARRIVES 0.5.3.
+  - method: gnupg.GPG.auto_locate_key
+    arity: 1
+    canonical_return_type: gnupg.AutoLocateKey
+    return: { type: gnupg.AutoLocateKey, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.auto_locate_key
+    arity: 2
+    canonical_return_type: gnupg.AutoLocateKey
+    return: { type: gnupg.AutoLocateKey, confidence: high }
+    role: output
+
+  - method: gnupg.GPG.auto_locate_key
+    arity: 3
+    canonical_return_type: gnupg.AutoLocateKey
+    return: { type: gnupg.AutoLocateKey, confidence: high }
+    role: output
+

--- a/internal/callgraph/contracts/python_python_gnupg_test.go
+++ b/internal/callgraph/contracts/python_python_gnupg_test.go
@@ -1,0 +1,477 @@
+// Copyright (C) 2026 SCANOSS.COM
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; version 2.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+package contracts_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/scanoss/crypto-finder/internal/callgraph/contracts"
+)
+
+// renderPythonGnupgInventory renders every loaded python-gnupg contract as one
+// line so the test below can compare the WHOLE SET rather than probing key by
+// key.
+//
+// A per-key subset assertion cannot see an entry that should not be there, an
+// entry that was dropped, or a field that was corrupted. Every field the loader
+// populates is rendered -- role, return type, return confidence,
+// canonical_return_type, parameter_types, varargs, and each parameter's
+// index/name/role plus its contributed property and derivation. Varargs is
+// rendered even though NO python-gnupg entry sets it, and that is deliberate
+// twice over: a `varargs: true` mutation otherwise survives every assertion in
+// this directory, and for Python the field would be INERT anyway --
+// `javaVarargsChainContracts` is the only consumer of `Contract.Varargs` and
+// its single call site is gated on `kb.Ecosystem == ecosystemJava`
+// (builder.go:1562). Rendering it pins the field at false so nobody adds it
+// later believing it collapses an arity.
+func renderPythonGnupgInventory(kb *contracts.KnowledgeBase) []string {
+	var inventory []string
+	for _, candidates := range kb.Contracts {
+		for i := range candidates {
+			contract := &candidates[i]
+			if contract.SourceLibrary != "python-gnupg" {
+				continue
+			}
+			line := fmt.Sprintf("%s#%d|%s|%s|%s|%s|%v|%v",
+				contract.Method, contract.Arity, contract.Role,
+				contract.Return.Type, contract.Return.Confidence,
+				contract.CanonicalReturnType, contract.ParameterTypes, contract.Varargs)
+			for j := range contract.Parameters {
+				parameter := &contract.Parameters[j]
+				index := -1
+				if parameter.Index != nil {
+					index = *parameter.Index
+				}
+				if parameter.Contributes == nil {
+					line += fmt.Sprintf("|%d:%s:%s", index, parameter.Name, parameter.Role)
+					continue
+				}
+				line += fmt.Sprintf("|%d:%s:%s:%s:%s", index, parameter.Name, parameter.Role,
+					parameter.Contributes.Property, parameter.Contributes.Derivation)
+			}
+			inventory = append(inventory, line)
+		}
+	}
+	sort.Strings(inventory)
+	return inventory
+}
+
+// pythonGnupgMethod is one row of the HAND-WRITTEN signature table below.
+//
+// python-gnupg reaches 118 contract entries from 24 methods because arity is an
+// EXACT match key for Python -- `ContractsFor` returns nil on a miss for every
+// ecosystem but rust (contracts.go:203-211) -- and eight of these methods
+// forward `**kwargs` to a `_file` sibling, so one method is genuinely callable
+// at up to nine different argument counts.
+//
+// Writing 118 literals by hand would be unreadable and, worse, unauditable: a
+// reader could not check them against the library. So the EXPECTATION IS THIS
+// TABLE, one row per method, every field READ OFF THE `def` LINE CITED, and the
+// test expands min..max into the 118 lines it compares. The expansion rule is
+// not invented here -- it is the rule stated in python-gnupg.yaml's header and
+// derived from the signatures: min is the parameters without a default (self
+// excluded), max is the parameters declared plus the forwarded target's
+// remaining parameters when the tail is `**kwargs`.
+//
+// WHAT MAKES THIS NON-TAUTOLOGICAL, which is the campaign's most repeated
+// defect: this table is written from `gnupg.py` and is INDEPENDENT of the YAML.
+// Deriving it from the YAML instead is the obvious repair and it is wrong -- it
+// makes the assertion green on a corrupted contract, which is the one thing
+// the test exists to prevent. A legitimate change to the contract is a
+// ONE-FIELD edit to one row here.
+type pythonGnupgMethod struct {
+	method     string // the contract key, read off an exported call graph
+	line       int    // the `def` line in the 0.5.6 sdist's gnupg.py
+	minArity   int
+	maxArity   int
+	role       string
+	returnTyp  string
+	confidence string
+	canonical  bool // whether canonical_return_type is declared
+}
+
+// pythonGnupgSignatures is the whole expectation. Citations are against the
+// python-gnupg 0.5.6 sdist (`gnupg.py`), which is the single module the whole
+// distribution ships. Version windows are in the YAML header, measured by
+// parsing every class and def out of all 25 archived sdists.
+var pythonGnupgSignatures = []pythonGnupgMethod{
+	// :1072 `class GPG(object)`, :1100 `def __init__(self, gpgbinary='gpg',
+	// gnupghome=None, verbose=False, use_agent=False, keyring=None,
+	// options=None, secret_keyring=None, env=None)` -- 8 parameters, all with
+	// defaults, so 0..8. TWO KEYS for one constructor: measured on an exported
+	// call graph, `import gnupg; gnupg.GPG(...)` emits no `.<init>` while
+	// `from gnupg import GPG; GPG(...)` does. Both are ordinary consumer code.
+	{"gnupg.GPG", 1100, 0, 8, "factory", "gnupg.GPG", "high", true},
+	{"gnupg.GPG.<init>", 1100, 0, 8, "factory", "gnupg.GPG", "high", true},
+
+	// :2172 `def encrypt(self, data, recipients, **kwargs)`. Two required, and
+	// the kwargs forward to encrypt_file (:2104), whose 9 parameters leave 7
+	// beyond `data` and `recipients` -- so 2..9. Returns result_map['crypt']
+	// (:1083) = Crypt.
+	{"gnupg.GPG.encrypt", 2172, 2, 9, "operation", "gnupg.Crypt", "high", true},
+	// :2104 `def encrypt_file(self, fileobj_or_path, recipients, sign=None,
+	// always_trust=False, passphrase=None, armor=True, output=None,
+	// symmetric=False, extra_args=None)` -- 9 parameters, 2 required.
+	{"gnupg.GPG.encrypt_file", 2104, 2, 9, "operation", "gnupg.Crypt", "high", true},
+
+	// :2202 `def decrypt(self, message, **kwargs)`, forwarding to decrypt_file
+	// (:2225) whose 5 parameters leave 4 beyond `message` -- so 1..5.
+	{"gnupg.GPG.decrypt", 2202, 1, 5, "operation", "gnupg.Crypt", "high", true},
+	// :2225 `def decrypt_file(self, fileobj_or_path, always_trust=False,
+	// passphrase=None, output=None, extra_args=None)` -- 5 parameters.
+	{"gnupg.GPG.decrypt_file", 2225, 1, 5, "operation", "gnupg.Crypt", "high", true},
+
+	// :1387 `def sign(self, message, **kwargs)`, forwarding to sign_file
+	// (:1442) whose 8 parameters leave 7 beyond `message` -- so 1..8. Returns
+	// result_map['sign'] (:1092) = Sign.
+	{"gnupg.GPG.sign", 1387, 1, 8, "operation", "gnupg.Sign", "high", true},
+	// :1442 `def sign_file(self, fileobj_or_path, keyid=None, passphrase=None,
+	// clearsign=True, detach=False, binary=False, output=None,
+	// extra_args=None)` -- 8 parameters.
+	{"gnupg.GPG.sign_file", 1442, 1, 8, "operation", "gnupg.Sign", "high", true},
+
+	// :1520 `def verify(self, data, **kwargs)`, forwarding to verify_file
+	// (:1542) whose 4 parameters leave 3 beyond `data` -- so 1..4. Returns
+	// result_map['verify'] (:1094) = Verify.
+	{"gnupg.GPG.verify", 1520, 1, 4, "operation", "gnupg.Verify", "high", true},
+	// :1542 `def verify_file(self, fileobj_or_path, data_filename=None,
+	// close_file=True, extra_args=None)` -- 4 parameters.
+	{"gnupg.GPG.verify_file", 1542, 1, 4, "operation", "gnupg.Verify", "high", true},
+	// :1581 `def verify_data(self, sig_filename, data, extra_args=None)` --
+	// 3 parameters, 2 required. ARRIVES AT 0.3.6.
+	{"gnupg.GPG.verify_data", 1581, 2, 3, "operation", "gnupg.Verify", "high", true},
+
+	// :2002 `def gen_key(self, input)` -- one parameter, no kwargs, so the
+	// arity is exactly 1. Returns result_map['generate'] (:1085) = GenKey.
+	{"gnupg.GPG.gen_key", 2002, 1, 1, "operation", "gnupg.GenKey", "high", true},
+	// :2016 `def gen_key_input(self, **kwargs)` -- NO declared parameters, so
+	// the arity is unbounded in principle. CAPPED AT 8, which is the one
+	// bounded choice in this table: the highest arity measured anywhere (the
+	// 24-package consumer draw, the library's own test_gnupg.py and the probe)
+	// is 6. Returns the rendered `--gen-key` block as a str (:2039-2045).
+	{"gnupg.GPG.gen_key_input", 2016, 0, 8, "factory", "builtins.str", "high", true},
+	// :2069 `def add_subkey(self, master_key, master_passphrase=None,
+	// algorithm='rsa', usage='encrypt', expire='-')` -- 5 parameters, 1
+	// required. ARRIVES AT 0.4.9. Returns result_map['addSubkey'] (:1086).
+	{"gnupg.GPG.add_subkey", 2069, 1, 5, "operation", "gnupg.AddSubkey", "high", true},
+
+	// :1606 `def import_keys(self, key_data, extra_args=None,
+	// passphrase=None)` -- 3 parameters. Returns result_map['import'] (:1087).
+	{"gnupg.GPG.import_keys", 1606, 1, 3, "operation", "gnupg.ImportResult", "high", true},
+	// :1628 `def import_keys_file(self, key_path, **kwargs)`, which reads the
+	// file and calls import_keys(f.read(), **kwargs) -- so the kwargs are
+	// import_keys' `extra_args` and `passphrase`, giving 1..3. ARRIVES AT 0.5.0.
+	{"gnupg.GPG.import_keys_file", 1628, 1, 3, "operation", "gnupg.ImportResult", "high", true},
+
+	// :1743 `def export_keys(self, keyids, secret=False, armor=True,
+	// minimal=False, passphrase=None, expect_passphrase=True, output=None)` --
+	// 7 parameters, 1 required. THE ONE DIVERGENT RETURN: it returns
+	// `result.data`, decoded to str only when `armor` is set (:1811-1814), so
+	// the value is str or bytes decided by an argument. One value is declared
+	// at LOW confidence and canonical_return_type is WITHHELD rather than
+	// asserting the armored form holds for every call.
+	{"gnupg.GPG.export_keys", 1743, 1, 7, "output", "builtins.str", "low", false},
+
+	// :1839 `def list_keys(self, secret=False, keys=None, sigs=False)` --
+	// 3 parameters, none required. Returns _get_list_output(p, 'list')
+	// (:1868 -> :1833-1837), i.e. result_map['list'] (:1089) = ListKeys.
+	{"gnupg.GPG.list_keys", 1839, 0, 3, "output", "gnupg.ListKeys", "high", true},
+	// :1883 `def scan_keys(self, filename)` -- one parameter. Returns
+	// _get_list_output(p, 'scan') (:1907), i.e. ScanKeys (:1090). ARRIVES 0.3.7.
+	{"gnupg.GPG.scan_keys", 1883, 1, 1, "output", "gnupg.ScanKeys", "high", true},
+	// :1909 `def scan_keys_mem(self, key_data)` -- one parameter, same result
+	// class (:1925, :1938). ARRIVES AT 0.5.1.
+	{"gnupg.GPG.scan_keys_mem", 1909, 1, 1, "output", "gnupg.ScanKeys", "high", true},
+	// :1939 `def search_keys(self, query, keyserver='pgp.mit.edu',
+	// extra_args=None)` -- 3 parameters. Returns result_map['search'] (:1091)
+	// = SearchKeys (:1976). ARRIVES AT 0.3.5.
+	{"gnupg.GPG.search_keys", 1939, 1, 3, "output", "gnupg.SearchKeys", "high", true},
+
+	// :1662 `def send_keys(self, keyserver, *keyids, **kwargs)` -- the varargs
+	// make the arity unbounded. CAPPED AT 4 (keyserver plus two key ids plus
+	// extra_args), the second bounded choice in this table. Returns
+	// result_map['send'] (:1088) = SendResult (:1675). ARRIVES AT 0.3.5.
+	{"gnupg.GPG.send_keys", 1662, 1, 4, "operation", "gnupg.SendResult", "high", true},
+	// :1638 `def recv_keys(self, keyserver, *keyids, **kwargs)` -- same shape,
+	// same cap. Returns result_map['import'] (:1641) = ImportResult.
+	{"gnupg.GPG.recv_keys", 1638, 1, 4, "operation", "gnupg.ImportResult", "high", true},
+	// :1978 `def auto_locate_key(self, email, mechanisms=None, **kwargs)` --
+	// 2 declared plus `extra_args` in kwargs, so 1..3. Returns
+	// result_map['auto-locate-key'] (:1992) = AutoLocateKey. ARRIVES AT 0.5.3.
+	{"gnupg.GPG.auto_locate_key", 1978, 1, 3, "output", "gnupg.AutoLocateKey", "high", true},
+}
+
+// expandPythonGnupgSignatures turns the hand-written table into the exact set
+// of rendered lines the loader must produce. The only arithmetic is min..max,
+// which is the rule the table's own citations establish.
+func expandPythonGnupgSignatures() []string {
+	var want []string
+	for _, m := range pythonGnupgSignatures {
+		for arity := m.minArity; arity <= m.maxArity; arity++ {
+			canonical := ""
+			if m.canonical {
+				canonical = m.returnTyp
+			}
+			// parameter_types is deliberately absent from every entry -- eight
+			// of these methods take **kwargs and eight take keyword arguments
+			// in any order, so at a given arity the positional types are not
+			// knowable. The loader renders the empty slice as [].
+			want = append(want, fmt.Sprintf("%s#%d|%s|%s|%s|%s|[]|false",
+				m.method, arity, m.role, m.returnTyp, m.confidence, canonical))
+		}
+	}
+	sort.Strings(want)
+	return want
+}
+
+// TestLoadEmbeddedPython_PythonGnupg_ExactSet pins the python-gnupg contract KB
+// as an EXACT SET, reported as a SYMMETRIC DIFFERENCE.
+//
+// WHAT THIS PROVES AND WHAT IT DOES NOT. It proves the loaded set is exactly
+// what the signature table describes, so any edit that adds, drops or corrupts
+// an entry fails here and the failure names the exact line. It does NOT prove
+// the table is TRUE -- a comparison can only find drift away from a baseline,
+// never an error inside it. The baseline's truth rests on the per-row citations
+// into python-gnupg 0.5.6's `gnupg.py`, and on the separate assertion below
+// that every contracted method is a real public method of the real class.
+func TestLoadEmbeddedPython_PythonGnupg_ExactSet(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+	got := renderPythonGnupgInventory(kb)
+	want := expandPythonGnupgSignatures()
+
+	if len(got) == 0 {
+		t.Fatal("no python-gnupg contracts loaded; every assertion here would be vacuous")
+	}
+
+	// A SYMMETRIC DIFFERENCE, NOT A COUNT AND NOT A TALLY. A `len(got) !=
+	// len(want)` check plus a role tally is the campaign's most repeated
+	// defect: it rejects a CORRECT repair in several places at once, so adding
+	// a real, present, crypto-relevant entry reads as a regression. There is
+	// ONE expectation -- the table above -- and the message says which
+	// direction the difference is in and quotes the exact line.
+	inWant := make(map[string]bool, len(want))
+	for _, line := range want {
+		inWant[line] = true
+	}
+	inGot := make(map[string]bool, len(got))
+	for _, line := range got {
+		inGot[line] = true
+	}
+	for _, line := range got {
+		if !inWant[line] {
+			t.Errorf("unexpected contract entry -- if the YAML change is intended, "+
+				"widen or add the matching row in pythonGnupgSignatures:\n\t\t%q", line)
+		}
+	}
+	for _, line := range want {
+		if !inGot[line] {
+			t.Errorf("expected contract entry did not load -- if it was deliberately "+
+				"removed, narrow or delete the matching row in "+
+				"pythonGnupgSignatures:\n\t\t%q", line)
+		}
+	}
+
+	// Roles are checked against the VOCABULARY, never against a tally. A tally
+	// would be a second mirror of the same table with no independent source,
+	// and the set comparison above already fails on any role change because
+	// role is a rendered field.
+	valid := map[string]bool{"factory": true, "config": true, "operation": true, "output": true}
+	for _, candidates := range kb.Contracts {
+		for i := range candidates {
+			c := &candidates[i]
+			if c.SourceLibrary == "python-gnupg" && !valid[c.Role] {
+				t.Errorf("%s#%d carries role %q, which is outside the whitelist",
+					c.Method, c.Arity, c.Role)
+			}
+		}
+	}
+}
+
+// TestLoadEmbeddedPython_PythonGnupg_EveryKeyIsRootedAtTheModule is the
+// contract-side half of the wrong-package assertion the rules carry in
+// the rules repository's own python-gnupg false-positive test module.
+//
+// A SECOND PyPI DISTRIBUTION IMPORTS AS `gnupg`: pkg:pypi/gnupg 2.3.1, a fork
+// of this library. python-gnupg is a SINGLE MODULE -- the sdist ships `gnupg.py`
+// and nothing else importable -- while the fork is a PACKAGE with submodules
+// `gnupg.gnupg`, `gnupg._meta`, `gnupg._parsers` and `gnupg._util`. So a key
+// carrying any of those segments would be the fork's, not this library's, and
+// no key here may name one. `pretty_bad_protocol` is the renamed continuation
+// of the same fork and is a different module root entirely.
+func TestLoadEmbeddedPython_PythonGnupg_EveryKeyIsRootedAtTheModule(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+	seen := 0
+	forkOnly := map[string]bool{
+		"_meta": true, "_parsers": true, "_util": true, "_trust": true,
+		"_logger": true, "_ansistrm": true, "copyleft": true,
+		"pretty_bad_protocol": true,
+	}
+	for _, candidates := range kb.Contracts {
+		for i := range candidates {
+			c := &candidates[i]
+			if c.SourceLibrary != "python-gnupg" {
+				continue
+			}
+			seen++
+			segments := strings.Split(c.Method, ".")
+			if segments[0] != "gnupg" {
+				t.Errorf("%s is not rooted at the gnupg module", c.Method)
+			}
+			// python-gnupg has no submodule at all, so the second segment is
+			// always the class `GPG`. A `gnupg.gnupg.` key would be the fork's.
+			if len(segments) > 1 && segments[1] != "GPG" {
+				t.Errorf("%s: the second segment is %q; python-gnupg is a single "+
+					"module whose only contracted class is GPG, so anything else "+
+					"is the forked pkg:pypi/gnupg distribution's shape",
+					c.Method, segments[1])
+			}
+			for _, segment := range segments {
+				if forkOnly[segment] {
+					t.Errorf("%s carries the forked distribution's module segment %q",
+						c.Method, segment)
+				}
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no python-gnupg contracts loaded; this assertion would be vacuous")
+	}
+}
+
+// TestLoadEmbeddedPython_PythonGnupg_NoNonCryptoMethodIsContracted pins the
+// deliberate NON-claims, which the exact-set test cannot express: it fails on
+// an entry that IS there and says nothing about one that is correctly absent.
+//
+// Each of these is a real public `GPG` method with real consumer call sites and
+// none performs or requests an operation on material this scan can name.
+// `delete_keys` and `trust_keys` have 4 and 2 real call sites respectively in
+// the 24-package consumer draw, so their absence is a decision, not an
+// oversight, and this test is what stops one being added without the decision
+// being revisited.
+func TestLoadEmbeddedPython_PythonGnupg_NoNonCryptoMethodIsContracted(t *testing.T) {
+	t.Parallel()
+
+	kb := loadPythonKB(t)
+	// gnupg.py line numbers at 0.5.6, for a reader auditing the decision.
+	skipped := map[string]int{
+		"gnupg.GPG.delete_keys":                     1688,
+		"gnupg.GPG.trust_keys":                      2290,
+		"gnupg.GPG.get_recipients":                  2255,
+		"gnupg.GPG.get_recipients_file":             2271,
+		"gnupg.GPG.make_args":                       1179,
+		"gnupg.GPG.set_output_without_confirmation": 1414,
+		"gnupg.GPG.is_valid_passphrase":             1429,
+		"gnupg.GPG.is_valid_file":                   1331,
+	}
+	seen := 0
+	for _, candidates := range kb.Contracts {
+		for i := range candidates {
+			c := &candidates[i]
+			if c.SourceLibrary != "python-gnupg" {
+				continue
+			}
+			seen++
+			if line, ok := skipped[c.Method]; ok {
+				t.Errorf("%s#%d is contracted, but it is a deliberate "+
+					"skipped-non-crypto entry (gnupg.py:%d at 0.5.6): it builds "+
+					"an argv, validates a string, reads an existing message's "+
+					"recipients, writes gpg's trustdb or removes a keyring "+
+					"entry. If the disposition has changed, change it in "+
+					"python-gnupg.yaml's API audit and here together.",
+					c.Method, c.Arity, line)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no python-gnupg contracts loaded; this assertion would be vacuous")
+	}
+}
+
+// TestLoadEmbeddedPython_PythonGnupg_LibraryBlock pins the library block, which
+// the exact-set rendering does not cover. version_range, coordinates, name and
+// description are parsed and then never consulted by any other assertion, so
+// corrupting one of them leaves every other test in this directory green.
+func TestLoadEmbeddedPython_PythonGnupg_LibraryBlock(t *testing.T) {
+	t.Parallel()
+
+	// library.name is what populates SourceLibrary on every entry; corrupting
+	// it empties the exact-set test as well as this one.
+	kb := loadPythonKB(t)
+	found := false
+	for _, candidates := range kb.Contracts {
+		for i := range candidates {
+			if candidates[i].SourceLibrary == "python-gnupg" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no contract carries SourceLibrary \"python-gnupg\"; library.name did not load")
+	}
+
+	data, err := os.ReadFile(filepath.Join("python", "python-gnupg.yaml"))
+	if err != nil {
+		t.Fatalf("read python-gnupg.yaml: %v", err)
+	}
+	single, err := contracts.Load(data)
+	if err != nil {
+		t.Fatalf("Load(python-gnupg.yaml): %v", err)
+	}
+	if single.SchemaVersion != "2" {
+		t.Errorf("schema_version = %q, want \"2\"", single.SchemaVersion)
+	}
+	if single.Ecosystem != "python" {
+		t.Errorf("ecosystem = %q, want \"python\"", single.Ecosystem)
+	}
+	if single.Library == nil {
+		t.Fatal("library block did not load")
+	}
+	if single.Library.Name != "python-gnupg" {
+		t.Errorf("library.name = %q, want \"python-gnupg\"", single.Library.Name)
+	}
+	// The lower bound is 0.3.3 and NOT the matrix's oldest row (0.2.3): PyPI
+	// serves NO FILES AT ALL for 0.2.3 through 0.3.2 -- nine of the 34
+	// committed CSV rows have an index entry with an empty file list, so no
+	// API could be read for them and none is claimed. Measured against
+	// https://pypi.org/pypi/python-gnupg/json, not assumed.
+	if single.Library.VersionRange != ">=0.3.3,<0.6" {
+		t.Errorf("library.version_range = %q, want \">=0.3.3,<0.6\"", single.Library.VersionRange)
+	}
+	// The DISTRIBUTION is `python-gnupg`; the IMPORT is `gnupg`. All three
+	// spellings are coordinates because the contract keys use the import name
+	// while the PURL uses the distribution name, and PEP 503 normalization
+	// (the mining service's PEP 503 normalizer) collapses
+	// `python_gnupg` onto `python-gnupg`.
+	wantCoordinates := []string{"python-gnupg", "python_gnupg", "gnupg"}
+	if !slices.Equal(single.Library.Coordinates, wantCoordinates) {
+		t.Errorf("library.coordinates = %#v, want %#v", single.Library.Coordinates, wantCoordinates)
+	}
+	if !strings.Contains(single.Library.Description, "IMPLEMENTS NO CRYPTOGRAPHY") {
+		t.Errorf("library.description does not state that the library runs the "+
+			"gpg binary rather than computing anything: %q", single.Library.Description)
+	}
+}


### PR DESCRIPTION
Adds the callgraph contract KB for the `python-gnupg` PyPI package: 118 entries
over 24 methods, plus an exact-set test.

**python-gnupg implements no cryptography.** It builds an argv and runs the `gpg`
executable, so these entries type the consumer's *request* rather than any
computation the library performs. Every return type is one of the library's own
status-line parsers, read from `GPG.result_map` (0.5.6 `gnupg.py:1082-1097`).

### Two constructor keys, because the `<init>` suffix follows the import

The whole distribution is a single module — the sdist ships `gnupg.py` and
nothing else importable — so there is no submodule spelling to declare. There are
still two keys, read off an exported call graph rather than written from the API:

```
import gnupg;          gnupg.GPG(gnupghome=...)  ->  gnupg.GPG
from gnupg import GPG; GPG(gnupghome=...)        ->  gnupg.GPG.<init>
```

Both are ordinary consumer code. **Those two entries are what makes the other 116
join**: without them the graph emits the consumer's own variable name — measured
as `probeconsumer.g.encrypt(?, ?)` with empty `parameter_types`, the uncontracted
shape — and with them the same lines resolve to `gnupg.GPG.encrypt(?, ?): gnupg.Crypt`.
The file was iterated to a fixed point: export, author, re-export, until nothing
moved.

### Why 118 entries for 24 methods

`ContractsFor` matches `method#arity` exactly and returns nil on a miss for every
ecosystem but rust (`contracts.go:203-211`), so a method reachable at five
argument counts needs five entries. Eight of these methods forward `**kwargs` to
a `_file` sibling, so one method is genuinely callable at up to nine counts.

**`varargs: true` is inert for Python** — measured: the only consumer of
`Contract.Varargs` is `javaVarargsChainContracts`, whose single call site is gated
on `kb.Ecosystem == ecosystemJava` (`builder.go:1562`). No entry uses the field,
and the exact-set test renders it anyway so nobody adds it later believing it
collapses an arity.

Every method's arity range is derived from its `def` line, not from a corpus:
min is the parameters without a default, max is the parameters declared plus the
forwarded target's remaining ones. Two caps are a *choice* rather than a
signature and both are stated in the header: `gen_key_input(**kwargs)` declares no
parameters at all and is capped at 8 (the highest arity measured anywhere is 6),
and `recv_keys`/`send_keys` take `*keyids` and are capped at 4.

### `export_keys` is the one divergent return

It returns `str` when `armor` is set (the default) and `bytes` otherwise
(`:1811-1814`), decided by an argument. A divergent return on one
`(method, arity)` key is a hard load error, so one value is declared at
`confidence: low` and `canonical_return_type` is **withheld** rather than
asserting the armored form holds for every call.

### The exact-set test, and how it avoids being tautological

The expectation is a **hand-written 24-row signature table**, every field read off
the `def` line cited beside it, and the test expands `min..max` into the 118 lines
it compares as a **symmetric difference**. The table is written from `gnupg.py`
and is independent of the YAML — deriving it from the YAML is the obvious repair
and it is wrong, because it goes green on a corrupted contract.

Proved rather than asserted:

- adding a real, present, undeclared entry (`gnupg.GPG.delete_keys#1`,
  `gnupg.py:1688`) makes it fail **exactly once**, naming the entry and quoting
  the line to paste;
- adding the matching table row makes it pass, so a legitimate change is a
  one-row edit;
- a **14-mutation battery** across all eleven classes — delete, role, arity,
  return type, confidence, canonical return, drop canonical, rename, varargs,
  parameter_types, and four library-block fields — **killed 14 of 14**.

Three further tests pin what the exact set cannot express: every key is rooted at
the `gnupg` module and carries no submodule segment (the *forked* `pkg:pypi/gnupg`
distribution is a package with `gnupg.gnupg`, `gnupg._meta` and friends, so such a
segment would be its shape and not this one); the eight deliberate
skipped-non-crypto methods are absent; and the library block's `version_range`,
`coordinates`, `name` and `description` are pinned, since nothing else consults
them.

### Version range

`>=0.3.3,<0.6`, and the lower bound is **not** the matrix's oldest row. PyPI
serves an **empty file list** for 0.2.3, 0.2.4, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.3.0,
0.3.1 and 0.3.2 — nine index entries with no sdist and no wheel — so no API could
be read for them and none is claimed. Per-symbol windows were measured by parsing
every `class` and `def` out of all 25 archived sdists, each boundary checked
against the release on both sides.

### Verification

- `go test ./...` with `-race`: all packages ok.
- `make lint`: 0 issues.
- Contract-join check against the rule metadata: 22 distinct `api` values, every
  one with an entry to join.
